### PR TITLE
Set higher-contrast primary color for Redoc in dark mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -82,6 +82,7 @@ const config = {
         ],
         theme: {
           primaryColor: "#27367b",
+          primaryColorDark: "#abb9ff"
         },
       },
     ],


### PR DESCRIPTION
Fixes #16
