### PR TITLE
Add documentation on how to deploy Solr using containers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common Development Commands
+
+### Core Commands
+- `npm install` - Install dependencies (requires Node.js >=20)
+- `npm start` - Start development server
+- `npm run build` - Build production release
+- `npm run serve` - Serve production release locally
+- `npm run format` - Format code with Prettier (targets docs, i18n, src directories)
+
+### Generation Commands
+- `npm run generate` - Generate OpenAPI reference documentation from specs
+- `npm run generate:changelog` - Generate changelog entries
+- `npm run generate:cli` - Generate CLI documentation
+- `npm run generate:translations` - Generate translation files
+
+## Project Architecture
+
+This is the **mittwald Developer Portal** - a Docusaurus-based documentation site that serves API documentation, CLI guides, platform documentation, and developer resources.
+
+### Key Architecture Components
+
+**Documentation Generation System**: The project uses automated generation for API reference docs from OpenAPI specifications located in `src/openapi/`. The generation system supports multiple API versions (v1, v2) with overlay customizations.
+
+**Multi-language Support**: Full internationalization with English (default) and German translations. English docs in `docs/`, German translations in `i18n/de/docusaurus-plugin-content-docs/current/`.
+
+**Docusaurus Framework**: Built on Docusaurus v3 with custom plugins for client redirects, multi-blog support (changelog), and Mermaid diagrams.
+
+### Directory Structure
+
+- `docs/` - Main documentation content (English)
+- `i18n/` - Internationalization files, primarily German translations
+- `src/` - Custom React components, OpenAPI utilities, and theme customizations
+- `generator/` - TypeScript scripts for automated doc generation from OpenAPI specs
+- `changelog/` - Changelog entries (auto-generated and manual)
+- `static/` - Static assets (images, fonts, OpenAPI spec files)
+
+### Generation System Details
+
+The `generator/` directory contains sophisticated tooling:
+- `generate-ref.ts` - Main API reference generator from OpenAPI specs
+- `overlays/` - Custom content overlays for specific API operations
+- `templates/` - EJS templates for generating documentation
+- `util/` - Utilities for spec processing, sidebar generation, title canonicalization
+
+### Custom Components
+
+The project extends Docusaurus with specialized components in `src/components/`:
+- OpenAPI-specific components for operation documentation
+- Feature showcase components for homepage
+- Custom styling and interaction elements
+
+## Development Notes
+
+- Uses TypeScript throughout with strict compilation settings
+- OpenAPI specs are version-managed (v1 legacy, v2 current)
+- Content must be updated in both English and German when applicable
+- Production builds may be necessary for multi-lingual content development
+- The site supports versioned documentation with v2 as current and v1 as unmaintained

--- a/docs/platform/databases/solr.mdx
+++ b/docs/platform/databases/solr.mdx
@@ -304,22 +304,21 @@ For other languages, replace `english` in the file paths with the appropriate la
 
 ### Using the Solr Admin UI
 
