### PR TITLE
docs: consolidate TYPO3 reverse proxy settings in varnish guide

### DIFF
--- a/docs/platform/workloads/varnish.mdx
+++ b/docs/platform/workloads/varnish.mdx
@@ -143,17 +143,6 @@ resource "mittwald_virtualhost" "example_backend" {
 }
 ```
 
-:::info TYPO3 Reverse Proxy settings
-
-Since TYPO3 will be accessed via the Varnish proxy, you will need to configure your TYPO3 instance to be aware of the reverse proxy; for this, set the `[SYS][reverseProxyIP]` and `[SYS][reverseProxyHeaderMultiValue]` values in `config/system/settings.php` or `config/system/additional.php`:
-
-```php
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'] = '*';
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue'] = 'first';
-```
-
-:::
-
 #### Step 2: Create the VCL configuration file
 
 Create a file named `default.vcl` in your Terraform working directory. Use the official VCL configuration for your application (see [Application-Specific VCL Configurations](#application-specific-vcl-configurations) below) with one critical addition for the mittwald platform:
@@ -368,17 +357,6 @@ $ mw domain virtualhost create \
   --path-to-container /:<container-id>:80/tcp
 ```
 
-:::info TYPO3 Reverse Proxy settings
-
-Since TYPO3 will be accessed via the Varnish proxy, you will need to configure your TYPO3 instance to be aware of the reverse proxy; for this, set the `[SYS][reverseProxyIP]` and `[SYS][reverseProxyHeaderMultiValue]` values in `config/system/settings.php` or `config/system/additional.php`:
-
-```php
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'] = '*';
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue'] = 'first';
-```
-
-:::
-
 ### Using the mStudio UI
 
 #### Step 1: Create the backend application
@@ -418,17 +396,6 @@ Upload it to `/files/varnish/default.vcl` in your app using the file manager or 
 3. Enter your public domain (e.g., `www.example.com`)
 4. Point it to the Varnish container on port 80
 
-:::info TYPO3 Reverse Proxy settings
-
-Since TYPO3 will be accessed via the Varnish proxy, you will need to configure your TYPO3 instance to be aware of the reverse proxy; for this, set the `[SYS][reverseProxyIP]` and `[SYS][reverseProxyHeaderMultiValue]` values in `config/system/settings.php` or `config/system/additional.php`:
-
-```php
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'] = '*';
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue'] = 'first';
-```
-
-:::
-
 ## Application-Specific VCL Configurations
 
 The VCL examples in the deployment section above show the basic structure with the critical Host header rewriting required for the mittwald platform. This section provides application-specific guidance for TYPO3, Shopware 5, and Shopware 6.
