### PR TITLE
Fix display of array items in Schema component

### DIFF
--- a/src/components/openapi/OperationInputValue.tsx
+++ b/src/components/openapi/OperationInputValue.tsx
@@ -34,7 +34,7 @@ export function ArrayValue({ schema }: { schema: OpenAPIV3.SchemaObject }) {
         <span className={styles.parameterAlternative}>Array[</span>
       </div>
       <div className={styles.parameterListBody}>{body}</div>
-      <Schema schema={schema} />
+      <PropertyValue name="*" schema={schema} required={false} />
       <div className={styles.parameterListHeader}>
         <span className={styles.parameterAlternative}>]</span>
       </div>
@@ -58,6 +58,8 @@ export function PropertyValue({
     body = <Markdown>{schema.description}</Markdown>;
   }
 
+  const hasSubSchema = schema.properties || schema.additionalProperties || schema.items;
+
   return (
     <li key={name}>
       <div className={styles.parameterListHeader}>
@@ -67,7 +69,7 @@ export function PropertyValue({
         {requiredOrOptional}
       </div>
       <div className={styles.parameterListBody}>{body}</div>
-      <Schema schema={schema} />
+      {hasSubSchema && <Schema schema={schema} />}
     </li>
   );
 }

--- a/src/components/openapi/Schema.tsx
+++ b/src/components/openapi/Schema.tsx
@@ -92,4 +92,6 @@ export default function Schema({ schema }: Props) {
   if (schema.type === "array") {
     return <ArraySchema schema={schema} />;
   }
+
+  return <PropertyValue name="*" schema={schema} required={false} />;
 }


### PR DESCRIPTION
This commit changes the display of array items so that the actual sub-schema of
said items is displayed.

This reduces the asthetic annoyance when an empty "Array[]" schema is displayed
(when no sub-schema is given), and also fixes a bug where the description of
array items was not rendered at all.
