### PR TITLE
docs: add --create-volumes flag to mw container run deployment examples

### DIFF
--- a/docs/guides/apps/collabora.md
+++ b/docs/guides/apps/collabora.md
@@ -86,6 +86,7 @@ mw container run \
   --description "Collabora Online Development Edition" \
   --publish 9980/tcp \
   --env "extra_params=--o:ssl.enable=false --o:ssl.termination=true --o:net.post_allow.host[0]=.+ --o:storage.wopi.host[0]=.+ --o:server_name=code.my-domain.tld" \
+  --create-volumes \
   collabora/code
 ```
 
@@ -97,6 +98,7 @@ mw container run \
   --description "Collabora Online Development Edition" \
   --publish 9980/tcp \
   --env "extra_params=--o:aliasgroup1=https://.*:443 --o:ssl.enable=false --o:ssl.termination=true --o:net.post_allow.host[0]=.+ --o:storage.wopi.host[0]=.+ --o:server_name=code.my-domain.tld" \
+  --create-volumes \
   collabora/code
 ```
 

--- a/docs/guides/apps/directus.md
+++ b/docs/guides/apps/directus.md
@@ -131,6 +131,7 @@ mw container run \
   --volume "uploads:/directus/uploads" \
   --volume "extensions:/directus/extensions" \
   --volume "templates:/directus/templates" \
+  --create-volumes \
   directus/directus
 ```
 

--- a/docs/platform/databases/opensearch.mdx
+++ b/docs/platform/databases/opensearch.mdx
@@ -91,6 +91,7 @@ mw container run \
   --env discovery.type=single-node \
   --env OPENSEARCH_INITIAL_ADMIN_PASSWORD=SuperSecurePassword123 \
   --volume opensearch-data:/usr/share/opensearch/data \
+  --create-volumes \
   opensearchproject/opensearch
 ```
 

--- a/docs/platform/databases/solr.mdx
+++ b/docs/platform/databases/solr.mdx
@@ -156,6 +156,7 @@ mw container run \
   --env SOLR_MODULES=scripting,analytics,analysis-extras,langid,clustering,extraction \
   --volume solr-data:/var/solr \
   --publish 8983:8983 \
+  --create-volumes \
   solr:9.9 solr-precreate typo3
 ```
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/apps/collabora.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/apps/collabora.md
@@ -86,6 +86,7 @@ mw container run \
   --description "Collabora Online Development Edition" \
   --publish 9980/tcp \
   --env "extra_params=--o:ssl.enable=false --o:ssl.termination=true --o:net.post_allow.host[0]=.+ --o:storage.wopi.host[0]=.+ --o:server_name=code.meine-domain.tld" \
+  --create-volumes \
   collabora/code
 ```
 
@@ -97,6 +98,7 @@ mw container run \
   --description "Collabora Online Development Edition" \
   --publish 9980/tcp \
   --env "extra_params=--o:aliasgroup1=https://.*:443 --o:ssl.enable=false --o:ssl.termination=true --o:net.post_allow.host[0]=.+ --o:storage.wopi.host[0]=.+ --o:server_name=code.meine-domain.tld" \
+  --create-volumes \
   collabora/code
 ```
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/apps/directus.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/apps/directus.md
@@ -131,6 +131,7 @@ mw container run \
   --volume "uploads:/directus/uploads" \
   --volume "extensions:/directus/extensions" \
   --volume "templates:/directus/templates" \
+  --create-volumes \
   directus/directus
 ```
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/opensearch.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/opensearch.mdx
@@ -91,6 +91,7 @@ mw container run \
   --env discovery.type=single-node \
   --env OPENSEARCH_INITIAL_ADMIN_PASSWORD=SuperSecurePassword123 \
   --volume opensearch-data:/usr/share/opensearch/data \
+  --create-volumes \
   opensearchproject/opensearch
 ```
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/solr.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/databases/solr.mdx
@@ -156,6 +156,7 @@ mw container run \
   --env SOLR_MODULES=scripting,analytics,analysis-extras,langid,clustering,extraction \
   --volume solr-data:/var/solr \
   --publish 8983:8983 \
+  --create-volumes \
   solr:9.9 solr-precreate typo3
 ```
 


### PR DESCRIPTION
## Summary
- Add `--create-volumes` flag to all `mw container run` command examples used for deploying applications
- Ensures volumes are automatically created during deployment
- Updated both English and German documentation

## Files Changed
- Directus deployment examples (English + German)
- Collabora deployment examples (English + German)  
- Solr deployment examples (English + German)
- OpenSearch deployment examples (English + German)

🤖 Generated with [Claude Code](https://claude.ai/code)