### PR TITLE
Fix headline levels in german redis technology article

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/current/technologies/databases/redis.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/technologies/databases/redis.mdx
@@ -11,29 +11,29 @@ import PlanCompatibility from "@site/src/components/PlanCompatibility";
 
 <PlanCompatibility plans={["ps", "ss"]} />
 
-# Was ist Redis?
+## Was ist Redis?
 
 Für einen Webshop ist gute Performance ein echter Wettbewerbsvorteil. Damit du deine Ladezeiten weiter minimieren kannst, kannst du in allen Space-Server- und proSpace-Tarifen Redis nutzen. Wozu du die Datenbank verwenden kannst und wie du sie einrichtest, liest du hier.
 
 Redis (kurz für Remote Dictionary Server) ist **In-Memory-Datenbank** und **Key-Value-Store** in einem. Das heißt: Anstatt auf der Festplatte werden deine Daten im Arbeitsspeicher abgelegt. Jeder Eintrag erhält seinen eigenen Schlüssel, über den er direkt abgerufen wird. Das sorgt für sehr kurze Zugriffszeiten.
 
-# Wozu brauche ich Redis?
+## Wozu brauche ich Redis?
 
 Generell gilt: Redis macht deine Projekte schneller, wenn Daten schnell geschrieben und abgefragt werden. Dank der überragenden Performance lässt sich Redis ideal als Cache verwenden. Auch als Session-Storage für Shopsysteme ist die Datenbank beliebt.
 
-# Wie erstelle ich eine Redis-Datenbank?
+## Wie erstelle ich eine Redis-Datenbank?
 
 Redis einzurichten ist einfach. Je nach CMS oder Shopsystem musst du jedoch einige Dinge beachten. Ich erkläre dir Schritt für Schritt, wie es geht.
 
-## Über das mStudio
+### Über das mStudio
 
 Lege zunächst im mStudio, der Verwaltungsumgebung deines Space-Servers bzw. deines proSpaces, eine Redis Datenbank an. Anschließend findest du in den Details unter Verbindungsinformationen sowohl Host als auch Port. Beide benötigst du für die Konfiguration deines Systems.
 
-## Über die API
+### Über die API
 
 Du kannst eine Redis-Datenbank auch über die API erstellen. Lies hierzu den Artikel ["Eine Redis-Datenbank erstellen"](../../../api/howtos/create-redis).
 
-# Redis als Session-Storage für PHP konfigurieren
+## Redis als Session-Storage für PHP konfigurieren
 
 Die `php.ini`-Datei liegt in deinem Projekt unter `.config/php/php.ini`. Füge den folgenden Code ein:
 
@@ -47,9 +47,9 @@ session.save_path = "tcp://HOST:PORT?database=15"
 
 Jede Redis Datenbank hat standardmäßig 16 Datenbanken, die von 0 bis 15 angesprochen werden können.
 
-# Übliche Anwendungen einrichten
+## Übliche Anwendungen einrichten
 
-## Shopware 6
+### Shopware 6
 
 Die Konfiguration für Redis trägst du in deiner Shopware 6 Installation in der `services.yaml` ein. Sie liegt im Verzeichnis `/config`. Falls dort noch keine Datei vorhanden ist, legst du diese einfach an. Folgende Zeilen fügst du am Ende der Datei ein:
 


### PR DESCRIPTION
The headline levels in the german version are different from the english ones. And they are wrong. I need this fix to update the link in mStudio.

<img width="1051" alt="image" src="https://github.com/mittwald/developer-portal/assets/5042280/8f1bcb94-6b32-4642-953f-8a97876037f1">
