### PR TITLE
Add Varnish caching proxy deployment guide

### DIFF
--- a/docs/platform/workloads/varnish.mdx
+++ b/docs/platform/workloads/varnish.mdx
@@ -444,9 +444,7 @@ The [mittwald TYPO3 Varnish extension](https://github.com/mittwald/typo3-varnish
 - **Streaming** for media files
 - **Retry logic** for server errors (5xx responses)
 
-**Key integration point**: Install the [mittwald TYPO3 Varnish extension](https://github.com/mittwald/typo3-varnishcache) in your TYPO3 installation. It automatically sends BAN requests to Varnish whenever content is updated in the backend, keeping your cache in sync with your content.
-
-**Frontend user sessions**: The example VCL checks for the `fe_typo_user` cookie. Pages for logged-in frontend users automatically bypass the cache.
+Install the [mittwald TYPO3 Varnish extension](https://github.com/mittwald/typo3-varnishcache) in your TYPO3 installation. It automatically sends BAN requests to Varnish whenever a TYPO3 page cache is flushed (either manually, or by editing a page), keeping your cache in sync with your content.
 
 :::info
 
@@ -466,6 +464,18 @@ Shopware 5 uses a custom cache invalidation mechanism. Use the [official Shopwar
 - **ESI support**: Enable with `Surrogate-Capability` and `Surrogate-Control` headers
 - **Custom headers**: `X-Shopware-Cache-Id` for identifying cacheable content
 
+When using Varnish with Shopware 5, make sure to follow the [official configuration guide](https://developers.shopware.com/sysadmins-guide/varnish-setup/#shopware-configuration) closely. Especially, remember to disable the built-in HTTP cache in Shopware 5 to avoid conflicts with Varnish, and set the `trustedProxies` configuration:
+
+```injectablephp
+'trustedProxies' => ['100.64.0.0/10'],
+```
+
+:::note Cloud-internal IP addresses
+
+mittwald's cloud platform assigns container addresses dynamically from the `100.64.0.0/10` range. Therefore, when configuring trusted proxies in Shopware 5, use this CIDR block to ensure proper handling of client IP addresses.
+
+:::
+
 **mittwald-specific addition**: In your `vcl_backend_fetch` subroutine, add the Host header rewriting:
 
 ```vcl
@@ -479,8 +489,6 @@ sub vcl_backend_fetch {
 ```
 
 **Cache warming**: Shopware 5 supports cache warming. Configure your shop to send warm-up requests to the internal backend hostname if needed.
-
-**Reference**: [Shopware 5 Varnish Setup Guide](https://developers.shopware.com/sysadmins-guide/varnish-setup/)
 
 ### Shopware 6 Configuration
 
@@ -502,7 +510,7 @@ shopware:
 
 2. Set environment variable: `SHOPWARE_HTTP_CACHE_ENABLED=1`
 
-**Key VCL requirements from [Shopware 6 documentation](https://developer.shopware.com/docs/guides/hosting/infrastructure/reverse-http-cache.html):**
+Key VCL requirements from [Shopware 6 documentation](https://developer.shopware.com/docs/guides/hosting/infrastructure/reverse-http-cache.html) include:
 
 - **XKey module**: Use `xkey.purge()` for hard purge or `xkey.softpurge()` for soft purge
 - **Surrogate keys**: Shopware sends `Xkey` headers for targeted invalidation
@@ -531,14 +539,10 @@ sub vcl_backend_fetch {
 }
 ```
 
-**Cache invalidation**: Use Shopware's built-in cache clearing:
+To invalidate the cache, use Shopware's built-in cache clearing:
 
 - `bin/console cache:clear:http` — Clears reverse proxy cache only (recommended)
 - Shopware automatically invalidates cache when content changes in the admin
-
-**Soft purge option**: Modify the VCL to use `xkey.softpurge()` instead of `xkey.purge()` to serve stale content while refreshing in the background.
-
-**Reference**: [Shopware 6 Reverse HTTP Cache Guide](https://developer.shopware.com/docs/guides/hosting/infrastructure/reverse-http-cache.html)
 
 :::tip Varnish Version
 
@@ -550,7 +554,19 @@ Make sure to use Varnish 6.0 or later for Shopware 6. The `varnish:8` image used
 
 ### Check if caching is working
 
-The VCL configuration adds an `x-cache` header to responses:
+Most VCL configurations add an `x-cache` header to responses using a `vcl_deliver` rule that should look like this:
+
+```vcl
+sub vcl_deliver {
+    if (obj.hits > 0) {
+        set resp.http.x-cache = "HIT";
+    } else {
+        set resp.http.x-cache = "MISS";
+    }
+}
+```
+
+When this is in place, you can check the response headers to see if content is being served from cache:
 
 ```shellsession
 $ curl -I https://www.example.com

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/workloads/varnish.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/workloads/varnish.mdx
@@ -444,9 +444,7 @@ Die [mittwald TYPO3 Varnish Extension](https://github.com/mittwald/typo3-varnish
 - **Streaming** für Mediendateien
 - **Retry-Logik** für Serverfehler (5xx-Antworten)
 
-**Wichtiger Integrationspunkt**: Installiere die [mittwald TYPO3 Varnish Extension](https://github.com/mittwald/typo3-varnishcache) in deiner TYPO3-Installation. Sie sendet automatisch BAN-Anfragen an Varnish, wenn Inhalte im Backend aktualisiert werden, und hält deinen Cache mit deinen Inhalten synchron.
-
-**Frontend-Benutzersitzungen**: Die Beispiel-VCL prüft auf das `fe_typo_user`-Cookie. Seiten für angemeldete Frontend-Benutzer umgehen automatisch den Cache.
+Installiere die [mittwald TYPO3 Varnish Extension](https://github.com/mittwald/typo3-varnishcache) in deiner TYPO3-Installation. Sie sendet automatisch BAN-Anfragen an Varnish, wenn ein TYPO3-Seiten-Cache geleert wird (entweder manuell oder durch Bearbeiten einer Seite), und hält deinen Cache mit deinen Inhalten synchron.
 
 :::info
 
@@ -466,6 +464,18 @@ Shopware 5 verwendet einen benutzerdefinierten Cache-Invalidierungsmechanismus. 
 - **ESI-Unterstützung**: Aktivieren mit `Surrogate-Capability`- und `Surrogate-Control`-Headern
 - **Benutzerdefinierte Header**: `X-Shopware-Cache-Id` zur Identifizierung von cachebaren Inhalten
 
+Wenn du Varnish mit Shopware 5 verwendest, stelle sicher, dass du der [offiziellen Konfigurationsanleitung](https://developers.shopware.com/sysadmins-guide/varnish-setup/#shopware-configuration) genau folgst. Insbesondere solltest du daran denken, den integrierten HTTP-Cache in Shopware 5 zu deaktivieren, um Konflikte mit Varnish zu vermeiden, und die `trustedProxies`-Konfiguration zu setzen:
+
+```injectablephp
+'trustedProxies' => ['100.64.0.0/10'],
+```
+
+:::note Cloud-interne IP-Adressen
+
+Die mittwald Cloud-Plattform weist Container-Adressen dynamisch aus dem Bereich `100.64.0.0/10` zu. Verwende daher beim Konfigurieren vertrauenswürdiger Proxies in Shopware 5 diesen CIDR-Block, um eine korrekte Behandlung der Client-IP-Adressen sicherzustellen.
+
+:::
+
 **mittwald-spezifische Ergänzung**: Füge in deiner `vcl_backend_fetch`-Subroutine die Host-Header-Umschreibung hinzu:
 
 ```vcl
@@ -479,8 +489,6 @@ sub vcl_backend_fetch {
 ```
 
 **Cache-Warming**: Shopware 5 unterstützt Cache-Warming. Konfiguriere deinen Shop so, dass er bei Bedarf Warm-up-Anfragen an den internen Backend-Hostnamen sendet.
-
-**Referenz**: [Shopware 5 Varnish-Setup-Anleitung](https://developers.shopware.com/sysadmins-guide/varnish-setup/)
 
 ### Shopware 6-Konfiguration
 
@@ -502,7 +510,7 @@ shopware:
 
 2. Setze die Umgebungsvariable: `SHOPWARE_HTTP_CACHE_ENABLED=1`
 
-**Wichtige VCL-Anforderungen aus der [Shopware 6-Dokumentation](https://developer.shopware.com/docs/guides/hosting/infrastructure/reverse-http-cache.html):**
+Wichtige VCL-Anforderungen aus der [Shopware 6-Dokumentation](https://developer.shopware.com/docs/guides/hosting/infrastructure/reverse-http-cache.html) umfassen:
 
 - **XKey-Modul**: Verwende `xkey.purge()` für Hard-Purge oder `xkey.softpurge()` für Soft-Purge
 - **Surrogate-Keys**: Shopware sendet `Xkey`-Header für gezielte Invalidierung
@@ -531,14 +539,10 @@ sub vcl_backend_fetch {
 }
 ```
 
-**Cache-Invalidierung**: Verwende die integrierte Cache-Löschung von Shopware:
+Zum Invalidieren des Caches verwende die integrierte Cache-Löschung von Shopware:
 
 - `bin/console cache:clear:http` — Löscht nur den Reverse-Proxy-Cache (empfohlen)
 - Shopware invalidiert den Cache automatisch, wenn Inhalte im Admin geändert werden
-
-**Soft-Purge-Option**: Ändere die VCL so, dass `xkey.softpurge()` anstelle von `xkey.purge()` verwendet wird, um veraltete Inhalte zu liefern, während im Hintergrund aktualisiert wird.
-
-**Referenz**: [Shopware 6 Reverse-HTTP-Cache-Anleitung](https://developer.shopware.com/docs/guides/hosting/infrastructure/reverse-http-cache.html)
 
 :::tip Varnish-Version
 
@@ -550,7 +554,19 @@ Stelle sicher, dass du für Shopware 6 Varnish 6.0 oder höher verwendest. Das i
 
 ### Prüfen, ob Caching funktioniert
 
-Die VCL-Konfiguration fügt den Antworten einen `x-cache`-Header hinzu:
+Die meisten VCL-Konfigurationen fügen den Antworten einen `x-cache`-Header hinzu, indem sie eine `vcl_deliver`-Regel verwenden, die so aussehen sollte:
+
+```vcl
+sub vcl_deliver {
+    if (obj.hits > 0) {
+        set resp.http.x-cache = "HIT";
+    } else {
+        set resp.http.x-cache = "MISS";
+    }
+}
+```
+
+Wenn dies vorhanden ist, kannst du die Antwort-Header überprüfen, um zu sehen, ob Inhalte aus dem Cache geliefert werden:
 
 ```shellsession
 $ curl -I https://www.example.com
@@ -569,7 +585,7 @@ Dieser Befehl gibt die Standardausgabe von Varnish selbst aus:
 $ mw container logs <container-id>
 ```
 
-Um die tatsächlichen (pro-Anfrage) Logs zu erhalten, verwenden Sie `varnishlog`:
+Um die tatsächlichen (pro-Anfrage) Logs zu erhalten, verwende `varnishlog`:
 
 ```shellsession
 $ mw container exec <container-id> -- varnishlog
@@ -577,7 +593,7 @@ $ mw container exec <container-id> -- varnishlog
 
 ### Varnish-Statistiken
 
-Verbinden Sie sich mit dem Container und verwenden Sie `varnishstat`:
+Verbinde dich mit dem Container und verwende `varnishstat`:
 
 ```shellsession
 $ mw container exec <container-id> -- varnishstat


### PR DESCRIPTION
## Summary

This PR adds a comprehensive guide for deploying Varnish Cache as a caching reverse proxy in front of TYPO3 and Shopware applications on the mittwald platform.

## Changes

- **New documentation**: `docs/platform/workloads/varnish.mdx`
- **Deployment methods**: Terraform, CLI, and mStudio UI instructions
- **TYPO3 integration**: Configuration examples with proper `user_inputs` and `trustedHostsPattern` setup
- **VCL configuration**: Examples based on the mittwald TYPO3 Varnish extension with platform-specific Host header rewriting
- **Monitoring & debugging**: Guide for checking cache performance, viewing logs, and troubleshooting common issues

## Key Features

- Architecture overview explaining the Host header rewriting requirement
- Complete Terraform example with proper TYPO3 app configuration
- VCL examples referencing the upstream mittwald/typo3-varnishcache repository
- Documentation on TYPO3's and Shopware's `reverseProxy` configuration
- Performance considerations and cache hit ratio monitoring

## Related

- Based on example VCL from https://github.com/mittwald/typo3-varnishcache and the official Shopware documentations for Shopware 5 and 6
- References container deployment docs at `containers.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)