### PR TITLE
Fix incorrect array key in TYPO3 caching configuration

### DIFF
--- a/docs/platform/databases/redis.mdx
+++ b/docs/platform/databases/redis.mdx
@@ -231,7 +231,7 @@ foreach ($redisCaches as $name => $values) {
     	'port' => $redisPort
     ];
     if (isset($values['defaultLifetime'])) {
-       	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$name]['options']['defaultLifetime'] = $values['lifetime'];
+       	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$name]['options']['defaultLifetime'] = $values['defaultLifetime'];
     }
 
     if (isset($values['compression'])) {

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/redis.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/redis.mdx
@@ -228,7 +228,7 @@ foreach ($redisCaches as $name => $values) {
     	'port' => $redisPort
     ];
     if (isset($values['defaultLifetime'])) {
-       	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$name]['options']['defaultLifetime'] = $values['lifetime'];
+       	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$name]['options']['defaultLifetime'] = $values['defaultLifetime'];
     }
 
     if (isset($values['compression'])) {


### PR DESCRIPTION
This PR fixes an incorrect array key in the TYPO3+Redis configuration example.

Fixes #271
