### PR TITLE
Add info for truncating embedding dimensions with Qwen3-Embedding-8B

### DIFF
--- a/docs/platform/aihosting/30-models/30-qwen3-embedding-8b.mdx
+++ b/docs/platform/aihosting/30-models/30-qwen3-embedding-8b.mdx
@@ -23,6 +23,55 @@ Query: {query}
 
 Here, `{query}` should express the individual search query in *one* sentence, and `{task_description}` should describe the task, for example:
 
+## Truncating and normalizing embeddings
+
+If you require smaller vector dimensions, you can truncate the embedding vector to the desired dimensions and normalize it afterwards.
+This is possible because the model was trained using [Matryoshka Representation Learning](https://arxiv.org/abs/2205.13147).
+To normalize the vector use code like this:
+
+Install the required libraries and set up the token first:
+
+```sh
+pip install python-dotenv openai langchain-openai
+echo 'OPENAI_API_KEY="sk-…"' > .env
+```
+
+Use the model and truncate to 256 dimensions + normalize the embedding:
+
+```python
+from openai import OpenAI
+import numpy as np
+from dotenv import load_dotenv
+
+# Load .env file
+load_dotenv()
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1"
+)
+
+def normalize_l2(x):
+    x = np.array(x)
+    if x.ndim == 1:
+        norm = np.linalg.norm(x)
+        if norm == 0:
+            return x
+        return x / norm
+    else:
+        norm = np.linalg.norm(x, 2, axis=1, keepdims=True)
+        return np.where(norm == 0, x, x / norm)
+
+
+response = client.embeddings.create(
+    model="Qwen3-Embedding-8B", input="Testing 123", encoding_format="float"
+)
+
+cut_dim = response.data[0].embedding[:256]
+norm_dim = normalize_l2(cut_dim)
+
+print(norm_dim)
+```
+
 ## Terms of use and licensing
 
 The [general terms of use](../../access-and-usage/terms-of-use/) apply. The model is provided by Alibaba under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.html), and reuse of the generated content is not subject to any additional restrictions.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/30-qwen3-embedding-8b.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/30-qwen3-embedding-8b.mdx
@@ -28,6 +28,56 @@ task = 'Given a web search query, retrieve relevant passages that answer the que
 query = 'Explain gravity'
 ```
 
+## Embeddings kürzen und normalisieren
+
+Wenn du kleinere Vektordimensionen benötigst, kannst du den Embedding-Vektor einfach auf die gewünschte Länge kürzen und anschließend normalisieren.
+Das ist möglich, weil das Modell mit [Matryoshka Representation Learning](https://arxiv.org/abs/2205.13147) trainiert wurde.
+
+Zum Normalisieren des Vektors kannst du zum Beispiel folgenden Code verwenden:
+
+Installiere zunächst die benötigten Bibliotheken und lege den Token an:
+
+```sh
+pip install python-dotenv openai langchain-openai
+echo 'OPENAI_API_KEY="sk-…"' > .env
+```
+
+Nutze dann das Modell und kürze auf 256 Dimensionen + normalisiere das Embedding:
+
+```python
+from openai import OpenAI
+import numpy as np
+from dotenv import load_dotenv
+
+# Load .env file
+load_dotenv()
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1"
+)
+
+def normalize_l2(x):
+    x = np.array(x)
+    if x.ndim == 1:
+        norm = np.linalg.norm(x)
+        if norm == 0:
+            return x
+        return x / norm
+    else:
+        norm = np.linalg.norm(x, 2, axis=1, keepdims=True)
+        return np.where(norm == 0, x, x / norm)
+
+
+response = client.embeddings.create(
+    model="Qwen3-Embedding-8B", input="Testing 123", encoding_format="float"
+)
+
+cut_dim = response.data[0].embedding[:256]
+norm_dim = normalize_l2(cut_dim)
+
+print(norm_dim)
+```
+
 ## Nutzungsbedingungen und Lizenzhinweise
 
 Es gelten die [allgemeinen Nutzungsbedinungen](../../access-and-usage/terms-of-use/). Das Modell wird von Alibaba unter der [Apache 2.0-Lizenz](https://www.apache.org/licenses/LICENSE-2.0.html) angeboten, eine Weiternutzung der generierten Inhalte unterliegt keiner zusätzlichen Restriktion.


### PR DESCRIPTION
As the `Qwen3-Embedding-8B` model was trained using MRL, even if the mittwald API does not allow setting the `dimensions` parameter, the user can truncate the embedding vector to their desired length.

Sources:
- https://platform.openai.com/docs/guides/embeddings/embedding-models#expander-11 -> "Reducing embedding dimensions"
- https://huggingface.co/Qwen/Qwen3-Embedding-8B -> "MRL Support"