### PR TITLE
Use OpenAPIv3 spec for v1 API

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -84,7 +84,7 @@ const config: Config = {
         specs: [
           {
             id: "v1",
-            spec: "https://api.mittwald.de/v1/swagger/swagger-public.json",
+            spec: "https://api.mittwald.de/v1/openapi.json",
             route: "/reference/v1",
           },
           {

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -97,9 +97,9 @@ const FeatureList = [
               <Translate id={"index.reference.reference"}>Reference</Translate>
             </Link>{" "}
             |{" "}
-            <a href={"https://api.mittwald.de/v1/swagger/swagger-public.json"}>
-              <Translate id={"index.reference.swagger"}>
-                Swagger 2.0 specification
+            <a href={"https://api.mittwald.de/v1/openapi.json"}>
+              <Translate id={"index.reference.openapi"}>
+                OpenAPI 3.0 specification
               </Translate>
             </a>
           </li>


### PR DESCRIPTION
This PR substitutes the old Swagger v2 API spec (for the v1 API) with an up-to-date OpenAPI v3 spec.

- Before: https://api.mittwald.de/v1/swagger/swagger-public.json
- After: https://api.mittwald.de/v1/openapi.json

This also has the added benefit of the build passing with significantly fewer errors. 😄 