### PR TITLE
Document Terraform provider in platform section

### DIFF
--- a/docs/platform/deployment/terraform.mdx
+++ b/docs/platform/deployment/terraform.mdx
@@ -1,0 +1,148 @@
+---
+title: Infrastructure as code with Terraform
+sidebar_label: Terraform
+tags:
+  - Terraform
+  - Deployment
+description: >
+  Terraform is an open-source tool that allows you to define and provision your infrastructure using a declarative configuration language.
+---
+
+[Terraform][terraform] is an open-source tool that allows you to define and provision your infrastructure using a declarative configuration language.
+
+## The mittwald terraform provider
+
+We offer a Terraform provider which allows you to manage your mStudio resources as declarative code. The provider is available on the [Terraform Registry][provider].
+
+### Prerequisites
+
+To get started using the mittwald terraform provider, you need to have the following prerequisites:
+
+- An mStudio API token with the required permissions to manage your resources. Have a look at the ["Getting started" section][apitoken] to learn how to obtain an API token.
+- The [Terraform CLI][terraform] installed on your local machine. The mittwald provider requires Terraform in version 1.10 or higher.
+
+Suggested reading:
+
+- [Terraform fundamentals][terraform-fundamentals]
+- [Documentation for the mittwald terraform provider][provider]
+
+### Your first Terraform configuration
+
+To get started with the mittwald terraform provider, create a new directory for your Terraform configuration and create a file named `main.tf` inside it. This file will contain your Terraform configuration.
+
+```hcl title="main.tf"
+terraform {
+  required_providers {
+    mittwald = {
+      source  = "mittwald/mittwald"
+      version = ">= 1.0.0, <2.0.0"
+    }
+  }
+}
+
+provider "mittwald" {}
+```
+
+This is a minimal configuration that initializes the mittwald provider. You can add more resources to this configuration as needed. The `required_providers` block specifies the mittwald provider and its version constraints. In a real-world project, this section might also include other providers you want to use. The `provider` block initializes the mittwald provider with default settings. You can customize this block to specify your API token and other settings.
+
+When no API token is specified, the provider will look for the `MITTWALD_API_TOKEN` environment variable. You can set this variable in your terminal or in your shell configuration file.
+
+After creating the `main.tf` file, you can initialize your Terraform configuration by running the following command in your terminal:
+
+```shellsession title="Local shell session"
+$ terraform init
+```
+
+:::important
+
+These commands are meant to be run either in your local shell, or in a CI environment; **not** in your hosting environment.
+
+:::
+
+### Creating a new resource
+
+To create a new project on an existing server, you can use the following Terraform configuration:
+
+```hcl title="main.tf"
+resource "mittwald_project" "foobar" {
+  server_id   = "<server-id>"
+  description = "Test project"
+}
+```
+
+After having defined a `mittwald_project` resource, you can create the project by running the following command in your terminal:
+
+```shellsession
+$ terraform apply
+```
+
+This command will create the project on the server specified in the `server_id` attribute.
+
+The IDs of created resources are automatically assigned by the mittwald API. Terraform will save the IDs of created resources in the state file, so that these are not recreated on subsequent runs. You can view the IDs of created resources by running the `terraform show` command.
+
+:::important
+
+The `terraform.tfstate` file should be saved for subsequent runs. Before committing this file to a version control system, make sure that it does not contain any sensitive information. Also consider a [remote backend][terraform-remote] for storing the state file.
+
+:::
+
+### Using variables
+
+There are some values that you might not want to hardcode in your Terraform configuration, such as the server ID. The same goes for secret values, like for example a MySQL user password.
+
+You can use [Terraform variables][terraform-variables] to make your configuration more flexible and reusable. To define a variable, you can define variables in your configuration, and then create a separate variable file (or pass variables via the command line).
+
+```hcl
+variable "server_id" {
+  description = "The ID of the server to create the project on"
+  type        = string
+}
+
+resource "mittwald_project" "example" {
+  server_id   = var.server_id
+  description = "Test project"
+}
+```
+
+## Advanced use cases
+
+### Using predefined modules
+
+For convenience, we provide a set of [predefined modules][terraform-modules] that you can use to deploy common workloads. These modules are available in the `mittwald` module namespace. Have a look at the [Terraform Registry][terraform-modules] for a list of available modules.
+
+### Interconnecting multiple providers
+
+Since Terraform is a multi-cloud tool, you can use it to manage resources across multiple providers. Just as an example, you can create a project on mittwald and then configure your DNS records on Cloudflare:
+
+```hcl
+resource "mittwald_project" "example" {
+  server_id   = var.server_id
+  description = "Test project"
+}
+
+resource "cloudflare_dns_record" "example_dns_record" {
+  for_each = toset(mittwald_project.example.default_ips)
+  zone_id  = var.dns_zone_id
+  content  = each.value
+  name     = "your-site.example"
+  proxied  = false
+  ttl      = 3600
+  type     = "A"
+}
+```
+
+## Managing your terraform state
+
+:::info
+
+This section is still work-in-progress. Stay tuned for updates!
+
+:::
+
+[terraform]: https://developer.hashicorp.com/terraform
+[terraform-fundamentals]: https://developer.hashicorp.com/terraform/tutorials/cli
+[terraform-remote]: https://developer.hashicorp.com/terraform/language/state/remote
+[terraform-variables]: https://developer.hashicorp.com/terraform/language/values/variables
+[terraform-modules]: https://registry.terraform.io/namespaces/mittwald
+[provider]: https://registry.terraform.io/providers/mittwald/mittwald/latest
+[apitoken]: /docs/v2/api/intro

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/deployment/terraform.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/deployment/terraform.mdx
@@ -1,0 +1,148 @@
+---
+title: Infrastructure as Code mit Terraform
+sidebar_label: Terraform
+tags:
+  - Terraform
+  - Deployment
+description: >
+  Terraform ist ein Open-Source-Tool, mit dem du deine Infrastruktur mithilfe einer deklarativen Konfigurationssprache definieren und bereitstellen kannst.
+---
+
+[Terraform][terraform] ist ein Open-Source-Tool, mit dem du deine Infrastruktur mithilfe einer deklarativen Konfigurationssprache definieren und bereitstellen kannst.
+
+## Der mittwald Terraform-Provider
+
+Wir bieten einen Terraform-Provider an, mit dem du deine mStudio-Ressourcen als deklarativen Code verwalten kannst. Der Provider ist in der [Terraform Registry][provider] verfügbar.
+
+### Voraussetzungen
+
+Um mit dem mittwald Terraform-Provider loszulegen, brauchst du folgendes:
+
+- Ein mStudio API-Token mit den erforderlichen Berechtigungen zur Verwaltung deiner Ressourcen. Schau dir den Abschnitt ["Erste Schritte"][apitoken] an, um zu erfahren, wie du ein API-Token erhältst.
+- Die [Terraform CLI][terraform] auf deinem lokalen Rechner. Der mittwald-Provider benötigt Terraform in Version 1.10 oder höher.
+
+Empfohlene Lektüre:
+
+- [Terraform-Grundlagen][terraform-fundamentals]
+- [Dokumentation für den mittwald Terraform-Provider][provider]
+
+### Deine erste Terraform-Konfiguration
+
+Um mit dem mittwald Terraform-Provider loszulegen, erstelle ein neues Verzeichnis für deine Terraform-Konfiguration und erstelle darin eine Datei mit dem Namen `main.tf`. Diese Datei wird deine Terraform-Konfiguration enthalten.
+
+```hcl title="main.tf"
+terraform {
+  required_providers {
+    mittwald = {
+      source  = "mittwald/mittwald"
+      version = ">= 1.0.0, <2.0.0"
+    }
+  }
+}
+
+provider "mittwald" {}
+```
+
+Das ist eine minimale Konfiguration, die den mittwald-Provider initialisiert. Du kannst nach Bedarf weitere Ressourcen zu dieser Konfiguration hinzufügen. Der Block `required_providers` gibt den mittwald-Provider und seine Versionsbeschränkungen an. In einem echten Projekt könnte dieser Abschnitt auch andere Provider enthalten, die du verwenden möchtest. Der Block `provider` initialisiert den mittwald-Provider mit den Standardeinstellungen. Du kannst diesen Block anpassen, um dein API-Token und andere Einstellungen anzugeben.
+
+Wenn kein API-Token angegeben ist, sucht der Provider nach der Umgebungsvariable `MITTWALD_API_TOKEN`. Du kannst diese Variable in deinem Terminal oder in deiner Shell-Konfigurationsdatei setzen.
+
+Nachdem du die Datei `main.tf` erstellt hast, kannst du deine Terraform-Konfiguration initialisieren, indem du den folgenden Befehl in deinem Terminal ausführst:
+
+```shellsession title="Lokale Shell-Sitzung"
+$ terraform init
+```
+
+:::important
+
+Diese Befehle sollten entweder in deiner lokalen Shell oder in einer CI-Umgebung ausgeführt werden; **nicht** in deiner Hosting-Umgebung.
+
+:::
+
+### Erstellen einer neuen Ressource
+
+Um ein neues Projekt auf einem bestehenden Server zu erstellen, kannst du die folgende Terraform-Konfiguration verwenden:
+
+```hcl title="main.tf"
+resource "mittwald_project" "foobar" {
+  server_id   = "<server-id>"
+  description = "Testprojekt"
+}
+```
+
+Nachdem du eine `mittwald_project`-Ressource definiert hast, kannst du das Projekt erstellen, indem du den folgenden Befehl in deinem Terminal ausführst:
+
+```shellsession
+$ terraform apply
+```
+
+Dieser Befehl erstellt das Projekt auf dem im Attribut `server_id` angegebenen Server.
+
+Die IDs der erstellten Ressourcen werden automatisch von der mittwald API zugewiesen. Terraform speichert die IDs der erstellten Ressourcen in der State-Datei, sodass diese bei nachfolgenden Ausführungen nicht erneut erstellt werden. Du kannst die IDs der erstellten Ressourcen anzeigen, indem du den Befehl `terraform show` ausführst.
+
+:::important
+
+Die Datei `terraform.tfstate` sollte für nachfolgende Ausführungen gespeichert werden. Bevor du diese Datei in ein Versionskontrollsystem überträgst, stelle sicher, dass sie keine sensiblen Informationen enthält. Ziehe auch ein [Remote-Backend][terraform-remote] in Betracht, um den Terraform-State zu speichern.
+
+:::
+
+### Verwendung von Variablen
+
+Es gibt einige Werte, die du möglicherweise nicht in deiner Terraform-Konfiguration hartcoden möchtest, wie z.B. die Server-ID. Das gilt auch für geheime Werte, wie zum Beispiel ein MySQL-Benutzerpasswort.
+
+Du kannst [Terraform-Variablen][terraform-variables] verwenden, um deine Konfiguration flexibler und wiederverwendbarer zu gestalten. Um eine Variable zu definieren, kannst du Variablen in deiner Konfiguration definieren und dann eine separate Variablendatei erstellen (oder Variablen über die Befehlszeile übergeben).
+
+```hcl
+variable "server_id" {
+  description = "Die ID des Servers, auf dem das Projekt erstellt werden soll"
+  type        = string
+}
+
+resource "mittwald_project" "example" {
+  server_id   = var.server_id
+  description = "Testprojekt"
+}
+```
+
+## Fortgeschrittene Anwendungsfälle
+
+### Verwendung vordefinierter Module
+
+Zur Vereinfachung stellen wir eine Reihe von [vordefinierten Modulen][terraform-modules] zur Verfügung, die du verwenden kannst, um gängige Workloads bereitzustellen. Diese Module sind im Modul-Namespace `mittwald` verfügbar. Schau dir das [Terraform Registry][terraform-modules] für eine Liste der verfügbaren Module an.
+
+### Verknüpfung mehrerer Provider
+
+Da Terraform ein Multi-Cloud-Tool ist, kannst du es verwenden, um Ressourcen über mehrere Provider hinweg zu verwalten. Zum Beispiel kannst du ein Projekt auf mittwald erstellen und dann deine DNS-Einträge bei Cloudflare konfigurieren:
+
+```hcl
+resource "mittwald_project" "example" {
+  server_id   = var.server_id
+  description = "Testprojekt"
+}
+
+resource "cloudflare_dns_record" "example_dns_record" {
+  for_each = toset(mittwald_project.example.default_ips)
+  zone_id  = var.dns_zone_id
+  content  = each.value
+  name     = "deine-seite.beispiel"
+  proxied  = false
+  ttl      = 3600
+  type     = "A"
+}
+```
+
+## Verwaltung deines Terraform-Zustands
+
+:::info
+
+Dieser Abschnitt ist noch in Arbeit. Bleib dran für Updates!
+
+:::
+
+[terraform]: https://developer.hashicorp.com/terraform
+[terraform-fundamentals]: https://developer.hashicorp.com/terraform/tutorials/cli
+[terraform-remote]: https://developer.hashicorp.com/terraform/language/state/remote
+[terraform-variables]: https://developer.hashicorp.com/terraform/language/values/variables
+[terraform-modules]: https://registry.terraform.io/namespaces/mittwald
+[provider]: https://registry.terraform.io/providers/mittwald/mittwald/latest
+[apitoken]: /docs/v2/api/intro

--- a/src/components/HomepageFeatures/PlatformFeature.tsx
+++ b/src/components/HomepageFeatures/PlatformFeature.tsx
@@ -120,9 +120,7 @@ function PlatformTools() {
             }
             links={[
               <Link to="/cli">CLI</Link>,
-              <Link to="/docs/v2/platform/development/ddev">
-                DDEV <NewBadge />
-              </Link>,
+              <Link to="/docs/v2/platform/development/ddev">DDEV</Link>,
             ]}
           />
         </li>
@@ -138,8 +136,8 @@ function PlatformTools() {
               <Link to="/docs/v2/platform/deployment/typo3surf">
                 TYPO3 Surf
               </Link>,
-              <Link href="https://github.com/mittwald/terraform-provider-mittwald">
-                Terraform
+              <Link to="/docs/v2/platform/deployment/terraform">
+                Terraform <NewBadge />
               </Link>,
             ]}
           />


### PR DESCRIPTION
- **feat: add (preliminary) documentation on how to use the terraform provider**
- **i18n: add german translation for terraform docs**
- **feat: adjust link on index page**