@@ -451,6 +418,13 @@ Install the [mittwald TYPO3 Varnish extension](https://github.com/mittwald/typo3
 When using the mittwald TYPO3 extension's VCL example, remember to add the Host header rewriting in `vcl_backend_fetch` as shown in the deployment examples above.
 
 :::
+
+Since TYPO3 will be accessed via the Varnish proxy, you will need to configure your TYPO3 instance to be aware of the reverse proxy; for this, set the `[SYS][reverseProxyIP]` and `[SYS][reverseProxyHeaderMultiValue]` values in `config/system/settings.php` or `config/system/additional.php`:
+
+```php
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'] = '*';
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue'] = 'first';
+```
 
 ### Shopware 5 Configuration
 
@@ -494,19 +468,19 @@ sub vcl_backend_fetch {
 
 Shopware 6 requires **Varnish 6.0 or later with the XKey module** for surrogate key-based cache invalidation.
 
-**Shopware 6 configuration requirements:**
+To configure Shopware 6 for reverse proxy caching, follow these steps:
 
 1. Enable reverse proxy in your Shopware configuration (`config/packages/shopware.yaml`):
 
-```yaml
-shopware:
-  http_cache:
-    reverse_proxy:
-      enabled: true
-      use_varnish_xkey: true
-      hosts: ["http://varnish"]
-      max_parallel_invalidations: 3
-```
+   ```yaml
+   shopware:
+     http_cache:
+       reverse_proxy:
+         enabled: true
+         use_varnish_xkey: true
+         hosts: ["http://varnish"]
+         max_parallel_invalidations: 3
+   ```
 
 2. Set environment variable: `SHOPWARE_HTTP_CACHE_ENABLED=1`
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/workloads/varnish.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/workloads/varnish.mdx
@@ -143,17 +143,6 @@ resource "mittwald_virtualhost" "example_backend" {
 }
 ```
 
-:::info TYPO3 Reverse-Proxy-Einstellungen
-
-Da auf TYPO3 über den Varnish-Proxy zugegriffen wird, musst du deine TYPO3-Instanz so konfigurieren, dass sie den Reverse-Proxy erkennt. Setze dazu die Werte `[SYS][reverseProxyIP]` und `[SYS][reverseProxyHeaderMultiValue]` in `config/system/settings.php` oder `config/system/additional.php`:
-
-```php
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'] = '*';
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue'] = 'first';
-```
-
-:::
-
 #### Schritt 2: Erstelle die VCL-Konfigurationsdatei
 
 Erstelle eine Datei mit dem Namen `default.vcl` in deinem Terraform-Arbeitsverzeichnis. Verwende die offizielle VCL-Konfiguration für deine Anwendung (siehe [Anwendungsspezifische VCL-Konfigurationen](#anwendungsspezifische-vcl-konfigurationen) unten) mit einer wichtigen Ergänzung für die mittwald-Plattform:
@@ -368,17 +357,6 @@ $ mw domain virtualhost create \
   --path-to-container /:<container-id>:80/tcp
 ```
 
-:::info TYPO3 Reverse-Proxy-Einstellungen
-
-Da auf TYPO3 über den Varnish-Proxy zugegriffen wird, musst du deine TYPO3-Instanz so konfigurieren, dass sie den Reverse-Proxy erkennt. Setze dazu die Werte `[SYS][reverseProxyIP]` und `[SYS][reverseProxyHeaderMultiValue]` in `config/system/settings.php` oder `config/system/additional.php`:
-
-```php
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'] = '*';
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue'] = 'first';
-```
-
-:::
-
 ### Mit der mStudio-Oberfläche
 
 #### Schritt 1: Backend-Anwendung erstellen
@@ -418,17 +396,6 @@ Lade sie nach `/files/varnish/default.vcl` in deiner App über den Dateimanager 
 3. Gib deine öffentliche Domain ein (z.B. `www.example.com`)
 4. Verweise auf den Varnish-Container auf Port 80
 
-:::info TYPO3 Reverse-Proxy-Einstellungen
-
-Da auf TYPO3 über den Varnish-Proxy zugegriffen wird, musst du deine TYPO3-Instanz so konfigurieren, dass sie den Reverse-Proxy erkennt. Setze dazu die Werte `[SYS][reverseProxyIP]` und `[SYS][reverseProxyHeaderMultiValue]` in `config/system/settings.php` oder `config/system/additional.php`:
-
-```php
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'] = '*';
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue'] = 'first';
-```
-
-:::
-
 ## Anwendungsspezifische VCL-Konfigurationen
 
 Die VCL-Beispiele im Deployment-Abschnitt oben zeigen die Grundstruktur mit der für die mittwald-Plattform erforderlichen Host-Header-Umschreibung. Dieser Abschnitt bietet anwendungsspezifische Anleitungen für TYPO3, Shopware 5 und Shopware 6.
@@ -451,6 +418,13 @@ Installiere die [mittwald TYPO3 Varnish Extension](https://github.com/mittwald/t
 Wenn du das VCL-Beispiel der mittwald TYPO3 Extension verwendest, denke daran, die Host-Header-Umschreibung in `vcl_backend_fetch` hinzuzufügen, wie in den Deployment-Beispielen oben gezeigt.
 
 :::
+
+Da auf TYPO3 über den Varnish-Proxy zugegriffen wird, musst du deine TYPO3-Instanz so konfigurieren, dass sie den Reverse-Proxy erkennt. Setze dazu die Werte `[SYS][reverseProxyIP]` und `[SYS][reverseProxyHeaderMultiValue]` in `config/system/settings.php` oder `config/system/additional.php`:
+
+```php
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'] = '*';
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue'] = 'first';
+```
 
 ### Shopware 5-Konfiguration
 
@@ -494,19 +468,19 @@ sub vcl_backend_fetch {
 
 Shopware 6 erfordert **Varnish 6.0 oder höher mit dem XKey-Modul** für Surrogate-Key-basierte Cache-Invalidierung.
 
-**Shopware 6-Konfigurationsanforderungen:**
+Um Shopware 6 für Reverse-Proxy-Caching zu konfigurieren, folge diesen Schritten:
 
 1. Aktiviere Reverse-Proxy in deiner Shopware-Konfiguration (`config/packages/shopware.yaml`):
 
-```yaml
-shopware:
-  http_cache:
-    reverse_proxy:
-      enabled: true
-      use_varnish_xkey: true
-      hosts: ["http://varnish"]
-      max_parallel_invalidations: 3
-```
+   ```yaml
+   shopware:
+     http_cache:
+       reverse_proxy:
+         enabled: true
+         use_varnish_xkey: true
+         hosts: ["http://varnish"]
+         max_parallel_invalidations: 3
+   ```
 
 2. Setze die Umgebungsvariable: `SHOPWARE_HTTP_CACHE_ENABLED=1`
 


### PR DESCRIPTION
## Summary

This PR consolidates duplicate TYPO3 reverse proxy configuration instructions in the Varnish documentation guide, improving maintainability and reducing redundancy.

## Changes

- Removed three duplicate TYPO3 reverse proxy info boxes from:
  - Terraform deployment section (after Step 1)
  - CLI deployment section (after Step 5)
  - mStudio UI deployment section (after Step 5)
- Consolidated TYPO3 reverse proxy settings into the application-specific "TYPO3 Configuration" section
- Improved Shopware 6 section formatting with better YAML indentation
- Applied changes to both English and German documentation

## Impact

- Net reduction of 52 lines by removing duplicate content
- Configuration instructions now appear once in a logical location
- Easier to maintain and update TYPO3-specific settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)