### PR TITLE
Fix h2 header size in changelog overview

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -183,8 +183,8 @@ aside {
   --ifm-h1-font-size: 32px !important;
 }
 
-h2.title_node_modules-\@docusaurus-theme-classic-lib-theme-BlogPostItem-Header-Title-styles-module {
-    font-size: 1.5rem;
+article > header > h2 {
+    font-size: 1.5rem !important;
 }
 
 h1.title_node_modules-\@docusaurus-theme-classic-lib-theme-BlogPostItem-Header-Title-styles-module {


### PR DESCRIPTION
This PR fixes the oversized headers in the changelog, mentioned in #183 