### PR TITLE
Use backticks to correctly escape variables in newest changelog entry

### DIFF
--- a/changelog/2025-08-22-api-changes-v2.mdx
+++ b/changelog/2025-08-22-api-changes-v2.mdx
@@ -47,7 +47,7 @@ While we generally strive to avoid breaking changes in accordance with our [API 
 
 - New optional request parameters 'order' and 'sort' have been added to the GET operation for listing extensions.
 
-- A new endpoint has been added to retrieve the contract for a given mail address with the GET operation at '/v2/mail-addresses/{mailAddressId}/contract'.
+- A new endpoint has been added to retrieve the contract for a given mail address with the GET operation at `/v2/mail-addresses/{mailAddressId}/contract`.
 
 - The optional property '/items/containerMeta/errorMessage' has been added to the response for status '200' in the GET operation for retrieving LLM licenses, and for status '201' in the POST operation for creating LLM beta licenses. The required property '/items/isBlocked' has also been added to the response for both operations.
 


### PR DESCRIPTION
As seen in the failed action https://github.com/mittwald/developer-portal/actions/runs/17168784561/job/48714531241 the variable was not escaped correctly.