### PR TITLE
Add OpenWebUI embedding batch size recommendation

### DIFF
--- a/docs/platform/aihosting/50-examples/10-openwebui.mdx
+++ b/docs/platform/aihosting/50-examples/10-openwebui.mdx
@@ -57,7 +57,8 @@ To enable more efficient document processing, you can use an embedding model:
 3. Enter the endpoint: `https://llm.aihosting.mittwald.de/v1`
 4. Enter your generated API key
 5. Select one of the available [embedding models](/docs/v2/platform/aihosting/models/) (such as Qwen3-Embedding-8B) under **"Embedding Model"**
-6. In the **"Retrieval"** section, optionally adjust the parameters **"Top K"** and **"RAG Template"** for optimal results
+6. Below set **Embedding Batch Size** to **32**.
+7. In the **"Retrieval"** section, optionally adjust the parameters **"Top K"** and **"RAG Template"** for optimal results
 
 ## Configuring Speech-to-Text {#speech-to-text}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/10-openwebui.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/10-openwebui.mdx
@@ -58,7 +58,7 @@ Für performantere Verarbeitung kann ein Embedding-Modell genutzt werden:
 4. Gib deinen generierten API-Key ein
 5. Wähle unter **„Embedding Model"** ein von uns angebotenes [Embedding-Modell](/docs/v2/platform/aihosting/models/) aus (wie z.B. Qwen3-Embedding-8B)
 6. Setze darunter **Embedding-Stapelgröße** auf **32**.
-6. Im Bereich **„Retrieval"** kannst du optional die Parameter **„Top K"** und **„RAG Template"** für optimale Ergebnisse anpassen
+7. Im Bereich **„Retrieval"** kannst du optional die Parameter **„Top K"** und **„RAG Template"** für optimale Ergebnisse anpassen
 
 ## Konfiguration von Speech-to-Text {#speech-to-text}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/10-openwebui.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/10-openwebui.mdx
@@ -57,6 +57,7 @@ Für performantere Verarbeitung kann ein Embedding-Modell genutzt werden:
 3. Gib den Endpunkt ein: `https://llm.aihosting.mittwald.de/v1`
 4. Gib deinen generierten API-Key ein
 5. Wähle unter **„Embedding Model"** ein von uns angebotenes [Embedding-Modell](/docs/v2/platform/aihosting/models/) aus (wie z.B. Qwen3-Embedding-8B)
+6. Setze darunter **Embedding-Stapelgröße** auf **32**.
 6. Im Bereich **„Retrieval"** kannst du optional die Parameter **„Top K"** und **„RAG Template"** für optimale Ergebnisse anpassen
 
 ## Konfiguration von Speech-to-Text {#speech-to-text}


### PR DESCRIPTION
Recommend to set embedding batch size to 32 in Openwebui (current default is 1). Customers get ratelimited very fast instead.