### PR TITLE
Add more documentation on how to work with DNS records

### DIFF
--- a/docs/api/howtos/manage-dns.mdx
+++ b/docs/api/howtos/manage-dns.mdx
@@ -1,0 +1,86 @@
+---
+sidebar_label: Managing DNS records
+sidebar_position: 20
+title: Managing DNS records over the API
+description: This article explains how to manage different kinds of DNS records via the API
+tags:
+  - DNS
+---
+
+import OperationHint from "@site/src/components/OperationHint";
+import OperationLink from "@site/src/components/OperationLink";
+import OperationExample from "@site/src/components/OperationExample";
+
+:::note
+
+In the following examples, substitute `PROJECT_ID` with your actual project ID. Please note that this needs to be the
+**full id** (formatted as a UUID), and **not** the short ID (formatted as `p-XXXXX`).
+
+:::
+
+## Setting a A/AAAA record for a domain or subdomain
+
+To modify the A or AAAA records of an existing domain or subdomain, you first need to obtain its DNS zone id. For this,
+list the project's DNS zones by using the <OperationLink operation="dns-list-dns-zones" /> endpoint. In the following
+examples, this zone ID will be referred to as `ZONE_ID`.
+
+You can then modify your A and AAAA records using the <OperationLink operation="dns-update-record-set" /> operation.
+Note that this operation is used for modifying _both_ A and AAAA records (even though the `recordSet` path parameter
+should always be set to `"a"`):
+
+<OperationExample
+  operation="dns-update-record-set"
+  pathParameters={{ recordSet: "a", dnsZoneId: "ZONE_ID" }}
+  example={{
+    a: ["203.0.113.1", "203.0.113.2"],
+    aaaa: ["2001:0DB8::1", "2001:0DB8::2"],
+    settings: { ttl: { auto: true } },
+  }}
+/>
+
+## Setting a CNAME record for a subdomain
+
+### Optional: Creating a subdomain first
+
+If the subdomain does not already exist, you need to create it first:
+
+<OperationExample
+  operation="ingress-create-ingress"
+  example={{
+    hostname: "subdomain.domain.example",
+    paths: [{ path: "/", target: { useDefaultPage: true } }],
+    projectId: "PROJECT_ID",
+  }}
+/>
+
+In this case, the `paths` property is largely irrelevant (since you'll be setting a custom CNAME record anyway), but
+it still is required by the API. Use the `useDefaultPage` target from the example if you do not want to explicitly
+define a domain target.
+
+### Setting the CNAME record
+
+When the subdomain exists, you first need to obtain its DNS zone id. For this, list the project's DNS zones by
+using the <OperationLink operation="dns-list-dns-zones" /> endpoint.
+
+Given the zone ID (referenced as `ZONE_ID` in subsequent examples), you can then set or modify the CNAME record:
+
+<OperationExample
+  operation="dns-update-record-set"
+  pathParameters={{ recordSet: "cname", dnsZoneId: "ZONE_ID" }}
+  example={{
+    fqdn: "your-cname-target.example",
+    settings: { ttl: { auto: true } },
+  }}
+/>
+
+## Resetting custom A/AAAA/MX records
+
+Typically, A, AAAA and MX records are managed by the mittwald platform, which you can override by setting custom records
+using the methods explained above. If you want to reset a record set to being managed by the mittwald platform, use
+the <OperationLink operation="dns-set-record-set-managed" /> operation.
+
+<OperationExample
+  operation="dns-set-record-set-managed"
+  pathParameters={{ recordSet: "a", dnsZoneId: "ZONE_ID" }}
+  example={{}}
+/>

--- a/generator/overlays/v2/dns-set-record-set-managed/description.mdx
+++ b/generator/overlays/v2/dns-set-record-set-managed/description.mdx
@@ -1,0 +1,4 @@
+This operation can be used to reset DNS records sets to being managed by the mittwald platform.
+
+This affects A, AAAA and MX record sets, which are typically managed by the platform. However, you can override these
+using the <OperationLink operation="dns-update-record-set" /> operation.

--- a/generator/overlays/v2/dns-update-record-set/description.mdx
+++ b/generator/overlays/v2/dns-update-record-set/description.mdx
@@ -1,0 +1,88 @@
+This operation can be used to update and replace individual DNS record sets.
+
+## Usage for different record types
+
+### Setting A and AAAA records
+
+A and AAAA records can be set in a single request by providing `"a"` as `recordSet` parameter:
+
+<OperationExample
+  operation="dns-update-record-set"
+  pathParameters={{ recordSet: "a" }}
+  example={{
+    a: ["203.0.113.1", "203.0.113.2"],
+    aaaa: ["2001:0DB8::1", "2001:0DB8::2"],
+    settings: { ttl: { auto: true } },
+  }}
+/>
+
+Setting an A and/or AAAA record will override the default DNS records provided by the mittwald platform. To reset
+the records to being managed by the platform, use the <OperationLink operation="dns-set-record-set-managed" /> operation.
+
+### Setting CNAME records
+
+CNAME records can be set as follows:
+
+<OperationExample
+  operation="dns-update-record-set"
+  pathParameters={{ recordSet: "cname" }}
+  example={{
+    fqdn: "your-cname-target.example",
+    settings: { ttl: { auto: true } },
+  }}
+/>
+
+### Setting MX records
+
+MX records can be set as follows:
+
+<OperationExample
+  operation="dns-update-record-set"
+  pathParameters={{ recordSet: "mx" }}
+  example={{
+    records: [
+      {
+        fqdn: "mx01.your-mailserver.example",
+        priority: 10,
+      },
+      {
+        fqdn: "mx02.your-mailserver.example",
+        priority: 10,
+      },
+    ],
+    settings: { ttl: { auto: true } },
+  }}
+/>
+
+### Setting TXT records
+
+TXT records can be set as follows:
+
+<OperationExample
+  operation="dns-update-record-set"
+  pathParameters={{ recordSet: "txt" }}
+  example={{
+    entries: ["foo", "bar"],
+    settings: { ttl: { auto: true } },
+  }}
+/>
+
+### Setting SRV records
+
+SRV records can be set as follows:
+
+<OperationExample
+  operation="dns-update-record-set"
+  pathParameters={{ recordSet: "txt" }}
+  example={{
+    records: [
+      {
+        fqdn: "service.your-domain.example",
+        port: 8080,
+        priority: 10,
+        weight: 10,
+      },
+    ],
+    settings: { ttl: { auto: true } },
+  }}
+/>

--- a/generator/overlays/v2/overlay.yaml
+++ b/generator/overlays/v2/overlay.yaml
@@ -16,7 +16,7 @@ actions:
         example: "203.0.113.123/32"
   - target: $.components.schemas['de.mittwald.v1.database.CreateMySqlUserWithDatabase'].properties.accessIpMask
     remove: true
-  - target: $.components.schemas['de.mittwald.v1.database.CreateMySqlUserWithDatabase'].properties.accessIpMask
+  - target: $.components.schemas['de.mittwald.v1.database.CreateMySqlUserWithDatabase'].properties
     update:
       externalAccess:
         description: >
@@ -30,6 +30,13 @@ actions:
       collation:
         description: A valid MySQL collation
         example: utf8mb4_general_ci
+
+  - target: $.paths['/v2/dns-zones/{dnsZoneId}/record-sets/{recordSet}'].put.parameters[?(@.name=="recordSet")]
+    update:
+      description: >
+        The record set to be updated. AAAA records are updated as part of the A record; so use `"a"` as value
+        if you want to update your AAAA records. Please also note that the request body schema varies depending on
+        which value you provide here.
   - target: $.paths['/v2/dns/zones/{zoneId}/recordset/acombined/custom'].put
     update:
       summary: Updates A records for a specific zone

--- a/generator/overlays/v2/overlay.yaml
+++ b/generator/overlays/v2/overlay.yaml
@@ -30,3 +30,38 @@ actions:
       collation:
         description: A valid MySQL collation
         example: utf8mb4_general_ci
+  - target: $.paths['/v2/dns/zones/{zoneId}/recordset/acombined/custom'].put
+    update:
+      summary: Updates A records for a specific zone
+      description: >
+        This operation is deprecated. Use the `PUT /v2/dns/zones/{zoneId}/record-sets/{recordSet}/` endpoint instead.
+  - target: $.paths['/v2/dns/zones/{zoneId}/recordset/cname'].put
+    update:
+      summary: Updates CNAME records for a specific zone
+      description: >
+        This operation is deprecated. Use the `PUT /v2/dns/zones/{zoneId}/record-sets/{recordSet}/` endpoint instead.
+  - target: $.paths['/v2/dns/zones/{zoneId}/recordset/mx/custom'].put
+    update:
+      summary: Updates MX records for a specific zone
+      description: >
+        This operation is deprecated. Use the `PUT /v2/dns/zones/{zoneId}/record-sets/{recordSet}/` endpoint instead.
+  - target: $.paths['/v2/dns/zones/{zoneId}/recordset/srv'].put
+    update:
+      summary: Updates SRV records for a specific zone
+      description: >
+        This operation is deprecated. Use the `PUT /v2/dns/zones/{zoneId}/record-sets/{recordSet}/` endpoint instead.
+  - target: $.paths['/v2/dns/zones/{zoneId}/recordset/txt'].put
+    update:
+      summary: Updates TXT records for a specific zone
+      description: >
+        This operation is deprecated. Use the `PUT /v2/dns/zones/{zoneId}/record-sets/{recordSet}/` endpoint instead.
+  - target: $.paths['/v2/dns/zones/{zoneId}/recordset/acombined/managed/ingress'].post
+    update:
+      summary: Resets A records to managed for a specific zone
+      description: >
+        This operation is deprecated. Use the `POST /v2/dns/zones/{zoneId}/record-sets/{recordSet}/actions/set-managed` endpoint instead.
+  - target: $.paths['/v2/dns/zones/{zoneId}/recordset/mx/managed'].post
+    update:
+      summary: Resets A records to managed for a specific zone
+      description: >
+        This operation is deprecated. Use the `POST /v2/dns/zones/{zoneId}/record-sets/{recordSet}/actions/set-managed` endpoint instead.

--- a/generator/util/overlay.ts
+++ b/generator/util/overlay.ts
@@ -56,6 +56,11 @@ export function applyOverlay(
         delete parent[toRemove];
       }
     } else {
+      const path = jsonpath.paths(overlayedSpec, action.target);
+      if (path.length === 0) {
+        throw new Error(`target ${action.target} did not match anything`);
+      }
+
       // It must be an update
       if (action.target === "$") {
         overlayedSpec = merger(action.update)(overlayedSpec);

--- a/i18n/de/docusaurus-plugin-content-docs/current/api/howtos/manage-dns.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/api/howtos/manage-dns.mdx
@@ -1,0 +1,77 @@
+---
+sidebar_label: Verwaltung von DNS-Einträgen
+sidebar_position: 20
+title: Verwaltung von DNS-Einträgen über die API
+description: Dieser Artikel erklärt, wie verschiedene Arten von DNS-Einträgen über die API verwaltet werden können.
+tags:
+  - DNS
+---
+
+import OperationHint from "@site/src/components/OperationHint";
+import OperationLink from "@site/src/components/OperationLink";
+import OperationExample from "@site/src/components/OperationExample";
+
+:::note
+
+Ersetze in den folgenden Beispielen `PROJECT_ID` durch deine tatsächliche Projekt-ID. Bitte beachte, dass dies die
+**vollständige ID** (im UUID-Format) sein muss und **nicht** die kurze ID (im Format `p-XXXXX`).
+
+:::
+
+## Einrichten eines A/AAAA-Eintrags für eine Domain oder Subdomain
+
+Um die A- oder AAAA-Einträge einer bestehenden Domain oder Subdomain zu ändern, musst du zuerst die DNS-Zonen-ID ermitteln. Dazu kannst du die DNS-Zonen des Projekts über den Endpunkt <OperationLink operation="dns-list-dns-zones" /> auflisten. In den folgenden Beispielen wird diese Zonen-ID als `ZONE_ID` bezeichnet.
+
+Anschließend kannst du deine A- und AAAA-Einträge mit der <OperationLink operation="dns-update-record-set" />-Operation ändern. Beachte, dass diese Operation zum Ändern von _sowohl_ A- als auch AAAA-Einträgen verwendet wird (auch wenn der Pfadparameter `recordSet` immer auf `"a"` gesetzt werden sollte):
+
+<OperationExample
+  operation="dns-update-record-set"
+  pathParameters={{ recordSet: "a", dnsZoneId: "ZONE_ID" }}
+  example={{
+    a: ["203.0.113.1", "203.0.113.2"],
+    aaaa: ["2001:0DB8::1", "2001:0DB8::2"],
+    settings: { ttl: { auto: true } },
+  }}
+/>
+
+## Einrichten eines CNAME-Eintrags für eine Subdomain
+
+### Optional: Zuerst eine Subdomain erstellen
+
+Falls die Subdomain noch nicht existiert, musst du sie zuerst erstellen:
+
+<OperationExample
+  operation="ingress-create-ingress"
+  example={{
+    hostname: "subdomain.domain.example",
+    paths: [{ path: "/", target: { useDefaultPage: true } }],
+    projectId: "PROJECT_ID",
+  }}
+/>
+
+In diesem Fall ist die Eigenschaft `paths` weitgehend irrelevant (da du ohnehin einen benutzerdefinierten CNAME-Eintrag setzen wirst), ist aber dennoch ein Pflichtfeld. Verwende das `useDefaultPage`-Ziel aus dem Beispiel, wenn du kein spezifisches Domain-Ziel definieren möchtest.
+
+### Den CNAME-Eintrag setzen
+
+Sobald die Subdomain existiert, musst du zuerst die DNS-Zonen-ID ermitteln. Dazu kannst du die DNS-Zonen des Projekts über den Endpunkt <OperationLink operation="dns-list-dns-zones" /> auflisten.
+
+Mit der Zonen-ID (in den weiteren Beispielen als `ZONE_ID` referenziert) kannst du dann den CNAME-Eintrag setzen oder ändern:
+
+<OperationExample
+  operation="dns-update-record-set"
+  pathParameters={{ recordSet: "cname", dnsZoneId: "ZONE_ID" }}
+  example={{
+    fqdn: "your-cname-target.example",
+    settings: { ttl: { auto: true } },
+  }}
+/>
+
+## Zurücksetzen von benutzerdefinierten A/AAAA/MX-Einträgen
+
+In der Regel werden A-, AAAA- und MX-Einträge von der mittwald-Plattform verwaltet, die du durch die oben erklärten Methoden mit benutzerdefinierten Einträgen überschreiben kannst. Wenn du die DNS-Records zurücksetzen möchtest, damit sie wieder von der mittwald-Plattform verwaltet werden, verwende die <OperationLink operation="dns-set-record-set-managed" />-Operation.
+
+<OperationExample
+  operation="dns-set-record-set-managed"
+  pathParameters={{ recordSet: "a", dnsZoneId: "ZONE_ID" }}
+  example={{}}
+/>

--- a/src/components/OperationExample.tsx
+++ b/src/components/OperationExample.tsx
@@ -2,7 +2,6 @@ import { APIVersion, getOperationById, useSpec } from "@site/src/openapi/specs";
 import CodeBlock from "@theme/CodeBlock";
 import OperationLink from "@site/src/components/OperationLink";
 import styles from "./OperationExample.module.css";
-import OperationDocCardById from "@site/src/components/openapi/OperationDocCardById";
 import clsx from "clsx";
 
 interface Props {
@@ -10,14 +9,19 @@ interface Props {
   operation: string;
   example: any;
   headers?: Record<string, string>;
+  pathParameters?: Record<string, string>;
   withoutLink?: boolean;
 }
 
 export default function OperationExample(p: Props) {
-  const { apiVersion = "v2" as APIVersion, withoutLink = false } = p;
+  const {
+    apiVersion = "v2" as APIVersion,
+    withoutLink = false,
+    pathParameters = {},
+  } = p;
   const spec = useSpec(apiVersion);
   const operation = getOperationById(spec, p.operation);
-  const headers = {
+  const headers: Record<string, string> = {
     Host: "api.mittwald.de",
     ...(p.headers || {}),
   };
@@ -26,7 +30,12 @@ export default function OperationExample(p: Props) {
     headers["Content-Type"] = "application/json";
   }
 
-  const requestLine = `${operation.method.toUpperCase()} ${operation.path} HTTP/1.1\n`;
+  let path = operation.path;
+  for (const param of Object.keys(pathParameters)) {
+    path = path.replace(`{${param}}`, pathParameters[param]);
+  }
+
+  const requestLine = `${operation.method.toUpperCase()} ${path} HTTP/1.1\n`;
   const headerLines = Object.keys(headers)
     .map((key) => `${key}: ${headers[key]}`)
     .join("\n");

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -558,6 +558,6 @@ section.row {
   text-align: center;
 }
 
-.flow--inline-alert {
+.flow--inline-alert, .flow--alert {
   margin-bottom: var(--ifm-leading);
 }


### PR DESCRIPTION
- **Add option to override parts of OpenAPI specs using overlay files**
- **Add overlays for better documenting database creation**
- **Document how to use overlays**
- **Add credit where credit is due**
- **Add overlays for undocumented deprecations**
- **Throw exception when overlay does not match anything**
- **Restore alert spacing**
- **Add option to set request path values for examples**
- **Add extensive documentation on how to set DNS records**
- **Add translation**
