### PR TITLE
Add aria-label to OperationList, silence warnings when rendering page

### DIFF
--- a/src/components/openapi/OperationDocCardList.tsx
+++ b/src/components/openapi/OperationDocCardList.tsx
@@ -44,7 +44,7 @@ export default function OperationDocCardList(p: Props) {
     }));
 
   return (
-    <OperationList.List batchSize={100}>
+    <OperationList.List batchSize={100} aria-label={p.tag}>
       <OperationList.StaticData data={operations} />
       <OperationList.Search autoSubmit />
       <OperationList.Sorting property="method" name="Method" />


### PR DESCRIPTION
Now the build run is a lot more quiet and does not yell about mysterious missing props anymore :+1: 