### PR TITLE
Refactor Schema + SchemaExample components

### DIFF
--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -464,9 +464,12 @@
     "message": "components.OperationHint.heading"
   },
   "components.SchemaWithExample.schema": {
-    "message": "Schema"
+    "message": "Schema-Dokumentation"
   },
   "components.SchemaWithExample.example": {
     "message": "Beispiel"
+  },
+  "components.SchemaWithExample.raw": {
+    "message": "JSON Schema"
   }
 }

--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -462,5 +462,11 @@
   },
   "components.OperationHint.heading": {
     "message": "components.OperationHint.heading"
+  },
+  "components.SchemaWithExample.schema": {
+    "message": "Schema"
+  },
+  "components.SchemaWithExample.example": {
+    "message": "Beispiel"
   }
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -444,5 +444,23 @@
   },
   "openapi.operation.response.body": {
     "message": "Response body"
+  },
+  "openapi.operation.metadata.operationidhelp.title": {
+    "message": "Operation IDs"
+  },
+  "openapi.operation.metadata.operationidhelp.text": {
+    "message": "Operation IDs are used to uniquely identify operations within an API, independent of the path or method. They are typically used by code generators to generate method names or function calls."
+  },
+  "openapi.operation.metadata.deprecationnotice.text": {
+    "message": "This operation is deprecated and should not be used anymore. Please refer to this operation's description for alternatives."
+  },
+  "openapi.example": {
+    "message": "Example"
+  },
+  "components.SchemaWithExample.schema": {
+    "message": "Schema"
+  },
+  "components.SchemaWithExample.example": {
+    "message": "Example"
   }
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -458,9 +458,12 @@
     "message": "Example"
   },
   "components.SchemaWithExample.schema": {
-    "message": "Schema"
+    "message": "Schema documentation"
   },
   "components.SchemaWithExample.example": {
     "message": "Example"
+  },
+  "components.SchemaWithExample.raw": {
+    "message": "JSON Schema"
   }
 }

--- a/src/components/openapi/OperationReference.tsx
+++ b/src/components/openapi/OperationReference.tsx
@@ -3,16 +3,12 @@ import { Fragment } from "react";
 import Markdown from "react-markdown";
 import CodeBlock from "@theme/CodeBlock";
 import { OpenAPIV3 } from "openapi-types";
-import Schema from "@site/src/components/openapi/Schema";
 import {
   Optional,
   Required,
 } from "@site/src/components/openapi/RequiredOptional";
 import Translate, { translate } from "@docusaurus/Translate";
 import HTTPResponseStatus from "@site/src/components/openapi/HTTPResponseStatus";
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-import SchemaExample from "@site/src/components/openapi/SchemaExample";
 import Accordion from "@mittwald/flow-react-components/Accordion";
 import Heading from "@mittwald/flow-react-components/Heading";
 import Content from "@mittwald/flow-react-components/Content";
@@ -25,6 +21,7 @@ import { OperationMetadata } from "@site/src/components/openapi/OperationMetadat
 import ParameterObject = OpenAPIV3.ParameterObject;
 import ReferenceObject = OpenAPIV3.ReferenceObject;
 import ResponseObject = OpenAPIV3.ResponseObject;
+import SchemaWithExample from "@site/src/components/openapi/SchemaWithExample";
 
 function OperationParameter({ param }: { param: ParameterObject }) {
   const body = [];
@@ -162,14 +159,7 @@ function OperationRequestBody({
           <p>
             Format: <code>application/json</code>
           </p>
-          <Tabs groupId="request-body" defaultValue="schema">
-            <TabItem value="schema" label="Schema">
-              <Schema schema={spec.content["application/json"].schema} />
-            </TabItem>
-            <TabItem value="example" label="Example">
-              <SchemaExample schema={spec.content["application/json"].schema} />
-            </TabItem>
-          </Tabs>
+          <SchemaWithExample schema={spec.content["application/json"].schema} withRawJSONSchema />
         </Content>
       </Accordion>
     );
@@ -213,14 +203,7 @@ function OperationResponseBody({ spec }: { spec?: OpenAPIV3.ResponseObject }) {
           </LabeledValue>
         </ColumnLayout>
 
-        <Tabs groupId="request-body" defaultValue="schema">
-          <TabItem value="schema" label="Schema">
-            <Schema schema={spec.content["application/json"].schema} />
-          </TabItem>
-          <TabItem value="example" label="Example">
-            <SchemaExample schema={spec.content["application/json"].schema} />
-          </TabItem>
-        </Tabs>
+        <SchemaWithExample schema={spec.content["application/json"].schema} withRawJSONSchema />
       </>
     );
   }

--- a/src/components/openapi/Schema.tsx
+++ b/src/components/openapi/Schema.tsx
@@ -74,7 +74,13 @@ function OneOfSchema({ schema }: Props) {
   );
 }
 
