### PR TITLE
Remove breaking change entry from changelog

### DIFF
--- a/changelog/2025-07-11-api-changes-v2.mdx
+++ b/changelog/2025-07-11-api-changes-v2.mdx
@@ -1,14 +1,12 @@
 ---
-title: Breaking (!) API changes for v2 API, July 4 to July 11
+title: API changes for v2 API, July 4 to July 11
 authors:
   - machine
 tags:
   - apiv2
-  - breaking
   - App
   - Marketplace
   - Contract
-
 ---
 
 import OperationHint from "@site/src/components/OperationHint";
@@ -18,22 +16,8 @@ During the week of July 4th to July 11th, 2025, the mittwald API underwent sever
 
 {/* truncate */}
 
-
-
-:::caution Breaking changes
-
-This document contains changes that can under certain circumstances be considered breaking. Please review the changes carefully.
-
-While we generally strive to avoid breaking changes in accordance with our [API stability guarantees](../../../../../docs/v2/api/stability), we occasionally might perform changes that would be considered breaking in the strictest sense of the term, but we do not consider as breaking in a practical sense. We will always provide ample notice and documentation for such changes.
-
-:::
-
-
-
 ## Summary
 
-
-- The API path for the operation `POST /v2/extensions/{extensionId}/checkout` has been removed without deprecation, which is a breaking change.
 - The optional property `/items/processes` has been removed from the `200` status response for the following operations:
   - `GET /v2/app-installations` (List AppInstallations that a user has access to)
   - `GET /v2/projects/{projectId}/app-installations` (List AppInstallations belonging to a Project).
@@ -50,112 +34,65 @@ While we generally strive to avoid breaking changes in accordance with our [API 
 
 _Disclaimer: This summary is AI-generated. If you find any discrepancies, please refer to the detailed changes below._
 
-
 ## Detailed changes
 
-
-
-### Changes in "extension-start-extension-checkout"
-
-
-- ⚠️ **Breaking:** api path removed without deprecation
-
-
-For details, refer to the <OperationLink operation="extension-start-extension-checkout" apiVersion="v2" /> endpoint.
-
-
-
 ### Changes in "List app installations that a user has access to"
-
 
 - removed the optional property '/items/processes' from the response with the '200' status
 
 - added the optional property '/items/lockedBy' to the response with the '200' status
 
-
 For details, refer to the <OperationLink operation="app-list-appinstallations-for-user" apiVersion="v2" /> endpoint.
 
-
-
 ### Changes in "Get an app installation"
-
 
 - removed the optional property 'processes' from the response with the '200' status
 
 - added the optional property 'lockedBy' to the response with the '200' status
 
-
 For details, refer to the <OperationLink operation="app-get-appinstallation" apiVersion="v2" /> endpoint.
 
-
-
 ### Changes in "List app installations belonging to a Project"
-
 
 - removed the optional property '/items/processes' from the response with the '200' status
 
 - added the optional property '/items/lockedBy' to the response with the '200' status
 
-
 For details, refer to the <OperationLink operation="app-list-appinstallations" apiVersion="v2" /> endpoint.
-
-
 
 ### Changes in "Trigger an uninstallation process for an app installation"
 
-
 - added the non-success response with the status '412'
-
 
 For details, refer to the <OperationLink operation="app-uninstall-appinstallation" apiVersion="v2" /> endpoint.
 
-
-
 ### Changes in "contract-get-next-termination-date-for-item"
-
 
 - api operation id 'contract-get-next-termination-date-for-item' removed and replaced with 'deprecated-contract-get-next-termination-date-for-item'
 
-
 For details, refer to the <OperationLink operation="contract-get-next-termination-date-for-item" apiVersion="v2" /> endpoint.
-
-
 
 ### Changes in "List ContractPartners of the contributor"
 
-
 - endpoint added
-
 
 For details, refer to the <OperationLink operation="contributor-list-contract-partners-of-contributor" apiVersion="v2" /> endpoint.
 
-
-
 ### Changes in "Creates or Updates Pricing for an Extension"
-
 
 - added the non-success response with the status '412'
 
-
 For details, refer to the <OperationLink operation="extension-update-extension-pricing" apiVersion="v2" /> endpoint.
 
-
-
 ### Changes in "List Invoices of a Customer"
-
 
 - added the new optional 'query' request parameter 'order'
 
 - added the new optional 'query' request parameter 'sort'
 
-
 For details, refer to the <OperationLink operation="invoice-list-customer-invoices" apiVersion="v2" /> endpoint.
 
-
-
-
 ## Client package releases
-
 
 ### mittwald JavaScript SDK Release 4.181.0
 
@@ -172,4 +109,3 @@ The mittwald JavaScript SDK has been updated to version 4.179.0. This release in
 ### mittwald JavaScript SDK Release 4.178.0
 
 The mittwald JavaScript SDK has been updated to version 4.178.0. This release includes an update to the generated client, enhancing the SDK's functionality. For more details, you can view the release on [GitHub](https://github.com/mittwald/api-client-js/releases/tag/4.178.0).
-


### PR DESCRIPTION
The publishing of this route was an error. The correct path to use for ordering an extension is `/v2/extensions/{extensionId}/order`. Since the wrong path was published only for a short time, we should remove the entry to avoid confusion.