### PR TITLE
Dokumentation für Modellwechsel (Livegang 14.01.) anpassen

### DIFF
--- a/src/components/openapi/OperationDocCardList.tsx
+++ b/src/components/openapi/OperationDocCardList.tsx
@@ -44,7 +44,7 @@ export default function OperationDocCardList(p: Props) {
     }));
 
   return (
-    <OperationList.List batchSize={100}>
+    <OperationList.List batchSize={100} aria-label={p.tag}>
       <OperationList.StaticData data={operations} />
       <OperationList.Search autoSubmit />
       <OperationList.Sorting property="method" name="Method" />


### PR DESCRIPTION
Ich habe die Dokumentation für die neuen Modelle angepasst:

- alte Modelle gelöscht
- neue Modelle ergänzt
- Beispiele ergänzt und Modellparameter angepasst
- n8n MCP, Opensearch MCP, Apache Solr MCP, Directus MCP, Postgres MCP Guides ergänzt, da dies unsere meist genutzten Container sind
- CLI Coding Guide ergänzt
- IDE Coding Guide ergänzt