### PR TITLE
Update 2024-10-07 changelog with a developers note

### DIFF
--- a/changelog/2024-10-07-api-changes-v2.mdx
+++ b/changelog/2024-10-07-api-changes-v2.mdx
@@ -40,6 +40,9 @@ On October 7, 2024, the mittwald API underwent several changes, including the re
 
 _Disclaimer: This summary is AI-generated. If you find any discrepancies, please refer to the detailed changes below._
 
+### Developer's note
+
+Even if these changes appear to be breaking, the actual response of the above-mentioned Order routes does not actually change. `first_name` and `last_name` were incorrectly named in the generated spec, because technically `firstName` and `lastName` were already returned beforehand.
 
 ## Detailed changes
 

--- a/changelog/2024-10-07-api-changes-v2.mdx
+++ b/changelog/2024-10-07-api-changes-v2.mdx
@@ -42,7 +42,7 @@ _Disclaimer: This summary is AI-generated. If you find any discrepancies, please
 
 ### Developer's note
 
-Even if these changes appear to be breaking, the actual response of the above-mentioned Order routes does not actually change. `first_name` and `last_name` were incorrectly named in the generated spec, because technically `firstName` and `lastName` were already returned beforehand.
+Even if these changes appear to be breaking, the response of the above-mentioned Order routes does not actually change. `first_name` and `last_name` were incorrectly named in the generated spec, because technically `firstName` and `lastName` were already returned beforehand.
 
 ## Detailed changes
 


### PR DESCRIPTION
Added context to the AI Generated Documentation about breaking changes in the Order API.