### PR TITLE
Generate changelog entry introduction sentences with LLM

### DIFF
--- a/generator/templates/changelog.mdx.ejs
+++ b/generator/templates/changelog.mdx.ejs
@@ -17,12 +17,7 @@
 import OperationHint from "@site/src/components/OperationHint";
 import OperationLink from "@site/src/components/OperationLink";
 
-This document contains a machine-generated summary of the API changes for <%= today.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-}) %>.
-The API changes are based on the diff between the OpenAPI schemas of the two versions.
+<%- introduction %>
 
 {/* truncate */}
 


### PR DESCRIPTION
This change addresses the feedback from #183, by replacing the generic default introduction sentence with an LLM-generated one that summarizes the actual API changes.
