### PR TITLE
Use native scrollbars in API reference

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,1 @@
+nativeScrollbars: true


### PR DESCRIPTION
This PR changes the redocly scrollbars to native scrollbars for performance reasons.

See https://redocly.com/docs/redoc/config/#nativescrollbars for more information.