-function Schema({ schema }: Props) {
+/**
+ * Renders a graphical representation of an OpenAPI-style JSON schema.
+ *
+ * @param schema The schema for which a documentation should be rendered
+ * @constructor
+ */
+export default function Schema({ schema }: Props) {
   if (isObjectSchema(schema)) {
     return <ObjectSchema schema={schema} />;
   }
@@ -87,5 +93,3 @@ function Schema({ schema }: Props) {
     return <ArraySchema schema={schema} />;
   }
 }
-
-export default Schema;

--- a/src/components/openapi/SchemaExample.tsx
+++ b/src/components/openapi/SchemaExample.tsx
@@ -2,13 +2,22 @@ import { OpenAPIV3 } from "openapi-types";
 import CodeBlock from "@theme/CodeBlock";
 import { generateSchemaExample } from "@site/src/openapi/generateSchemaExample";
 
-function SchemaExample({
-  schema,
-  title,
-}: {
+interface Props {
   title?: string;
   schema: OpenAPIV3.SchemaObject;
-}) {
+}
+
+/**
+ * This component renders an example of a given schema.
+ *
+ * The schema example is generated using the `generateSchemaExample` function.
+ * Existing `.example` values defined with in the schema are respected;
+ * otherwise, the example is generated based on the schema type.
+ *
+ * @param schema The schema for which to generate an example
+ * @param title Optional title for the example
+ */
+export default function SchemaExample({ schema, title }: Props) {
   if (schema.oneOf) {
     return schema.oneOf.map((s, idx) => (
       <SchemaExample
@@ -25,5 +34,3 @@ function SchemaExample({
     </CodeBlock>
   );
 }
-
-export default SchemaExample;

--- a/src/components/openapi/SchemaFromSpec.tsx
+++ b/src/components/openapi/SchemaFromSpec.tsx
@@ -18,7 +18,11 @@ interface Props {
  * @param path The path to the schema in the OpenAPI spec
  * @param withExample Whether to render an example of the schema
  */
-export default function SchemaFromSpec({ apiVersion, path, withExample }: Props) {
+export default function SchemaFromSpec({
+  apiVersion,
+  path,
+  withExample,
+}: Props) {
   const spec = specs[apiVersion];
 
   let refPath = path.split("/");

--- a/src/components/openapi/SchemaFromSpec.tsx
+++ b/src/components/openapi/SchemaFromSpec.tsx
@@ -3,6 +3,7 @@ import TabItem from "@theme/TabItem";
 import SchemaExample from "@site/src/components/openapi/SchemaExample";
 import Tabs from "@theme/Tabs";
 import { APIVersion, specs } from "@site/src/openapi/specs";
+import SchemaWithExample from "@site/src/components/openapi/SchemaWithExample";
 
 interface Props {
   apiVersion: APIVersion;
@@ -17,7 +18,7 @@ interface Props {
  * @param path The path to the schema in the OpenAPI spec
  * @param withExample Whether to render an example of the schema
  */
-function SchemaFromSpec({ apiVersion, path, withExample }: Props) {
+export default function SchemaFromSpec({ apiVersion, path, withExample }: Props) {
   const spec = specs[apiVersion];
 
   let refPath = path.split("/");
@@ -33,19 +34,8 @@ function SchemaFromSpec({ apiVersion, path, withExample }: Props) {
   }
 
   if (withExample) {
-    return (
-      <Tabs groupId="component" defaultValue="schema">
-        <TabItem value="schema" label="Schema">
-          <Schema schema={current} />
-        </TabItem>
-        <TabItem value="example" label="Example">
-          <SchemaExample schema={current} />
-        </TabItem>
-      </Tabs>
-    );
+    return <SchemaWithExample schema={current} />;
   }
 
   return <Schema schema={current} />;
 }
-
-export default SchemaFromSpec;

--- a/src/components/openapi/SchemaWithExample.tsx
+++ b/src/components/openapi/SchemaWithExample.tsx
@@ -3,6 +3,7 @@ import TabItem from "@theme/TabItem";
 import Schema from "@site/src/components/openapi/Schema";
 import SchemaExample from "@site/src/components/openapi/SchemaExample";
 import { OpenAPIV3 } from "openapi-types";
+import { translate } from "@docusaurus/Translate";
 
 interface Props {
   schema: OpenAPIV3.SchemaObject;
@@ -18,10 +19,10 @@ interface Props {
 export default function SchemaWithExample({ schema }: Props) {
   return (
     <Tabs groupId="component" defaultValue="schema">
-      <TabItem value="schema" label="Schema">
+      <TabItem value="schema" label={translate({id: "components.SchemaWithExample.schema"})}>
         <Schema schema={schema} />
       </TabItem>
-      <TabItem value="example" label="Example">
+      <TabItem value="example" label={translate({id: "components.SchemaWithExample.example"})}>
         <SchemaExample schema={schema} />
       </TabItem>
     </Tabs>

--- a/src/components/openapi/SchemaWithExample.tsx
+++ b/src/components/openapi/SchemaWithExample.tsx
@@ -2,7 +2,6 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Schema from "@site/src/components/openapi/Schema";
 import SchemaExample from "@site/src/components/openapi/SchemaExample";
-import { APIVersion } from "@site/src/openapi/specs";
 import { OpenAPIV3 } from "openapi-types";
 
 interface Props {

--- a/src/components/openapi/SchemaWithExample.tsx
+++ b/src/components/openapi/SchemaWithExample.tsx
@@ -15,6 +15,7 @@ interface Props {
  * This component renders a schema with an example in a tabbed view.
  *
  * @param schema The schema to render and to generate an example for
+ * @param withRawJSONSchema Whether to show the raw JSON schema in a tab
  * @see Schema
  * @see SchemaExample
  */

--- a/src/components/openapi/SchemaWithExample.tsx
+++ b/src/components/openapi/SchemaWithExample.tsx
@@ -4,9 +4,11 @@ import Schema from "@site/src/components/openapi/Schema";
 import SchemaExample from "@site/src/components/openapi/SchemaExample";
 import { OpenAPIV3 } from "openapi-types";
 import { translate } from "@docusaurus/Translate";
+import CodeBlock from "@theme/CodeBlock";
 
 interface Props {
   schema: OpenAPIV3.SchemaObject;
+  withRawJSONSchema?: boolean;
 }
 
 /**
@@ -16,7 +18,7 @@ interface Props {
  * @see Schema
  * @see SchemaExample
  */
-export default function SchemaWithExample({ schema }: Props) {
+export default function SchemaWithExample({ schema, withRawJSONSchema }: Props) {
   return (
     <Tabs groupId="component" defaultValue="schema">
       <TabItem value="schema" label={translate({id: "components.SchemaWithExample.schema"})}>
@@ -25,6 +27,9 @@ export default function SchemaWithExample({ schema }: Props) {
       <TabItem value="example" label={translate({id: "components.SchemaWithExample.example"})}>
         <SchemaExample schema={schema} />
       </TabItem>
+      {withRawJSONSchema && <TabItem value="raw" label={translate({id: "components.SchemaWithExample.raw"})}>
+        <CodeBlock language="yaml">{JSON.stringify(schema, null, 2)}</CodeBlock>
+      </TabItem>}
     </Tabs>
   );
 }

--- a/src/components/openapi/SchemaWithExample.tsx
+++ b/src/components/openapi/SchemaWithExample.tsx
@@ -1,0 +1,30 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Schema from "@site/src/components/openapi/Schema";
+import SchemaExample from "@site/src/components/openapi/SchemaExample";
+import { APIVersion } from "@site/src/openapi/specs";
+import { OpenAPIV3 } from "openapi-types";
+
+interface Props {
+  schema: OpenAPIV3.SchemaObject;
+}
+
+/**
+ * This component renders a schema with an example in a tabbed view.
+ *
+ * @param schema The schema to render and to generate an example for
+ * @see Schema
+ * @see SchemaExample
+ */
+export default function SchemaWithExample({ schema }: Props) {
+  return (
+    <Tabs groupId="component" defaultValue="schema">
+      <TabItem value="schema" label="Schema">
+        <Schema schema={schema} />
+      </TabItem>
+      <TabItem value="example" label="Example">
+        <SchemaExample schema={schema} />
+      </TabItem>
+    </Tabs>
+  );
+}


### PR DESCRIPTION
This PR refactors the `Schema` and `SchemaExample` components, and introduces the `SchemaWithExample` component for easily rendering a schema alongside its example with a single component.
