### PR TITLE
Activate trailing slashes for SEO reasons

### DIFF
--- a/docs/api/howtos/create-nodejs.mdx
+++ b/docs/api/howtos/create-nodejs.mdx
@@ -12,7 +12,7 @@ import OperationHint from "@site/src/components/OperationHint";
 
 To install a Node.js application, you will need to have the following:
 
-- The project ID of an existing project ([how to create a project](./create-project))
+- The project ID of an existing project ([how to create a project](../create-project))
 - The application and version ID of the generic custom Node.js application (see next section)
 
 ## Determine the app and app version ID

--- a/docs/api/howtos/create-redis.mdx
+++ b/docs/api/howtos/create-redis.mdx
@@ -13,7 +13,7 @@ This article describes how to create a Redis database via the API.
 
 ## Prerequisites
 
-To create a Redis database, you will need to have access to a project. Refer to the [guide „create a project“](./create-project) for this. You will need the **project ID** for the subsequent operations.
+To create a Redis database, you will need to have access to a project. Refer to the [guide "create a project"](../create-project) for this. You will need the **project ID** for the subsequent operations.
 
 ## List available Redis versions
 

--- a/docs/api/howtos/manage-mailbox.mdx
+++ b/docs/api/howtos/manage-mailbox.mdx
@@ -18,7 +18,7 @@ In our API, we differentiate between two types of mailboxes:
 
 ## Requirements
 
-To manage email accounts, you will need an existing project. You can create a new project using the [Creating a project](./create-project) guide.
+To manage email accounts, you will need an existing project. You can create a new project using the [Creating a project](../create-project) guide.
 
 ## Create a new email account
 

--- a/docs/technologies/databases/redis.mdx
+++ b/docs/technologies/databases/redis.mdx
@@ -31,7 +31,7 @@ First, create a Redis database in the mStudio, the management environment of you
 
 ### Using the API
 
-You can also create a Redis database via the API. To do this, read the article ["Creating a Redis database"](../../api/howtos/create-redis).
+You can also create a Redis database via the API. To do this, read the article ["Creating a Redis database"](../../../api/howtos/create-redis).
 
 ## Configuring Redis as a session storage for PHP
 

--- a/docs/technologies/languages/nodejs.mdx
+++ b/docs/technologies/languages/nodejs.mdx
@@ -22,7 +22,7 @@ To start a Node.js application from the mStudio, follow these steps:
 
 ### Via the API
 
-To learn how to deploy a Node.js application via the API, read the article ["Starting a Node.js application"](../../api/howtos/create-nodejs).
+To learn how to deploy a Node.js application via the API, read the article ["Starting a Node.js application"](../../../api/howtos/create-nodejs).
 
 ### Deploying your app
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,6 +23,7 @@ const config = {
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
+  trailingSlash: true,
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want

--- a/i18n/de/docusaurus-plugin-content-docs/current/api/howtos/create-redis.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/api/howtos/create-redis.mdx
@@ -9,11 +9,13 @@ tags:
   - Databases
 ---
 
+import OperationHint from "@site/src/components/OperationHint";
+
 Dieser Artikel beschreibt, wie Du eine Redis-Datenbank über die API erstellst.
 
 ## Voraussetzungen
 
-Um eine Redis-Datenbank zu erstellen, benötigst Du Zugriff auf ein Projekt. Wie Du ein Projekt erstellst, erfährst Du [hier](./create-project). Du benötigst die **Projekt-ID** für die folgenden Schritte.
+Um eine Redis-Datenbank zu erstellen, benötigst Du Zugriff auf ein Projekt. Wie Du ein Projekt erstellst, erfährst Du [hier](../create-project). Du benötigst die **Projekt-ID** für die folgenden Schritte.
 
 ## Liste verfügbarer Redis-Versionen
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/api/howtos/manage-mailbox.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/api/howtos/manage-mailbox.mdx
@@ -17,7 +17,7 @@ In unserer API unterscheiden wir zwischen zwei Arten von E-Mail-Konten:
 
 ## Voraussetzungen
 
-Um E-Mail-Konten zu verwalten, benötigst du ein bestehendes Projekt. Um ein neues Projekt per API zu erstellen, folge dem ["Erstellen eines Projekts"](./create-project)-Guide.
+Um E-Mail-Konten zu verwalten, benötigst du ein bestehendes Projekt. Um ein neues Projekt per API zu erstellen, folge dem ["Erstellen eines Projekts"](../create-project)-Guide.
 
 ## Ein neues E-Mail-Konto erstellen
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/technologies/databases/redis.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/technologies/databases/redis.mdx
@@ -31,7 +31,7 @@ Lege zunächst im mStudio, der Verwaltungsumgebung deines Space-Servers bzw. dei
 
 ## Über die API
 
-Du kannst eine Redis-Datenbank auch über die API erstellen. Lies hierzu den Artikel ["Eine Redis-Datenbank erstellen"](../../api/howtos/create-redis).
+Du kannst eine Redis-Datenbank auch über die API erstellen. Lies hierzu den Artikel ["Eine Redis-Datenbank erstellen"](../../../api/howtos/create-redis).
 
 # Redis als Session-Storage für PHP konfigurieren
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/technologies/languages/nodejs.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/technologies/languages/nodejs.mdx
@@ -22,7 +22,7 @@ Um eine Node.js-Anwendung über die mStudio-Oberfläche zu starten, folge diesen
 
 ### Über die API
 
-Um zu erfahren, wie man eine Node.js-Anwendung über die API bereitstellt, lies den Artikel ["Eine Node.js-Anwendung starten"](../../api/howtos/create-nodejs).
+Um zu erfahren, wie man eine Node.js-Anwendung über die API bereitstellt, lies den Artikel ["Eine Node.js-Anwendung starten"](../../../api/howtos/create-nodejs).
 
 ### Deine Anwendung bereitstellen
 


### PR DESCRIPTION
This PR activates trailing slashes in all generated links and the XML sitemap.

This is necessary for SEO reasons, because the webserver on the deployment target will redirect all URLs 
without trailing slashes to ones with trailing slashes, anyway.
