### PR TITLE
Add a helper script to quickly generate translations

### DIFF
--- a/generator/generate-translations.ts
+++ b/generator/generate-translations.ts
@@ -1,0 +1,86 @@
+import listFilesWithExtensions from "@site/generator/util/list_files";
+import fs from "fs/promises";
+import OpenAI from "openai";
+import path from "path";
+
+const openai = new OpenAI();
+
+async function findFilesWithoutTranslations() {
+  const files = await listFilesWithExtensions("docs", [".md", ".mdx"]);
+  const filesWithoutPrefix = files.map((file) => file.replace("docs/", ""));
+  const filesWithoutReference = filesWithoutPrefix.filter(
+    (file) =>
+      !file.startsWith("reference/") && !file.startsWith("cli/reference/"),
+  );
+  const filesWithoutExamples = filesWithoutReference.filter(
+    (f) => !f.includes("/examples/"),
+  );
+
+  const filesWithoutTranslation: string[] = [];
+  for (const file of filesWithoutExamples) {
+    const fileInTranslations =
+      "i18n/de/docusaurus-plugin-content-docs/current/" + file;
+    if (!(await fileExists(fileInTranslations))) {
+      filesWithoutTranslation.push(file);
+    }
+  }
+
+  return filesWithoutTranslation;
+}
+
+async function fileExists(filename: string): Promise<boolean> {
+  try {
+    await fs.access(filename);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && (error as any).code === "ENOENT") {
+      return false; // File does not exist
+    }
+    throw error; // Some other error occurred
+  }
+}
+
+async function translateFile(file: string): Promise<void> {
+  const content = await fs.readFile(path.join("docs", file), {
+    encoding: "utf-8",
+  });
+  const completion = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [
+      {
+        role: "system",
+        content:
+          "Your task is to translate a markdown or MDX file in the mittwald developer portal from English to German. " +
+          "Respond with the translated file content, without any additional text or explanation.\n\n" +
+          "Address the user informally and use the 'du' form. " +
+          "Keep established terms and phrases in English, for example but not limited to 'deployment', 'API', 'Infrastructure as code'. " +
+          "Do not modify code blocks at all.",
+      },
+      { role: "user", content },
+    ],
+    max_tokens: 4096 * 2,
+    temperature: 0,
+  });
+
+  const translatedContent = completion.choices[0].message.content;
+  const outputFile = path.join(
+    "i18n/de/docusaurus-plugin-content-docs/current",
+    file,
+  );
+
+  console.log("writing to ", outputFile);
+  await fs.writeFile(outputFile, translatedContent);
+}
+
+async function main() {
+  const files = await findFilesWithoutTranslations();
+
+  for (const file of files) {
+    await translateFile(file);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/generator/util/list_files.ts
+++ b/generator/util/list_files.ts
@@ -1,0 +1,28 @@
+import { readdir } from "fs/promises";
+import * as path from "path";
+
+export default async function listFilesWithExtensions(
+  dir: string,
+  extensions: string[],
+): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        return await listFilesWithExtensions(fullPath, extensions);
+      } else if (
+        entry.isFile() &&
+        extensions.includes(path.extname(entry.name).toLowerCase())
+      ) {
+        return [fullPath];
+      } else {
+        return [];
+      }
+    }),
+  );
+
+  return files.flat();
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --write docs i18n src",
     "generate": "tsx generator/generate-ref.ts",
     "generate:changelog": "tsx generator/generate-changelog.ts",
-    "generate:cli": "tsx generator/generate-cli.ts"
+    "generate:cli": "tsx generator/generate-cli.ts",
+    "generate:translations":  "tsx generator/generate-translations.ts"
   },
   "dependencies": {
     "@datapunt/matomo-tracker-react": "^0.5.1",


### PR DESCRIPTION
This PR adds a small helper script that can be used to quickly generate documentation translations.

This command requires an OpenAI API key in your local environment.

Invoke with:

```
$ export OPENAI_API_KEY=XXX 
$ npm run generate:translations
```
