### PR TITLE
docs: improve MySQL database API documentation

### DIFF
--- a/generator/overlays/v2/database-create-mysql-database/description.mdx
+++ b/generator/overlays/v2/database-create-mysql-database/description.mdx
@@ -1,0 +1,9 @@
+This operation creates a MySQL database and an associated MySQL user.
+
+:::note
+
+This operation is asynchronous. Even after a successful response, you will still need to wait until the database is successfully provisioned. Currently, the recommended way for that is to poll the <OperationLink operation="database-get-mysql-database" /> endpoint and observe the `mainUser.status` field in the response.
+
+Both the database itself (`.status`) and the linked user (`.mainUser.status`) must have a status of ready to ensure a successful connection.
+
+:::

--- a/generator/overlays/v2/database-get-mysql-database/description.mdx
+++ b/generator/overlays/v2/database-get-mysql-database/description.mdx
@@ -1,0 +1,9 @@
+Returns a MySQL database and its current status.
+
+:::note
+
+To test whether you can establish a connection to the database, also observe the `.mainUser.status` field.
+
+Both the database itself (`.status`) and the linked user (`.mainUser.status`) must have a status of ready to ensure a successful connection.
+
+:::

--- a/generator/overlays/v2/overlay.yaml
+++ b/generator/overlays/v2/overlay.yaml
@@ -2,46 +2,53 @@ overlay: 1.0.0
 info:
   title: Augment documentation
 actions:
-  - target: $.components.schemas['de.mittwald.v1.database.CreateMySqlDatabase'].properties
-    update:
-      version:
-        description: >
-          The MySQL version number for this database, in `<major>.<minor>` format. Use the
-          `GET /v2/mysql-version` endpoint to query available versions.
-        example: "8.0"
-  - target: $.components.schemas['de.mittwald.v1.database.CreateMySqlUser'].properties
-    update:
-      accessIpMask:
-        description: An IP range (in CIDR notation) for which access should be allowed.
-        example: "203.0.113.123/32"
-      externalAccess:
-        description: >
-          Describes if users should be able to connection to this database from external
-          sources. Defaults to `false` when not set.
-      password:
-        description: >
-          The password for the database user. This password has to comply with the password
-          policy specified for MySQL users in the [password security specification](/docs/v2/api/security/passwords#mysql).
+  # Hide the accessIpMask field from all MySQL user schemas, because it is
+  # currently only halfway supported anyway.
   - target: $.components.schemas['de.mittwald.v1.database.CreateMySqlUserWithDatabase'].properties.accessIpMask
     remove: true
-  - target: $.components.schemas['de.mittwald.v1.database.CreateMySqlUserWithDatabase'].properties
-    update:
-      externalAccess:
-        description: >
-          Describes if users should be able to connection to this database from external
-          sources. Defaults to `false` when not set.
-      password:
-        description: >
-          The password for the database user. This password has to comply with the password
-          policy specified for MySQL users in the [password security specification](/docs/v2/api/security/passwords#mysql).
+  - target: $.components.schemas['de.mittwald.v1.database.CreateMySqlUser'].properties.accessIpMask
+    remove: true
+  - target: $.components.schemas['de.mittwald.v1.database.MySqlUser'].properties.accessIpMask
+    remove: true
+
+  # Override the description of the characterSettings field in all MySQL database
+  # schemas to include links to the MySQL documentation and the API endpoint for
+  # querying available character sets and collations.
+  # These links are developer portal-specific, so it doesn't make sense to include
+  # them in the schema itself.
   - target: $.components.schemas['de.mittwald.v1.database.characterSettings'].properties
     update:
       characterSet:
-        description: A valid MySQL character set
-        example: utf8mb4
+        description: |
+          A valid MySQL character set. Refer to the [MySQL manual](https://dev.mysql.com/doc/refman/8.4/en/charset-mysql.html)
+          for more information and available character sets.
+          
+          You can also use the [`GET /v2/mysql-charsets` endpoint](/docs/v2/reference/database/database-list-mysql-charsets/)
+          to query available character sets for your MySQL database.
       collation:
-        description: A valid MySQL collation
-        example: utf8mb4_general_ci
+        description: |
+          A valid MySQL collation. Refer to the [MySQL manual](https://dev.mysql.com/doc/refman/8.4/en/charset-mysql.html)
+          for more information and available collations.
+          
+          You can also use the [`GET /v2/mysql-charsets` endpoint](/docs/v2/reference/database/database-list-mysql-charsets/)
+          to query available character sets (and collations of these character sets) for your MySQL database.
+
+  # Override the description of the password field in all MySQL user schemas.
+  # This description contains a link to the password policy, which doesn't make
+  # sense to include in the schema itself.
+  - target: $.components.schemas['de.mittwald.v1.database.CreateMySqlUser'].properties
+    update:
+      password:
+        description: >
+          The password for the database user. This password has to comply with the password
+          policy specified for MySQL users in the [password security specification](/docs/v2/api/security/passwords#mysql).
+  - target: $.components.schemas['de.mittwald.v1.database.CreateMySqlUserWithDatabase'].properties
+    update:
+      password:
+        description: >
+          The password for the database user. This password has to comply with the password
+          policy specified for MySQL users in the [password security specification](/docs/v2/api/security/passwords#mysql).
+
   - target: $.paths['/v2/mysql-users/{mysqlUserId}/password'].patch.requestBody.content['application/json'].schema.properties.password
     update:
       description: >


### PR DESCRIPTION
## Summary
- Add operation-level documentation for MySQL database create/get endpoints explaining async behavior and status checking
- Improve character settings descriptions with links to MySQL documentation and API endpoints
- Remove `accessIpMask` field from MySQL user schemas (currently only partially supported)
- Add explanatory comments to overlay configuration

Relates to #953

🤖 Generated with [Claude Code](https://claude.ai/claude-code)