### PR TITLE
fix: copyright year is stuck on 2023

### DIFF
--- a/i18n/de/docusaurus-theme-classic/footer.json
+++ b/i18n/de/docusaurus-theme-classic/footer.json
@@ -23,10 +23,6 @@
     "message": "Impressum",
     "description": "The label of footer link with label=Legal linking to https://www.mittwald.de/impressum"
   },
-  "copyright": {
-    "message": "Copyright © 2023 Mittwald CM Service GmbH & Co. KG. Built with Docusaurus.",
-    "description": "The footer copyright"
-  },
   "link.item.label.Feedback": {
     "message": "Feedback",
     "description": "The label of footer link with label=Feedback linking to https://github.com/mittwald/developer-portal/issues"

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -23,10 +23,6 @@
     "message": "Legal",
     "description": "The label of footer link with label=Legal linking to https://www.mittwald.de/impressum"
   },
-  "copyright": {
-    "message": "Copyright © 2023 Mittwald CM Service GmbH & Co. KG. Built with Docusaurus.",
-    "description": "The footer copyright"
-  },
   "link.item.label.Feedback": {
     "message": "Feedback",
     "description": "The label of footer link with label=Feedback linking to https://github.com/mittwald/developer-portal/issues"


### PR DESCRIPTION
The copyright year in the footer is currently stuck at 2023. This is caused by the direct definition [here](i18n/en/docusaurus-theme-classic/footer.json#L27) and [here](i18n/en/docusaurus-theme-classic/footer.json#L27) overriding the `docusaurus.config.ts` where the year is dynamically set according to the current year at build time.

This PR removes the explicit definition of the copyright translation of the footer from the EN and DE translation files, so that the dynamic translation takes effect again

The current footer:
<img width="875" alt="image" src="https://github.com/user-attachments/assets/ed8d232e-d2a0-4104-87d5-634fe30f2491">