-Alternatively, you can use the Solr admin UI to create a new core. In this case, start by preparing the respective directories and configuration files (using the `solr create_core` command will do this for you):
+Alternatively, you can use the Solr admin UI to create a new core. For a TYPO3 Solr core, first follow steps 1-3 from the [manual initialization section](#initializing-a-typo3-solr-core-manually) above to prepare all the necessary TYPO3 configuration files and the plugin JAR file.
 
-1. Make sure that the `instanceDir` at `/var/solr/data/<corename>` exists (with `<corename>` being a name of your choice)
-2. Within that instance directory, the `conf/solrconfig.xml` file must exist. Refer to the [Solr manual](https://solr.apache.org/guide/solr/latest/configuration-guide/configuring-solrconfig-xml.html) to learn more about this configuration file.
-
-After these prerequisites are met, you can create the new Core via the Solr admin UI:
+After the prerequisites are met, you can create the new core via the Solr Admin UI:
 
 1. Access the Solr Admin UI using one of the methods described in [Accessing Solr from outside the hosting environment](#public-access)
 2. Click on the "Core Admin" menu item
 3. Click on "Add Core" and fill in the required fields:
 
-- name: The name of your core (e.g., "typo3")
-- instanceDir: Leave as default or specify a custom directory
-- dataDir: Leave as default or specify a custom directory
-- config: Leave as default (`solrconfig.xml`)
-- schema: Leave as default (`schema.xml`)
+- **name**: The name of your core (e.g., "typo3")
+- **instanceDir**: `/var/solr/data/typo3` (or your chosen core directory)
+- **dataDir**: Leave as default or specify a custom directory
+- **config**: `solrconfig.xml`
+- **schema**: `schema.xml`
+
+4. Click "Add Core" to create the TYPO3 Solr core
 
 ## Operation
 

--- a/docs/platform/databases/solr.mdx
+++ b/docs/platform/databases/solr.mdx
@@ -53,6 +53,71 @@ $ mw container port-forward solr
 
 While this command is running, you should be able to connect to your Solr instance via the URL `http://localhost:8983`.
 
+#### TYPO3-Specific Terraform Setup
+
+For TYPO3 projects, we provide a specialized TYPO3 module that automatically configures Solr with the necessary schema and configuration files optimized for TYPO3:
+
+```hcl
+module "solr" {
+  source = "mittwald/solr/mittwald"
+
+  project_id = var.project_id
+
+  solr_version = "9"
+  solr_core_name = "typo3"
+  solr_heap = "2g"
+}
+
+module "solr_typo3" {
+  source = "mittwald/solr/mittwald//modules/typo3"
+
+  solr_stack_id = module.solr.stack_id
+  solr_core_name = "typo3"
+  solr_core_language = "english"
+  typo3_solr_version = "13.0.3"
+}
+
+output "solr_url" {
+  value = module.solr.url
+}
+```
+
+For multi-language TYPO3 installations, you can create separate cores for each language:
+
+```hcl
+module "solr" {
+  source = "mittwald/solr/mittwald"
+
+  project_id = var.project_id
+  solr_version = "9"
+  solr_heap = "2g"
+}
+
+module "solr_typo3" {
+  source = "mittwald/solr/mittwald//modules/typo3"
+  for_each = toset(["german", "english"])
+
+  solr_stack_id = module.solr.stack_id
+  solr_core_name = "typo3_${each.key}"
+  solr_core_language = each.key
+  typo3_solr_version = "13.0.3"
+}
+
+output "solr_url" {
+  value = module.solr.url
+}
+```
+
+The TYPO3 module automatically:
+
+- Downloads and installs the appropriate `schema.xml` for the specified language
+- Configures language-specific analyzers and filters
+- Sets up the required TYPO3 Solr plugin JAR file
+- Creates core.properties with the correct configuration
+- Installs additional configuration files like protwords, synonyms and stopwords
+
+The `typo3_solr_version` should match the version of the TYPO3 Solr extension you're using in your project.
+
 ### Using the mStudio UI
 
 Alternatively, you can set up a Solr container manually:
@@ -73,6 +138,8 @@ Alternatively, you can set up a Solr container manually:
    ```dotenv
    # adjust as needed
    SOLR_HEAP=512m
+   SOLR_CONFIG_LIB_ENABLED=true
+   SOLR_MODULES=scripting,analytics,analysis-extras,langid,clustering,extraction
    ```
 
 The suggested port values are standard in the Solr context and can be accepted as is. The default port for Solr is 8983.
@@ -85,12 +152,14 @@ You can also deploy a Solr container using the mittwald CLI with the `mw contain
 mw container run \
   --name solr \
   --env SOLR_HEAP=512m \
+  --env SOLR_CONFIG_LIB_ENABLED=true \
+  --env SOLR_MODULES=scripting,analytics,analysis-extras,langid,clustering,extraction \
   --volume solr-data:/var/solr \
   --publish 8983:8983 \
   solr:9.9 solr-precreate typo3
 ```
 
-This command creates a new container named "solr" using the Solr image, sets the necessary environment variables, and mounts a volume for persistent data storage.
+This command creates a new container named "solr" using the Solr image, sets the necessary environment variables including enabling the lib directory configuration and additional Solr modules, and mounts a volume for persistent data storage.
 
 ### Using the CLI with `mw stack deploy`
 
@@ -106,6 +175,8 @@ If you prefer using Docker Compose, you can create a `docker-compose.yml` file a
        command: solr-precreate typo3
        environment:
          - SOLR_HEAP=512m
+         - SOLR_CONFIG_LIB_ENABLED=true
+         - SOLR_MODULES=scripting,analytics,analysis-extras,langid,clustering,extraction
        ports:
          - "8983:8983"
        volumes:
@@ -164,11 +235,72 @@ If you did not create a core on container startup (using the `solr-precreate` co
 
 ### Using the Command Line
 
-The easies way to create a new Solr core is using the `solr create_core` command and the `mw container exec` command:
+The easiest way to create a new Solr core is using the `solr create_core` command and the `mw container exec` command:
 
+```shellsession
+$ mw container exec <CONTAINER-ID> 'solr create_core -c typo3'
 ```
-mw container exec <CONTAINER-ID> 'solr create_core -c typo3'
-```
+
+### Initializing a TYPO3 Solr Core Manually
+
+If you're not using the Terraform TYPO3 module, you can manually initialize a Solr core with TYPO3-specific configuration files using the `mw container cp` command. This approach is similar to using `docker cp`:
+
+1. First, clone the TYPO3 Solr extension repository to get all configuration files:
+
+   ```bash
+   # Clone the TYPO3 Solr extension repository
+   git clone https://github.com/TYPO3-Solr/ext-solr.git /tmp/ext-solr
+
+   # Navigate to the configuration directory
+   cd /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf
+   ```
+
+2. Create the core directory structure in the Solr container:
+
+   ```bash
+   mw container exec <CONTAINER-ID> 'mkdir -p /var/solr/data/typo3/conf'
+   mw container exec <CONTAINER-ID> 'mkdir -p /var/solr/data/typo3/lib'
+   ```
+
+3. Copy the configuration files to the Solr container:
+
+   ```bash
+   # Copy main configuration files
+   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/solrconfig.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
+   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/general_schema_fields.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
+   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/general_schema_types.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
+   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/elevate.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
+   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/currency.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
+
+   # Copy language-specific files (example for English)
+   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/english/schema.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
+   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/english/protwords.txt <CONTAINER-ID>:/var/solr/data/typo3/conf/
+
+   # Copy the TYPO3 Solr plugin JAR file
+   mw container cp /tmp/ext-solr/Resources/Private/Solr/typo3lib/solr-typo3-plugin-6.0.0.jar <CONTAINER-ID>:/var/solr/data/typo3/lib/
+   ```
+
+4. Create the core.properties file:
+
+   ```bash
+   mw container exec <CONTAINER-ID> 'echo "name=typo3" > /var/solr/data/typo3/core.properties'
+   mw container exec <CONTAINER-ID> 'echo "config=solrconfig.xml" >> /var/solr/data/typo3/core.properties'
+   mw container exec <CONTAINER-ID> 'echo "schema=english/schema.xml" >> /var/solr/data/typo3/core.properties'
+   ```
+
+5. Reload the Solr core to apply the new configuration:
+
+   ```bash
+   mw container exec <CONTAINER-ID> 'curl "http://localhost:8983/solr/admin/cores?action=RELOAD&core=typo3"'
+   ```
+
+6. Clean up the temporary files:
+
+   ```bash
+   rm -rf /tmp/ext-solr
+   ```
+
+For other languages, replace `english` in the file paths with the appropriate language directory (e.g., `german`, `french`, etc.). Replace `<CONTAINER-ID>` with your actual Solr container ID, which you can find using `mw container list`.
 
 ### Using the Solr Admin UI
 

--- a/docs/platform/databases/solr.mdx
+++ b/docs/platform/databases/solr.mdx
@@ -55,7 +55,7 @@ While this command is running, you should be able to connect to your Solr instan
 
 #### TYPO3-Specific Terraform Setup
 
-For TYPO3 projects, we provide a specialized TYPO3 module that automatically configures Solr with the necessary schema and configuration files optimized for TYPO3:
+For TYPO3 projects, we provide a [specialized Terraform module](https://registry.terraform.io/modules/mittwald/solr/mittwald/latest) that automatically configures Solr with the necessary schema and configuration files optimized for TYPO3:
 
 ```hcl
 module "solr" {
@@ -266,21 +266,16 @@ If you're not using the Terraform TYPO3 module, you can manually initialize a So
 
    ```bash
    # Copy main configuration files
-   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/solrconfig.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
-   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/general_schema_fields.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
-   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/general_schema_types.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
-   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/elevate.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
-   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/currency.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
+   mw container cp -r /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf <CONTAINER-ID>:/var/solr/data/typo3/conf
 
    # Copy language-specific files (example for English)
-   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/english/schema.xml <CONTAINER-ID>:/var/solr/data/typo3/conf/
-   mw container cp /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/english/protwords.txt <CONTAINER-ID>:/var/solr/data/typo3/conf/
+   mw container cp -r /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/english <CONTAINER-ID>:/var/solr/data/typo3/conf/english
 
    # Copy the TYPO3 Solr plugin JAR file
    mw container cp /tmp/ext-solr/Resources/Private/Solr/typo3lib/solr-typo3-plugin-6.0.0.jar <CONTAINER-ID>:/var/solr/data/typo3/lib/
    ```
 
-4. Create the core.properties file:
+4. Create the `core.properties` file:
 
    ```bash
    mw container exec <CONTAINER-ID> 'echo "name=typo3" > /var/solr/data/typo3/core.properties'

--- a/docs/platform/databases/solr.mdx
+++ b/docs/platform/databases/solr.mdx
@@ -30,8 +30,9 @@ module "solr" {
   source = "mittwald/solr/mittwald"
 
   project_id = var.project_id
+
   solr_version = "9"
-  solr_core_name = "products"
+  solr_core_name = "typo3"
   solr_heap = "2g"
 }
 
@@ -40,7 +41,7 @@ output "solr_url" {
 }
 ```
 
-After this, you can access your Solr backend using the URL returned by the Terraform output. Usually, the URL should be `http://solr:8983`.
+After this, you can access your Solr backend using the URL returned by the Terraform output. Usually, the URL should be `http://solr:8983`. Note that this URL is only accessible from within the hosting environment (e.g., from your application containers or via SSH).
 
 ### Using the mStudio UI
 
@@ -48,9 +49,9 @@ Alternatively, you can set up a Solr container manually:
 
 1. Go to **Containers** in your project in mStudio and create a new one. You can choose any name you like.
 
-2. As image, enter either `solr:9` or `solr:9.9`, depending on how specific the version should be constrained. You can keep the entrypoint and command as suggested.
+2. As image, enter either `solr:9` or a more specific version number like `solr:9.9`, depending on how specific the version should be constrained. You can keep the entrypoint and command as suggested.
 
-3. (optional) To automatically create a Solr core on container startup, change the command to `solr-precreate <corename>`, replacing `<corename>` with a name of your choice.
+3. (optional, but recommended) To automatically create a Solr core on container startup, change the command to `solr-precreate <corename>`, replacing `<corename>` with a name of your choice.
 
 4. To make your Solr data persistent, create a volume under **Volumes** as follows:
 
@@ -60,7 +61,8 @@ Alternatively, you can set up a Solr container manually:
 5. Set the following environment variables for the container:
 
    ```dotenv
-   SOLR_HEAP=512m  # limits Solr RAM usage - important to prevent excessive memory consumption
+   # adjust as needed
+   SOLR_HEAP=512m
    ```
 
 The suggested port values are standard in the Solr context and can be accepted as is. The default port for Solr is 8983.
@@ -120,38 +122,70 @@ curl -X GET "http://solr:8983/solr/admin/info/system"
 
 You should receive a response with information about your Solr instance, including version, memory usage, and system properties.
 
+### Accessing Solr from outside the hosting environment {#public-access}
+
+The Solr URL (`http://solr:8983`) is only accessible from within the hosting environment. To access Solr from your local machine or from the internet, you have two options:
+
+#### Option 1: Using port forwarding
+
+You can use the mittwald CLI to forward the Solr port to your local machine:
+
+```bash
+mw container port-forward solr 8983:8983
+```
+
+This command creates a secure tunnel between your local machine and the Solr container. After running this command, you can access the Solr admin interface at `http://localhost:8983/` in your local web browser.
+
+#### Option 2: Connecting a domain
+
+For more permanent access, you can connect a domain to your Solr container:
+
+1. In mStudio, go to **Domains** and add a new domain or subdomain (e.g., `solr.yourdomain.com`)
+2. Configure the domain to point to your Solr container on port 8983
+3. Once the DNS has propagated, you can access Solr at `http://solr.yourdomain.com/`
+
+Note that if you choose this option, you should consider implementing proper authentication to protect your Solr instance from unauthorized access.
+
 ## Creating a Solr Core
 
-After setting up your Solr container, you'll need to create a core to store your search indices. You can do this using the Solr Admin UI or via the command line:
-
-### Using the Solr Admin UI
-
-1. Access the Solr Admin UI at `http://solr:8983/solr/`
-2. Click on the "Core Admin" menu item
-3. Click on "Add Core" and fill in the required fields:
-   - name: The name of your core (e.g., "typo3")
-   - instanceDir: Leave as default or specify a custom directory
-   - dataDir: Leave as default or specify a custom directory
-   - config: Leave as default (`solrconfig.xml`)
-   - schema: Leave as default (`schema.xml`)
+If you did not create a core on container startup (using the `solr-precreate` command mentioned above), you'll need to create a core to store your search indices, after setting up your Solr container. You can do this using the Solr Admin UI or via the command line:
 
 ### Using the Command Line
 
-You can also create a core using the Solr API via curl:
+The easies way to create a new Solr core is using the `solr create_core` command and the `mw container exec` command:
 
-```bash
-curl "http://solr:8983/solr/admin/cores?action=CREATE&name=typo3&configSet=_default"
 ```
+mw container exec <CONTAINER-ID> 'solr create_core -c typo3'
+```
+
+### Using the Solr Admin UI
+
+Alternatively, you can use the Solr admin UI to create a new core. In this case, start by preparing the respective directories and configuration files (using the `solr create_core` command will do this for you):
+
+1. Make sure that the `instanceDir` at `/var/solr/data/<corename>` exists (with `<corename>` being a name of your choice)
+2. Within that instance directory, the `conf/solrconfig.xml` file must exist. Refer to the [Solr manual](https://solr.apache.org/guide/solr/latest/configuration-guide/configuring-solrconfig-xml.html) to learn more about this configuration file.
+
+After these prerequisites are met, you can create the new Core via the Solr admin UI:
+
+1. Access the Solr Admin UI using one of the methods described in [Accessing Solr from outside the hosting environment](#public-access)
+2. Click on the "Core Admin" menu item
+3. Click on "Add Core" and fill in the required fields:
+
+- name: The name of your core (e.g., "typo3")
+- instanceDir: Leave as default or specify a custom directory
+- dataDir: Leave as default or specify a custom directory
+- config: Leave as default (`solrconfig.xml`)
+- schema: Leave as default (`schema.xml`)
 
 ## Operation
 
-Solr runs as long as the container is running. When using Solr as a search engine for your CMS, the search indices need to be populated by your application. For this, most CMS platforms offer integrations.
+Solr runs as long as the container is running. When using Solr as a search engine for your CMS, the search indices need to be populated by your application. For this, many CMS platforms offer integrations.
 
 The volume is automatically included in the regular backup of your project.
 
 ## Setting up Solr with TYPO3 CMS
 
-TYPO3 CMS can be integrated with Solr using the extension `solr` (also known as EXT:solr). This section provides a step-by-step guide to configure TYPO3 with your Solr instance.
+TYPO3 CMS can be integrated with Solr using the [extension `solr`](https://extensions.typo3.org/extension/solr). This section provides a step-by-step guide to configure TYPO3 with your Solr instance.
 
 ### Installing the Solr Extension
 
@@ -180,104 +214,8 @@ TYPO3 CMS can be integrated with Solr using the extension `solr` (also known as 
 
 ### Configuring TypoScript
 
-Add the following TypoScript setup to your root template:
-
-```typoscript
-plugin.tx_solr {
-    solr {
-        host = solr
-        port = 8983
-        path = /solr/
-        scheme = http
-        core = typo3
-    }
-
-    index {
-        queue {
-            pages {
-                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
-                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
-                indexer {
-                    // add options here if needed
-                }
-
-                // Define which pages should be indexed
-                additionalWhereClause = nav_hide = 0
-            }
-
-            // Add configuration for other content types as needed
-        }
-    }
-
-    search {
-        // Configure search settings
-        targetPage = 123  // Replace with your search results page UID
-    }
-}
-```
+To get started quickly, include the static TypoScript templates that are provided by the extension. Refer to the [extension's manual](https://docs.typo3.org/p/apache-solr-for-typo3/solr/13.0/en-us/GettingStarted/ConfigureExtension.html#static-typoscript) for more information.
 
 ### Initializing the Index
 
-After configuring the extension, you need to initialize the index:
-
-1. Go to the TYPO3 backend and navigate to "Site Management > Solr".
-2. Select the "Index Queue" tab.
-3. Select the content types you want to index (e.g., pages).
-4. Click on "Initialize selected content types".
-
-Alternatively, you can use the TYPO3 console to initialize and index content:
-
-```bash
-# Initialize the index queue for pages
-./vendor/bin/typo3 solr:updateconnections
-./vendor/bin/typo3 solr:initializeindex pages
-
-# Index all queued items
-./vendor/bin/typo3 solr:indexqueue:indexall
-```
-
-### Adding a Search Form to Your Website
-
-To add a search form to your website, you can use the provided Fluid templates or create your own:
-
-1. Add a plugin content element to a page.
-2. Select "Search: Form" as the plugin type.
-3. Configure the plugin settings as needed.
-
-For the search results, create a new page and add a "Search: Results" plugin to it. Make sure to set this page's UID as the `targetPage` in your TypoScript configuration.
-
-### Advanced Configuration
-
-For more advanced configuration options, refer to the [official EXT:solr documentation](https://docs.typo3.org/p/apache-solr-for-typo3/solr/main/en-us/).
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Connection Issues**: If TYPO3 cannot connect to Solr, verify that:
-
-   - The Solr container is running
-   - The hostname, port, and path are correctly configured
-   - There are no network restrictions between your application and the Solr container
-
-2. **Indexing Issues**: If content is not being indexed properly:
-
-   - Check the TYPO3 system log for errors
-   - Verify that the Solr core exists and is properly configured
-   - Make sure the content you're trying to index meets the criteria defined in your TypoScript configuration
-
-3. **Search Not Working**: If search functionality is not working as expected:
-   - Verify that content has been indexed (check the Solr admin interface)
-   - Ensure the search plugin is properly configured
-   - Check that the search results page is correctly set up
-
-### Solr Admin Interface
-
-The Solr Admin Interface provides valuable tools for troubleshooting:
-
-- **Core Admin**: Manage your Solr cores
-- **Query**: Test search queries directly against your Solr index
-- **Schema Browser**: Explore your schema configuration
-- **Logging**: View Solr logs for error messages
-
-Access the admin interface at `http://solr:8983/solr/`.
+For initializing the search index for the first time, refer to the [extension manual](https://docs.typo3.org/permalink/apache-solr-for-typo3-solr:started-index).

--- a/docs/platform/databases/solr.mdx
+++ b/docs/platform/databases/solr.mdx
@@ -1,0 +1,283 @@
+---
+title: Solr
+sidebar_position: 110
+description: |
+  Apache Solr is a powerful, open-source search platform built on Apache Lucene.
+---
+
+import PlanCompatibility from "@site/src/components/PlanCompatibility";
+
+<PlanCompatibility plans={["ps", "ss"]} />
+
+## What is Solr?
+
+Apache Solr is a highly reliable, scalable and fault-tolerant search platform providing distributed indexing, replication, load-balanced querying, automated failover and recovery, centralized configuration, and more. Solr powers the search and navigation features of many of the world's largest internet sites, enabling powerful full-text search along with hit highlighting, faceted search, real-time indexing, dynamic clustering, database integration, and rich document handling.
+
+Solr is built on Apache Lucene, a high-performance, full-featured text search engine library written in Java. Solr extends Lucene with HTTP APIs, making it easy to use from virtually any programming language. Solr's external configuration allows it to be tailored to many types of applications without Java coding, and it has a plugin architecture to support more advanced customization.
+
+For content management systems like TYPO3, Solr provides powerful search capabilities that can significantly enhance the user experience by enabling fast and relevant search results across your website content.
+
+## Creating a Solr database
+
+You can provision a Solr search engine in your mittwald hosting environment using [containers](../../workloads/containers). There are several approaches to set up Solr:
+
+### Using Terraform (Recommended)
+
+The most convenient way to provision a Solr database is using [Terraform](/docs/v2/guides/deployment/terraform) with our [Solr module](https://registry.terraform.io/modules/mittwald/solr/mittwald/latest). The following example shows how you can use this module in your own Terraform deployment:
+
+```hcl
+module "solr" {
+  source = "mittwald/solr/mittwald"
+
+  project_id = var.project_id
+  solr_version = "9"
+  solr_core_name = "products"
+  solr_heap = "2g"
+}
+
+output "solr_url" {
+  value = module.solr.url
+}
+```
+
+After this, you can access your Solr backend using the URL returned by the Terraform output. Usually, the URL should be `http://solr:8983`.
+
+### Using the mStudio UI
+
+Alternatively, you can set up a Solr container manually:
+
+1. Go to **Containers** in your project in mStudio and create a new one. You can choose any name you like.
+
+2. As image, enter either `solr:9` or `solr:9.9`, depending on how specific the version should be constrained. You can keep the entrypoint and command as suggested.
+
+3. (optional) To automatically create a Solr core on container startup, change the command to `solr-precreate <corename>`, replacing `<corename>` with a name of your choice.
+
+4. To make your Solr data persistent, create a volume under **Volumes** as follows:
+
+   - Volume: Create new volume
+   - Path in container (Mount Point): `/var/solr`
+
+5. Set the following environment variables for the container:
+
+   ```dotenv
+   SOLR_HEAP=512m  # limits Solr RAM usage - important to prevent excessive memory consumption
+   ```
+
+The suggested port values are standard in the Solr context and can be accepted as is. The default port for Solr is 8983.
+
+### Using the CLI with `mw container run`
+
+You can also deploy a Solr container using the mittwald CLI with the `mw container run` command:
+
+```bash
+mw container run \
+  --name solr \
+  --env SOLR_HEAP=512m \
+  --volume solr-data:/var/solr \
+  --publish 8983:8983 \
+  solr:9.9 solr-precreate typo3
+```
+
+This command creates a new container named "solr" using the Solr image, sets the necessary environment variables, and mounts a volume for persistent data storage.
+
+### Using the CLI with `mw stack deploy`
+
+If you prefer using Docker Compose, you can create a `docker-compose.yml` file and deploy it using the `mw stack deploy` command:
+
+1. Create a `docker-compose.yml` file with the following content:
+
+   ```yaml
+   version: "3"
+   services:
+     solr:
+       image: solr:9.9
+       command: solr-precreate typo3
+       environment:
+         - SOLR_HEAP=512m
+       ports:
+         - "8983:8983"
+       volumes:
+         - solr-data:/var/solr
+   volumes:
+     solr-data:
+   ```
+
+2. Deploy the stack using the CLI:
+
+   ```bash
+   mw stack deploy
+   ```
+
+This approach is particularly useful when you need to deploy multiple containers that work together.
+
+### Accessing your container within your hosting environment
+
+Once the container is running, you can verify the instance is accessible by requesting it via `curl`:
+
+```bash
+curl -X GET "http://solr:8983/solr/admin/info/system"
+```
+
+You should receive a response with information about your Solr instance, including version, memory usage, and system properties.
+
+## Creating a Solr Core
+
+After setting up your Solr container, you'll need to create a core to store your search indices. You can do this using the Solr Admin UI or via the command line:
+
+### Using the Solr Admin UI
+
+1. Access the Solr Admin UI at `http://solr:8983/solr/`
+2. Click on the "Core Admin" menu item
+3. Click on "Add Core" and fill in the required fields:
+   - name: The name of your core (e.g., "typo3")
+   - instanceDir: Leave as default or specify a custom directory
+   - dataDir: Leave as default or specify a custom directory
+   - config: Leave as default (`solrconfig.xml`)
+   - schema: Leave as default (`schema.xml`)
+
+### Using the Command Line
+
+You can also create a core using the Solr API via curl:
+
+```bash
+curl "http://solr:8983/solr/admin/cores?action=CREATE&name=typo3&configSet=_default"
+```
+
+## Operation
+
+Solr runs as long as the container is running. When using Solr as a search engine for your CMS, the search indices need to be populated by your application. For this, most CMS platforms offer integrations.
+
+The volume is automatically included in the regular backup of your project.
+
+## Setting up Solr with TYPO3 CMS
+
+TYPO3 CMS can be integrated with Solr using the extension `solr` (also known as EXT:solr). This section provides a step-by-step guide to configure TYPO3 with your Solr instance.
+
+### Installing the Solr Extension
+
+1. Install the Solr extension using Composer:
+
+   ```bash
+   composer require apache-solr-for-typo3/solr
+   ```
+
+   Or download it from the [TYPO3 Extension Repository](https://extensions.typo3.org/extension/solr) and install it through the Extension Manager.
+
+2. After installation, go to the Extension Manager in the TYPO3 backend and activate the extension.
+
+### Configuring the Solr Connection
+
+1. Create or edit your site configuration in TYPO3 (Site Management > Sites).
+
+2. In the site configuration, go to the "Solr" tab and configure the connection:
+
+   - Host: `solr` (the hostname of your Solr container)
+   - Port: `8983` (the default Solr port)
+   - Path: `/solr/` (the default Solr path)
+   - Core: `typo3` (or the name of the core you created)
+
+3. Save the configuration.
+
+### Configuring TypoScript
+
+Add the following TypoScript setup to your root template:
+
+```typoscript
+plugin.tx_solr {
+    solr {
+        host = solr
+        port = 8983
+        path = /solr/
+        scheme = http
+        core = typo3
+    }
+
+    index {
+        queue {
+            pages {
+                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                indexer {
+                    // add options here if needed
+                }
+
+                // Define which pages should be indexed
+                additionalWhereClause = nav_hide = 0
+            }
+
+            // Add configuration for other content types as needed
+        }
+    }
+
+    search {
+        // Configure search settings
+        targetPage = 123  // Replace with your search results page UID
+    }
+}
+```
+
+### Initializing the Index
+
+After configuring the extension, you need to initialize the index:
+
+1. Go to the TYPO3 backend and navigate to "Site Management > Solr".
+2. Select the "Index Queue" tab.
+3. Select the content types you want to index (e.g., pages).
+4. Click on "Initialize selected content types".
+
+Alternatively, you can use the TYPO3 console to initialize and index content:
+
+```bash
+# Initialize the index queue for pages
+./vendor/bin/typo3 solr:updateconnections
+./vendor/bin/typo3 solr:initializeindex pages
+
+# Index all queued items
+./vendor/bin/typo3 solr:indexqueue:indexall
+```
+
+### Adding a Search Form to Your Website
+
+To add a search form to your website, you can use the provided Fluid templates or create your own:
+
+1. Add a plugin content element to a page.
+2. Select "Search: Form" as the plugin type.
+3. Configure the plugin settings as needed.
+
+For the search results, create a new page and add a "Search: Results" plugin to it. Make sure to set this page's UID as the `targetPage` in your TypoScript configuration.
+
+### Advanced Configuration
+
+For more advanced configuration options, refer to the [official EXT:solr documentation](https://docs.typo3.org/p/apache-solr-for-typo3/solr/main/en-us/).
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Connection Issues**: If TYPO3 cannot connect to Solr, verify that:
+
+   - The Solr container is running
+   - The hostname, port, and path are correctly configured
+   - There are no network restrictions between your application and the Solr container
+
+2. **Indexing Issues**: If content is not being indexed properly:
+
+   - Check the TYPO3 system log for errors
+   - Verify that the Solr core exists and is properly configured
+   - Make sure the content you're trying to index meets the criteria defined in your TypoScript configuration
+
+3. **Search Not Working**: If search functionality is not working as expected:
+   - Verify that content has been indexed (check the Solr admin interface)
+   - Ensure the search plugin is properly configured
+   - Check that the search results page is correctly set up
+
+### Solr Admin Interface
+
+The Solr Admin Interface provides valuable tools for troubleshooting:
+
+- **Core Admin**: Manage your Solr cores
+- **Query**: Test search queries directly against your Solr index
+- **Schema Browser**: Explore your schema configuration
+- **Logging**: View Solr logs for error messages
+
+Access the admin interface at `http://solr:8983/solr/`.

--- a/docs/platform/databases/solr.mdx
+++ b/docs/platform/databases/solr.mdx
@@ -343,12 +343,16 @@ TYPO3 CMS can be integrated with Solr using the [extension `solr`](https://exten
 
 2. In the site configuration, go to the "Solr" tab and configure the connection:
 
+   - Scheme and port: `http` and `8983`
    - Host: `solr` (the hostname of your Solr container)
    - Port: `8983` (the default Solr port)
-   - Path: `/solr/` (the default Solr path)
-   - Core: `typo3` (or the name of the core you created)
+   - URL path to Apache solr server: `/`
 
-3. Save the configuration.
+3. Then, per language of your site configuration, configure the name of the Solr core. If your site has multiple languages, you should create one core per language.
+
+   - Corename: `typo3` (or the name of the core you created)
+
+4. Save the configuration.
 
 ### Configuring TypoScript
 

--- a/docs/platform/databases/solr.mdx
+++ b/docs/platform/databases/solr.mdx
@@ -41,7 +41,17 @@ output "solr_url" {
 }
 ```
 
+The `solr_version` input can be any valid Docker tag from the [official `solr` repository](https://hub.docker.com/_/solr). Use `9` to simply use the latest available version of Solr 9, or a more specific tag like `9.9`.
+
 After this, you can access your Solr backend using the URL returned by the Terraform output. Usually, the URL should be `http://solr:8983`. Note that this URL is only accessible from within the hosting environment (e.g., from your application containers or via SSH).
+
+To access your Solr container from your local machine (without connecting it to a domain), you can use the `mw container port-forward` command:
+
+```shellsession
+$ mw container port-forward solr
+```
+
+While this command is running, you should be able to connect to your Solr instance via the URL `http://localhost:8983`.
 
 ### Using the mStudio UI
 

--- a/docs/platform/databases/solr.mdx
+++ b/docs/platform/databases/solr.mdx
@@ -122,6 +122,8 @@ If you prefer using Docker Compose, you can create a `docker-compose.yml` file a
 
 This approach is particularly useful when you need to deploy multiple containers that work together.
 
+## Accessing Solr
+
 ### Accessing your container within your hosting environment
 
 Once the container is running, you can verify the instance is accessible by requesting it via `curl`:

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/solr.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/solr.mdx
@@ -122,6 +122,8 @@ Wenn du Docker Compose bevorzugst, kannst du eine `docker-compose.yml`-Datei ers
 
 Dieser Ansatz ist besonders nützlich, wenn du mehrere Container deployen möchtest, die zusammenarbeiten.
 
+## Auf den Container zugreifen
+
 ### Zugriff auf deinen Container innerhalb deiner Hosting-Umgebung
 
 Sobald der Container läuft, kannst du überprüfen, ob die Instanz verfügbar ist, indem du über `curl` darauf zugreifst:

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/solr.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/solr.mdx
@@ -1,0 +1,231 @@
+---
+title: Solr
+sidebar_position: 110
+description: |
+  Apache Solr ist eine leistungsstarke, quelloffene Suchplattform, die auf Apache Lucene basiert.
+---
+
+import PlanCompatibility from "@site/src/components/PlanCompatibility";
+
+<PlanCompatibility plans={["ps", "ss"]} />
+
+## Was ist Solr?
+
+Apache Solr ist eine hochzuverlässige, skalierbare und fehlertolerante Suchplattform, die verteilte Indizierung, Replikation, lastverteilte Abfragen, automatisches Failover und Recovery, zentralisierte Konfiguration und mehr bietet. Solr treibt die Such- und Navigationsfunktionen vieler der größten Internetseiten der Welt an und ermöglicht leistungsstarke Volltextsuche zusammen mit Trefferhervorhebung, facettierter Suche, Echtzeit-Indizierung, dynamischem Clustering, Datenbankintegration und umfangreicher Dokumentenverarbeitung.
+
+Solr basiert auf Apache Lucene, einer leistungsstarken, funktionsreichen Suchmaschinen-Bibliothek, die in Java geschrieben ist. Solr erweitert Lucene mit HTTP-APIs, was die Nutzung aus praktisch jeder Programmiersprache erleichtert. Die externe Konfiguration von Solr ermöglicht es, die Software an viele Arten von Anwendungen anzupassen, ohne Java-Programmierung zu benötigen, und es verfügt über eine Plugin-Architektur für fortgeschrittenere Anpassungen.
+
+Für Content-Management-Systeme wie TYPO3 bietet Solr leistungsstarke Suchfunktionen, die die Benutzererfahrung erheblich verbessern können, indem sie schnelle und relevante Suchergebnisse über die gesamten Website-Inhalte ermöglichen.
+
+## Eine Solr-Datenbank erstellen
+
+Du kannst eine Solr-Suchmaschine in deiner mittwald Hosting-Umgebung mit [Containern](../../workloads/containers) bereitstellen. Es gibt verschiedene Ansätze, um Solr einzurichten:
+
+### Verwendung von Terraform (Empfohlen)
+
+Der bequemste Weg, eine Solr-Datenbank bereitzustellen, ist die Verwendung von [Terraform](/docs/v2/guides/deployment/terraform) mit unserem [Solr-Modul](https://registry.terraform.io/modules/mittwald/solr/mittwald/latest). Das folgende Beispiel zeigt, wie du dieses Modul in deinem eigenen Terraform-Deployment verwenden kannst:
+
+```hcl
+module "solr" {
+  source = "mittwald/solr/mittwald"
+
+  project_id = var.project_id
+
+  solr_version = "9"
+  solr_core_name = "typo3"
+  solr_heap = "2g"
+}
+
+output "solr_url" {
+  value = module.solr.url
+}
+```
+
+Der `solr_version`-Input kann jeder gültige Docker-Tag aus dem [offiziellen `solr`-Repository](https://hub.docker.com/_/solr) sein. Verwende `9`, um einfach die neueste verfügbare Version von Solr 9 zu nutzen, oder einen spezifischeren Tag wie `9.9`.
+
+Danach kannst du auf dein Solr-Backend über die vom Terraform-Output zurückgegebene URL zugreifen. In der Regel sollte die URL `http://solr:8983` sein. Beachte, dass diese URL nur innerhalb der Hosting-Umgebung zugänglich ist (z.B. von deinen Anwendungs-Containern oder über SSH).
+
+Um von deinem lokalen Rechner auf deinen Solr-Container zuzugreifen (ohne ihn mit einer Domain zu verbinden), kannst du den Befehl `mw container port-forward` verwenden:
+
+```shellsession
+$ mw container port-forward solr
+```
+
+Während dieser Befehl läuft, solltest du dich über die URL `http://localhost:8983` mit deiner Solr-Instanz verbinden können.
+
+### Verwendung der mStudio-Benutzeroberfläche
+
+Alternativ kannst du einen Solr-Container manuell einrichten:
+
+1. Gehe in deinem Projekt in mStudio auf den **Container**-Menüpunkt und erstelle einen neuen Container. Du kannst einen beliebigen Namen wählen.
+
+2. Gib als Image entweder `solr:9` oder eine spezifischere Versionsnummer wie `solr:9.9` ein, je nachdem, wie spezifisch die Version eingeschränkt werden soll. Du kannst den Entrypoint und das Command wie vorgeschlagen beibehalten.
+
+3. (optional, aber empfohlen) Um automatisch einen Solr-Core beim Container-Start zu erstellen, ändere das Command zu `solr-precreate <corename>`. Ersetze dabei `<corename>` durch einen Namen deiner Wahl.
+
+4. Um deine Solr-Daten persistent zu speichern, erstelle ein Volume unter **Volumes** wie folgt:
+
+   - Volume: Neues Volume erstellen
+   - Pfad im Container (Mount Point): `/var/solr`
+
+5. Setze die folgenden Umgebungsvariablen für den Container:
+
+   ```dotenv
+   # nach Bedarf anpassen
+   SOLR_HEAP=512m
+   ```
+
+Die vorgeschlagenen Port-Werte sind im Solr-Kontext Standard und können unverändert übernommen werden. Der Standardport für Solr ist 8983.
+
+### Verwendung der CLI mit `mw container run`
+
+Du kannst auch einen Solr-Container mit der mittwald CLI und dem Befehl `mw container run` bereitstellen:
+
+```bash
+mw container run \
+  --name solr \
+  --env SOLR_HEAP=512m \
+  --volume solr-data:/var/solr \
+  --publish 8983:8983 \
+  solr:9.9 solr-precreate typo3
+```
+
+Dieser Befehl erstellt einen neuen Container namens "solr" mit dem Solr-Image, setzt die notwendigen Umgebungsvariablen und mountet ein Volume für die persistente Datenspeicherung.
+
+### Verwendung der CLI mit `mw stack deploy`
+
+Wenn du Docker Compose bevorzugst, kannst du eine `docker-compose.yml`-Datei erstellen und sie mit dem Befehl `mw stack deploy` bereitstellen:
+
+1. Erstelle eine `docker-compose.yml`-Datei mit folgendem Inhalt:
+
+   ```yaml
+   version: "3"
+   services:
+     solr:
+       image: solr:9.9
+       command: solr-precreate typo3
+       environment:
+         - SOLR_HEAP=512m
+       ports:
+         - "8983:8983"
+       volumes:
+         - solr-data:/var/solr
+   volumes:
+     solr-data:
+   ```
+
+2. Stelle den Stack mit der CLI bereit:
+
+   ```bash
+   mw stack deploy
+   ```
+
+Dieser Ansatz ist besonders nützlich, wenn du mehrere Container deployen möchtest, die zusammenarbeiten.
+
+### Zugriff auf deinen Container innerhalb deiner Hosting-Umgebung
+
+Sobald der Container läuft, kannst du überprüfen, ob die Instanz verfügbar ist, indem du über `curl` darauf zugreifst:
+
+```bash
+curl -X GET "http://solr:8983/solr/admin/info/system"
+```
+
+Du solltest eine Antwort mit Informationen über deine Solr-Instanz erhalten, einschließlich Version, Speichernutzung und Systemeigenschaften.
+
+### Zugriff auf Solr von außerhalb der Hosting-Umgebung {#public-access}
+
+Die Solr-URL (`http://solr:8983`) ist nur innerhalb der Hosting-Umgebung zugänglich. Um von deinem lokalen Rechner oder aus dem Internet auf Solr zuzugreifen, hast du zwei Möglichkeiten:
+
+#### Option 1: Verwendung von Port-Forwarding
+
+Du kannst die mittwald CLI verwenden, um den Solr-Port auf deinen lokalen Rechner weiterzuleiten:
+
+```bash
+mw container port-forward solr 8983:8983
+```
+
+Dieser Befehl erstellt einen sicheren Tunnel zwischen deinem lokalen Rechner und dem Solr-Container. Nach Ausführung dieses Befehls kannst du auf die Solr-Admin-Oberfläche unter `http://localhost:8983/` in deinem lokalen Webbrowser zugreifen.
+
+#### Option 2: Verbinden einer Domain
+
+Für einen dauerhafteren Zugriff kannst du eine Domain mit deinem Solr-Container verbinden:
+
+1. Gehe in mStudio zu **Domains** und füge eine neue Domain oder Subdomain hinzu (z.B. `solr.deinedomain.de`)
+2. Konfiguriere die Domain so, dass sie auf deinen Solr-Container auf Port 8983 zeigt
+3. Sobald die DNS-Änderungen propagiert sind, kannst du auf Solr unter `http://solr.deinedomain.de/` zugreifen
+
+Beachte, dass du bei dieser Option eine ordnungsgemäße Authentifizierung implementieren solltest, um deine Solr-Instanz vor unbefugtem Zugriff zu schützen.
+
+## Einen Solr-Core erstellen
+
+Wenn du keinen Core beim Container-Start erstellt hast (mit dem oben erwähnten `solr-precreate`-Befehl), musst du nach dem Einrichten deines Solr-Containers einen Core erstellen, um deine Suchindizes zu speichern. Das kannst du über die Solr-Admin-UI oder über die Kommandozeile tun:
+
+### Verwendung der Kommandozeile
+
+Der einfachste Weg, einen neuen Solr-Core zu erstellen, ist die Verwendung des `solr create_core`-Befehls und des `mw container exec`-Befehls:
+
+```
+mw container exec <CONTAINER-ID> 'solr create_core -c typo3'
+```
+
+### Verwendung der Solr-Admin-UI
+
+Alternativ kannst du die Solr-Admin-UI verwenden, um einen neuen Core zu erstellen. In diesem Fall musst zu zunächst die entsprechenden Verzeichnisse und Konfigurationsdateien vorbereiten (falls du den `solr create_core`-Befehl verwendest, übernimmt der diese Vorbereitung für dich):
+
+1. Stelle sicher, dass das `instanceDir` unter `/var/solr/data/<corename>` existiert (wobei `<corename>` ein Name deiner Wahl ist)
+2. Innerhalb dieses Instance-Verzeichnisses muss die Datei `conf/solrconfig.xml` existieren. Siehe das [Solr-Handbuch](https://solr.apache.org/guide/solr/latest/configuration-guide/configuring-solrconfig-xml.html), um mehr über diese Konfigurationsdatei zu erfahren.
+
+Nachdem diese Voraussetzungen erfüllt sind, kannst du den neuen Core über die Solr-Admin-UI erstellen:
+
+1. Greife auf die Solr-Admin-UI zu, indem du eine der in [Zugriff auf Solr von außerhalb der Hosting-Umgebung](#public-access) beschriebenen Methoden verwendest
+2. Klicke auf den Menüpunkt "Core Admin"
+3. Klicke auf "Add Core" und fülle die erforderlichen Felder aus:
+
+- name: Der Name deines Cores (z.B. "typo3")
+- instanceDir: Belasse es bei der Standardeinstellung oder gib ein benutzerdefiniertes Verzeichnis an
+- dataDir: Belasse es bei der Standardeinstellung oder gib ein benutzerdefiniertes Verzeichnis an
+- config: Belasse es bei der Standardeinstellung (`solrconfig.xml`)
+- schema: Belasse es bei der Standardeinstellung (`schema.xml`)
+
+## Betrieb
+
+Solr läuft, solange der Container läuft. Wenn du Solr als Suchmaschine für dein CMS verwendest, müssen die Suchindizes von deiner Anwendung befüllt werden. Dafür bieten viele CMS-Plattformen Integrationen an.
+
+Das Volume wird automatisch in das reguläre Backup deines Projekts einbezogen.
+
+## Einrichtung von Solr mit TYPO3 CMS
+
+TYPO3 CMS kann mit Solr über die [Erweiterung `solr`](https://extensions.typo3.org/extension/solr) integriert werden. Dieser Abschnitt bietet eine Schritt-für-Schritt-Anleitung zur Konfiguration von TYPO3 mit deiner Solr-Instanz.
+
+### Installation der Solr-Erweiterung
+
+1. Installiere die Solr-Erweiterung mit Composer:
+
+   ```bash
+   composer require apache-solr-for-typo3/solr
+   ```
+
+   Oder lade sie aus dem [TYPO3 Extension Repository](https://extensions.typo3.org/extension/solr) herunter und installiere sie über den Extension Manager.
+
+2. Nach der Installation gehe zum Extension Manager im TYPO3-Backend und aktiviere die Erweiterung.
+
+### Konfiguration der Solr-Verbindung
+
+1. Erstelle oder bearbeite deine Site-Konfiguration in TYPO3 (Site Management > Sites).
+
+2. In der Site-Konfiguration gehe zum Tab "Solr" und konfiguriere die Verbindung:
+
+   - Host: `solr` (der Hostname deines Solr-Containers)
+   - Port: `8983` (der Standard-Solr-Port)
+   - Path: `/solr/` (der Standard-Solr-Pfad)
+   - Core: `typo3` (oder der Name des Cores, den du erstellt hast)
+
+3. Speichere die Konfiguration.
+
+### Konfiguration von TypoScript
+
+Um schnell zu starten, füge die statischen TypoScript-Templates ein, die von der Erweiterung bereitgestellt werden. Weitere Informationen findest du im [Handbuch der Erweiterung](https://docs.typo3.org/p/apache-solr-for-typo3/solr/13.0/en-us/GettingStarted/ConfigureExtension.html#static-typoscript).
+
+### Initialisierung des Index
+
+Für die erstmalige Initialisierung des Suchindex, siehe das [Erweiterungshandbuch](https://docs.typo3.org/permalink/apache-solr-for-typo3-solr:started-index).

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/solr.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/solr.mdx
@@ -53,6 +53,71 @@ $ mw container port-forward solr
 
 Während dieser Befehl läuft, solltest du dich über die URL `http://localhost:8983` mit deiner Solr-Instanz verbinden können.
 
+#### TYPO3-spezifische Terraform-Einrichtung
+
+Für TYPO3-Projekte bieten wir ein [spezielles Terraform-Modul](https://registry.terraform.io/modules/mittwald/solr/mittwald/latest), das Solr automatisch mit den notwendigen Schema- und Konfigurationsdateien konfiguriert, die für TYPO3 optimiert sind:
+
+```hcl
+module "solr" {
+  source = "mittwald/solr/mittwald"
+
+  project_id = var.project_id
+
+  solr_version = "9"
+  solr_core_name = "typo3"
+  solr_heap = "2g"
+}
+
+module "solr_typo3" {
+  source = "mittwald/solr/mittwald//modules/typo3"
+
+  solr_stack_id = module.solr.stack_id
+  solr_core_name = "typo3"
+  solr_core_language = "english"
+  typo3_solr_version = "13.0.3"
+}
+
+output "solr_url" {
+  value = module.solr.url
+}
+```
+
+Für mehrsprachige TYPO3-Installationen kannst du separate Cores für jede Sprache erstellen:
+
+```hcl
+module "solr" {
+  source = "mittwald/solr/mittwald"
+
+  project_id = var.project_id
+  solr_version = "9"
+  solr_heap = "2g"
+}
+
+module "solr_typo3" {
+  source = "mittwald/solr/mittwald//modules/typo3"
+  for_each = toset(["german", "english"])
+
+  solr_stack_id = module.solr.stack_id
+  solr_core_name = "typo3_${each.key}"
+  solr_core_language = each.key
+  typo3_solr_version = "13.0.3"
+}
+
+output "solr_url" {
+  value = module.solr.url
+}
+```
+
+Das TYPO3-Modul führt automatisch folgende Aktionen aus:
+
+- Lädt und installiert die entsprechende `schema.xml` für die angegebene Sprache
+- Konfiguriert sprachspezifische Analyzer und Filter
+- Richtet die erforderliche TYPO3 Solr Plugin JAR-Datei ein
+- Erstellt core.properties mit der korrekten Konfiguration
+- Installiert zusätzliche Konfigurationsdateien wie protwords, synonyms und stopwords
+
+Die `typo3_solr_version` sollte mit der Version der TYPO3 Solr-Erweiterung übereinstimmen, die du in deinem Projekt verwendest.
+
 ### Verwendung der mStudio-Benutzeroberfläche
 
 Alternativ kannst du einen Solr-Container manuell einrichten:
@@ -73,6 +138,8 @@ Alternativ kannst du einen Solr-Container manuell einrichten:
    ```dotenv
    # nach Bedarf anpassen
    SOLR_HEAP=512m
+   SOLR_CONFIG_LIB_ENABLED=true
+   SOLR_MODULES=scripting,analytics,analysis-extras,langid,clustering,extraction
    ```
 
 Die vorgeschlagenen Port-Werte sind im Solr-Kontext Standard und können unverändert übernommen werden. Der Standardport für Solr ist 8983.
@@ -85,12 +152,14 @@ Du kannst auch einen Solr-Container mit der mittwald CLI und dem Befehl `mw cont
 mw container run \
   --name solr \
   --env SOLR_HEAP=512m \
+  --env SOLR_CONFIG_LIB_ENABLED=true \
+  --env SOLR_MODULES=scripting,analytics,analysis-extras,langid,clustering,extraction \
   --volume solr-data:/var/solr \
   --publish 8983:8983 \
   solr:9.9 solr-precreate typo3
 ```
 
-Dieser Befehl erstellt einen neuen Container namens "solr" mit dem Solr-Image, setzt die notwendigen Umgebungsvariablen und mountet ein Volume für die persistente Datenspeicherung.
+Dieser Befehl erstellt einen neuen Container namens "solr" mit dem Solr-Image, setzt die notwendigen Umgebungsvariablen einschließlich der Aktivierung der lib-Verzeichnis-Konfiguration und zusätzlicher Solr-Module, und mountet ein Volume für die persistente Datenspeicherung.
 
 ### Verwendung der CLI mit `mw stack deploy`
 
@@ -106,6 +175,8 @@ Wenn du Docker Compose bevorzugst, kannst du eine `docker-compose.yml`-Datei ers
        command: solr-precreate typo3
        environment:
          - SOLR_HEAP=512m
+         - SOLR_CONFIG_LIB_ENABLED=true
+         - SOLR_MODULES=scripting,analytics,analysis-extras,langid,clustering,extraction
        ports:
          - "8983:8983"
        volumes:
@@ -166,28 +237,83 @@ Wenn du keinen Core beim Container-Start erstellt hast (mit dem oben erwähnten 
 
 Der einfachste Weg, einen neuen Solr-Core zu erstellen, ist die Verwendung des `solr create_core`-Befehls und des `mw container exec`-Befehls:
 
+```shellsession
+$ mw container exec <CONTAINER-ID> 'solr create_core -c typo3'
 ```
-mw container exec <CONTAINER-ID> 'solr create_core -c typo3'
-```
+
+### Manuelle Initialisierung eines TYPO3 Solr-Cores
+
+Wenn du nicht das Terraform TYPO3-Modul verwendest, kannst du einen Solr-Core manuell mit TYPO3-spezifischen Konfigurationsdateien initialisieren, indem du den Befehl `mw container cp` verwendest. Dieser Befehl funktioniert ähnlich wie `docker cp`:
+
+1. Klone zunächst das Git-Repository der TYPO3 Solr-Erweiterungs, um alle Konfigurationsdateien zu erhalten:
+
+   ```bash
+   # Klone das Git-Repository der TYPO3 Solr-Erweiterung
+   git clone https://github.com/TYPO3-Solr/ext-solr.git /tmp/ext-solr
+
+   # Navigiere zum Konfigurationsverzeichnis
+   cd /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf
+   ```
+
+2. Erstelle die Core-Verzeichnisstruktur im Solr-Container:
+
+   ```bash
+   mw container exec <CONTAINER-ID> 'mkdir -p /var/solr/data/typo3/conf'
+   mw container exec <CONTAINER-ID> 'mkdir -p /var/solr/data/typo3/lib'
+   ```
+
+3. Kopiere die Konfigurationsdateien in den Solr-Container:
+
+   ```bash
+   # Kopiere Hauptkonfigurationsdateien
+   mw container cp -r /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf <CONTAINER-ID>:/var/solr/data/typo3/conf
+
+   # Kopiere sprachspezifische Dateien (Beispiel für Deutsch)
+   mw container cp -r /tmp/ext-solr/Resources/Private/Solr/configsets/ext_solr_13_0_0/conf/german <CONTAINER-ID>:/var/solr/data/typo3/conf/german
+
+   # Kopiere die TYPO3 Solr Plugin JAR-Datei
+   mw container cp /tmp/ext-solr/Resources/Private/Solr/typo3lib/solr-typo3-plugin-6.0.0.jar <CONTAINER-ID>:/var/solr/data/typo3/lib/
+   ```
+
+4. Erstelle die `core.properties`-Datei:
+
+   ```bash
+   mw container exec <CONTAINER-ID> 'echo "name=typo3" > /var/solr/data/typo3/core.properties'
+   mw container exec <CONTAINER-ID> 'echo "config=solrconfig.xml" >> /var/solr/data/typo3/core.properties'
+   mw container exec <CONTAINER-ID> 'echo "schema=german/schema.xml" >> /var/solr/data/typo3/core.properties'
+   ```
+
+5. Lade den Solr-Core neu, um die neue Konfiguration anzuwenden:
+
+   ```bash
+   mw container exec <CONTAINER-ID> 'curl "http://localhost:8983/solr/admin/cores?action=RELOAD&core=typo3"'
+   ```
+
+6. Bereinige die temporären Dateien:
+
+   ```bash
+   rm -rf /tmp/ext-solr
+   ```
+
+Für andere Sprachen ersetze `german` in den Dateipfaden durch das entsprechende Sprachverzeichnis (z.B. `english`, `french`, etc.). Ersetze `<CONTAINER-ID>` durch deine tatsächliche Solr-Container-ID, die du mit `mw container list` finden kannst.
 
 ### Verwendung der Solr-Admin-UI
 
-Alternativ kannst du die Solr-Admin-UI verwenden, um einen neuen Core zu erstellen. In diesem Fall musst zu zunächst die entsprechenden Verzeichnisse und Konfigurationsdateien vorbereiten (falls du den `solr create_core`-Befehl verwendest, übernimmt der diese Vorbereitung für dich):
+Alternativ kannst du die Solr-Admin-UI verwenden, um einen neuen Core zu erstellen. Für einen TYPO3 Solr-Core folge zunächst den Schritten 1-3 aus dem [Abschnitt zur manuellen Initialisierung](#manuelle-initialisierung-eines-typo3-solr-cores) oben, um alle notwendigen TYPO3-Konfigurationsdateien und die Plugin JAR-Datei vorzubereiten.
 
-1. Stelle sicher, dass das `instanceDir` unter `/var/solr/data/<corename>` existiert (wobei `<corename>` ein Name deiner Wahl ist)
-2. Innerhalb dieses Instance-Verzeichnisses muss die Datei `conf/solrconfig.xml` existieren. Siehe das [Solr-Handbuch](https://solr.apache.org/guide/solr/latest/configuration-guide/configuring-solrconfig-xml.html), um mehr über diese Konfigurationsdatei zu erfahren.
-
-Nachdem diese Voraussetzungen erfüllt sind, kannst du den neuen Core über die Solr-Admin-UI erstellen:
+Nachdem die Voraussetzungen erfüllt sind, kannst du den neuen Core über die Solr-Admin-UI erstellen:
 
 1. Greife auf die Solr-Admin-UI zu, indem du eine der in [Zugriff auf Solr von außerhalb der Hosting-Umgebung](#public-access) beschriebenen Methoden verwendest
 2. Klicke auf den Menüpunkt "Core Admin"
 3. Klicke auf "Add Core" und fülle die erforderlichen Felder aus:
 
-- name: Der Name deines Cores (z.B. "typo3")
-- instanceDir: Belasse es bei der Standardeinstellung oder gib ein benutzerdefiniertes Verzeichnis an
-- dataDir: Belasse es bei der Standardeinstellung oder gib ein benutzerdefiniertes Verzeichnis an
-- config: Belasse es bei der Standardeinstellung (`solrconfig.xml`)
-- schema: Belasse es bei der Standardeinstellung (`schema.xml`)
+- **name**: Der Name deines Cores (z.B. "typo3")
+- **instanceDir**: `/var/solr/data/typo3` (oder dein gewähltes Core-Verzeichnis)
+- **dataDir**: Belasse es bei der Standardeinstellung oder gib ein benutzerdefiniertes Verzeichnis an
+- **config**: `solrconfig.xml`
+- **schema**: `schema.xml`
+
+4. Klicke auf "Add Core", um den TYPO3 Solr-Core zu erstellen
 
 ## Betrieb
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/solr.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/solr.mdx
@@ -343,12 +343,16 @@ TYPO3 CMS kann mit Solr über die [Erweiterung `solr`](https://extensions.typo3.
 
 2. In der Site-Konfiguration gehe zum Tab "Solr" und konfiguriere die Verbindung:
 
+   - Scheme und Port: `http` und `8983`
    - Host: `solr` (der Hostname deines Solr-Containers)
    - Port: `8983` (der Standard-Solr-Port)
-   - Path: `/solr/` (der Standard-Solr-Pfad)
-   - Core: `typo3` (oder der Name des Cores, den du erstellt hast)
+   - URL path to Apache solr server: `/`
 
-3. Speichere die Konfiguration.
+3. Konfiguriere dann pro Sprache deiner Site-Konfiguration den Namen des Solr-Cores. Wenn deine Website mehrere Sprachen hat, solltest du einen Core pro Sprache erstellen.
+
+   - Corename: `typo3` (oder der Name des Cores, den du erstellt hast)
+
+4. Speichere die Konfiguration.
 
 ### Konfiguration von TypoScript
 

--- a/src/components/HomepageFeatures/PlatformFeature.tsx
+++ b/src/components/HomepageFeatures/PlatformFeature.tsx
@@ -78,6 +78,7 @@ function PlatformCoreFeatures() {
               <Link to="/docs/v2/platform/databases/opensearch">
                 OpenSearch
               </Link>,
+              <Link to="/docs/v2/platform/databases/solr">Solr</Link>,
             ]}
           />
         </li>
@@ -92,7 +93,9 @@ function PlatformCoreFeatures() {
               </>
             }
             links={[
-              <Link to="/docs/v2/platform/aihosting/introduction">Introduction</Link>,
+              <Link to="/docs/v2/platform/aihosting/introduction">
+                Introduction
+              </Link>,
             ]}
           />
         </li>


### PR DESCRIPTION
This PR adds a documentation on the various ways to deploy Solr

Still to do:

- [x] german translation
- [x] wait for mittwald/cli#1274 to be merged and released (the not-yet-existent `mw container port-forward` command is referenced in this article)
