### PR TITLE
docs: clarify API limits, errors, and system prompt (EN + DE)

### DIFF
--- a/docs/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
+++ b/docs/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
@@ -48,6 +48,29 @@ curl -i -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
 
 The `model` parameter requires a valid model name, which can be retrieved via the `/v1/models` route. Additional model parameters such as `temperature`, `top_p`, or `top_k` can be provided. Recommended settings for these can be found in the model descriptions if they differ from the defaults. Which extended parameters influence the response depends on the model.
 
+### System prompt {#system-prompt}
+
+All chat models support a system prompt via the `role: "system"` message. Pass it as the first entry in the `messages` array:
+
+```sh
+curl -i -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $APIKEY" \
+    -d '{
+        "model": "Ministral-3-14B-Instruct-2512",
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant. Always respond in English."
+            },
+            {
+                "role": "user",
+                "content": "Erkläre mir, was eine API ist."
+            }
+        ]
+    }'
+```
+
 To receive a streamed response, the option `stream: true` must be set.
 
 ```sh
@@ -71,7 +94,12 @@ curl -i -N -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
 
 ### Vision (image + text)
 
+Images must be submitted as Base64-encoded data URLs. Encode the image file first, then pass the result in the request:
+
 ```sh
+# Encode the image to a Base64 data URL
+IMAGE_B64=$(base64 -i photo.jpg | tr -d '\n')
+
 curl -i -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $APIKEY" \
@@ -81,12 +109,14 @@ curl -i -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
           "role": "user",
           "content": [
             {"type": "text", "text": "What is in this image?"},
-            {"type": "image_url", "image_url": {"url": "https://example.com/photo.jpg"}}
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,'"$IMAGE_B64"'"}}
           ]
         }],
         "temperature": 0.1
     }'
 ```
+
+For ready-to-use helpers that resize and encode images, see the [Python examples](../../examples/python/#vision-encoding) or [JavaScript examples](../../examples/javascript/#vision-encoding).
 
 ### Function calling (tools)
 
@@ -180,7 +210,7 @@ This endpoint allows you to transcribe audio files into text using Whisper model
 curl -X POST https://llm.aihosting.mittwald.de/v1/audio/transcriptions \
     -H "Authorization: Bearer $APIKEY" \
     -F "file=@/path/to/audio.mp3" \
-    -F "model=Whisper-Large-V3-Turbo"
+    -F "model=whisper-large-v3-turbo"
 ```
 
 The `file` parameter should contain the audio file to be transcribed. Supported formats include MP3, OGG, WAV, and FLAC. Maximum file size is 25 MB. The `model` parameter specifies which Whisper model to use for transcription.

--- a/docs/platform/aihosting/40-api-endpoints/20-errors.mdx
+++ b/docs/platform/aihosting/40-api-endpoints/20-errors.mdx
@@ -6,10 +6,10 @@ title: Errors and error messages
 
 If the API returns a status code outside the 200 to 399 range, there is an error in the request. The following errors are expected:
 
+- `400 Bad Request`: The request cannot be processed. An error message should be included explaining the reasons:
+  - `At most n image(s) may be provided in one request.`: The total number of images in the provided context exceeds the model's capacity. Either remove images from the context or start a new context.
+  - `max_tokens must be at least…`: The maximum context length of the model was exceeded for text generation. The error message also shows the number of excess tokens (as a negative value). The context must be shortened.
 - `401 Unauthorized`: No API key was provided in the `Authorization` header, or the API key is invalid.
 - `408 Request Timeout`: The request exceeded the maximum allowed duration of 1,800 seconds (30 minutes) and was terminated. Consider splitting large workloads into smaller, independent requests.
 - `429 Too Many Requests`: The rate limit has been reached. No further requests can be made within the current time window. The limit resets after the window has passed. Rate-limit responses do **not** include a `Retry-After` header — implement a fixed delay or exponential back-off in your client.
 - `502 Bad Gateway` / `503 Service Unavailable`: The model is temporarily unavailable, for example due to a restart or overload. Retry the request after a short delay.
-- `400 Bad Request`: The request cannot be processed. An error message should be included explaining the reasons:
-  - `At most n image(s) may be provided in one request.`: The total number of images in the provided context exceeds the model's capacity. Either remove images from the context or start a new context.
-  - `max_tokens must be at least…`: The maximum context length of the model was exceeded for text generation. The error message also shows the number of excess tokens (as a negative value). The context must be shortened.

--- a/docs/platform/aihosting/40-api-endpoints/20-errors.mdx
+++ b/docs/platform/aihosting/40-api-endpoints/20-errors.mdx
@@ -6,8 +6,10 @@ title: Errors and error messages
 
 If the API returns a status code outside the 200 to 399 range, there is an error in the request. The following errors are expected:
 
-- `401 Unauthorized`: No API key was provided in the `Authorization` header, or the API key is invalid.
-- `429 Too Many Requests`: The rate limit has been reached. No further requests can be made within the current minute. The limit resets after the minute has passed.
 - `400 Bad Request`: The request cannot be processed. An error message should be included explaining the reasons:
   - `At most n image(s) may be provided in one request.`: The total number of images in the provided context exceeds the model's capacity. Either remove images from the context or start a new context.
   - `max_tokens must be at least…`: The maximum context length of the model was exceeded for text generation. The error message also shows the number of excess tokens (as a negative value). The context must be shortened.
+- `401 Unauthorized`: No API key was provided in the `Authorization` header, or the API key is invalid.
+- `408 Request Timeout`: The request exceeded the maximum allowed duration of 1,800 seconds (30 minutes) and was terminated. Consider splitting large workloads into smaller, independent requests.
+- `429 Too Many Requests`: The rate limit has been reached. No further requests can be made within the current time window. The limit resets after the window has passed. Rate-limit responses do **not** include a `Retry-After` header — implement a fixed delay or exponential back-off in your client.
+- `502 Bad Gateway` / `503 Service Unavailable`: The model is temporarily unavailable, for example due to a restart or overload. Retry the request after a short delay.

--- a/docs/platform/aihosting/40-api-endpoints/20-errors.mdx
+++ b/docs/platform/aihosting/40-api-endpoints/20-errors.mdx
@@ -6,10 +6,10 @@ title: Errors and error messages
 
 If the API returns a status code outside the 200 to 399 range, there is an error in the request. The following errors are expected:
 
-- `400 Bad Request`: The request cannot be processed. An error message should be included explaining the reasons:
-  - `At most n image(s) may be provided in one request.`: The total number of images in the provided context exceeds the model's capacity. Either remove images from the context or start a new context.
-  - `max_tokens must be at least…`: The maximum context length of the model was exceeded for text generation. The error message also shows the number of excess tokens (as a negative value). The context must be shortened.
 - `401 Unauthorized`: No API key was provided in the `Authorization` header, or the API key is invalid.
 - `408 Request Timeout`: The request exceeded the maximum allowed duration of 1,800 seconds (30 minutes) and was terminated. Consider splitting large workloads into smaller, independent requests.
 - `429 Too Many Requests`: The rate limit has been reached. No further requests can be made within the current time window. The limit resets after the window has passed. Rate-limit responses do **not** include a `Retry-After` header — implement a fixed delay or exponential back-off in your client.
 - `502 Bad Gateway` / `503 Service Unavailable`: The model is temporarily unavailable, for example due to a restart or overload. Retry the request after a short delay.
+- `400 Bad Request`: The request cannot be processed. An error message should be included explaining the reasons:
+  - `At most n image(s) may be provided in one request.`: The total number of images in the provided context exceeds the model's capacity. Either remove images from the context or start a new context.
+  - `max_tokens must be at least…`: The maximum context length of the model was exceeded for text generation. The error message also shows the number of excess tokens (as a negative value). The context must be shortened.

--- a/docs/platform/aihosting/40-api-endpoints/30-deviations-and-limitations.mdx
+++ b/docs/platform/aihosting/40-api-endpoints/30-deviations-and-limitations.mdx
@@ -11,11 +11,24 @@ Although our API is compatible with the OpenAI API, there are some limitations:
 - Only selected endpoints are implemented (see [list](../supported-endpoints/))
 - Some parameters like `n`, `logprobs`, `functions` (depending on the model) are not available
 - Vision input is currently only supported via Base64, not via URLs
+- The `response_format` parameter only accepts `"text"` as the value. The OpenAI-style `{"type": "json_object"}` variant is not supported and is silently ignored. To reliably obtain JSON output, instruct the model via the system prompt or user message (e.g. "Respond with a valid JSON object only.").
 
 ## Limitations
 
 All requests are subject to a rate limit to ensure fair and consistent usage and availability of the models for all users. Requests are limited according to the respective tariff the user has booked. Please check the according price information regarding the limitations applied in your case.
 
 All models are also subject to model-specific limitations. These always include the allowed context length measured in the number of transmitted tokens. For vision-capable models that process images, only a limited number of images can be transmitted per request, meaning _across the entire submitted context_. This affects all images sent in the full chat history of a request.
+
+### Request timeout {#request-timeout}
+
+Each request may run for a maximum of **1,800 seconds (30 minutes)**. Requests that exceed this duration are terminated and return a `408 Request Timeout` error. For long-running workloads such as FAQ generation with large inputs, consider splitting the work into smaller, independent requests.
+
+### Output token limit {#output-token-limit}
+
+There is no artificial per-request cap on output tokens beyond the model's context window. The `max_tokens` parameter can be set to any value up to the model's full context length minus the number of input tokens sent. The maximum context length for each model is listed on the respective [model page](../../models/).
+
+### System prompt support {#system-prompt-support}
+
+All chat models support the `role: "system"` message type. You can pass a system prompt as the first message in the `messages` array with `"role": "system"`.
 
 Currently, it is **not possible to generate images**. A corresponding API route does not exist.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
@@ -48,6 +48,29 @@ curl -i -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
 
 Der Parameter `model` erfordert eine gültige Modellbezeichnung, welcher über die `/v1/models`-Route ermittelt werden kann. Es können weitere Modellparameter wie `temperature`, `top_p` oder `top_k` übermittelt werden. Empfohlene Einstellungen hierfür finden sich in der Beschreibung der Modelle, sofern diese vom Standard abweichen. Welche erweiterten Parameter Einfluss auf die Antwort nehmen ist modellabhängig.
 
+### System-Prompt {#system-prompt}
+
+Alle Chat-Modelle unterstützen einen System-Prompt über den Nachrichtentyp `role: "system"`. Dieser wird als erster Eintrag im `messages`-Array übergeben:
+
+```sh
+curl -i -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $APIKEY" \
+    -d '{
+        "model": "Ministral-3-14B-Instruct-2512",
+        "messages": [
+            {
+                "role": "system",
+                "content": "Du bist ein hilfreicher Assistent. Antworte immer auf Deutsch."
+            },
+            {
+                "role": "user",
+                "content": "Explain what an API is."
+            }
+        ]
+    }'
+```
+
 Für eine Stream-Response muss die Option `stream: true` gesetzt werden.
 
 ```sh
@@ -71,7 +94,12 @@ curl -i -N -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
 
 ### Vision (Bild + Text)
 
+Bilder müssen als Base64-kodierte Data-URLs übermittelt werden. Die Bilddatei wird zunächst enkodiert und dann in der Anfrage übergeben:
+
 ```sh
+# Bild als Base64-Data-URL enkodieren
+IMAGE_B64=$(base64 -i photo.jpg | tr -d '\n')
+
 curl -i -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $APIKEY" \
@@ -81,12 +109,14 @@ curl -i -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
           "role": "user",
           "content": [
             {"type": "text", "text": "Was ist auf diesem Bild?"},
-            {"type": "image_url", "image_url": {"url": "https://example.com/photo.jpg"}}
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,'"$IMAGE_B64"'"}}
           ]
         }],
         "temperature": 0.1
     }'
 ```
+
+Fertige Hilfsfunktionen zum Skalieren und Enkodieren von Bildern sind in den [Python-Beispielen](../../examples/python/#vision-encoding) und [JavaScript-Beispielen](../../examples/javascript/#vision-encoding) zu finden.
 
 ### Function Calling (Tools)
 
@@ -180,7 +210,7 @@ Dieser Endpunkt ermöglicht es, Audiodateien mit Whisper-Modellen in Text zu tra
 curl -X POST https://llm.aihosting.mittwald.de/v1/audio/transcriptions \
     -H "Authorization: Bearer $APIKEY" \
     -F "file=@/path/to/audio.mp3" \
-    -F "model=Whisper-Large-V3-Turbo"
+    -F "model=whisper-large-v3-turbo"
 ```
 
 Der `file`-Parameter sollte die zu transkribierende Audiodatei enthalten. Unterstützte Formate sind MP3, OGG, WAV und FLAC. Die maximale Dateigröße beträgt 25 MB. Der `model`-Parameter gibt an, welches Whisper-Modell für die Transkription verwendet werden soll.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/20-errors.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/20-errors.mdx
@@ -6,8 +6,10 @@ title: Fehlercodes und Fehlermeldungen
 
 Liefert die API einen Statuscode außerhalb des Intervalls von 200 bis 399 zurück, liegt ein Fehler in der Anfrage vor. Folgende Fehler sind erwartbar:
 
-- `401 Unauthorized`: Es wurde kein API-Key im `Authorization`-Header übermittelt oder der API-Key ist ungültig.
-- `429 Too Many Requests`: Das RateLimit wurde erreicht. Weitere Anfragen sind innerhalb der Minute nicht möglich. Nach Ablauf der Minute wird das RateLimit zurückgesetzt.
 - `400 Bad Request`: Die Anfrage kann nicht verarbeitet werden. Es sollte eine Fehlernachricht mitgeliefert werden, die die Gründe dafür erläutert:
-  - `At most n image(s) may be provided in one request.`: Die Anzahl der maximal erlaubten Bilder im gesamten übermittelten Context überschreitet die Kapazitäten des Models. Entweder müssen Bilder aus dem übermittelten Context entfernt oder ein neuer Context muss eröffnet werden.
-  - `max_tokens must be at least…`: Die maximale Context-Länge des Modells wurde überschritten für die Generierung von Text. Die Fehlermeldung gibt zudem die Anzahl der Überschreitung als Differenz (negativer Wert, Anzahl Token) aus. Der Context muss gekürzt werden.
+  - `At most n image(s) may be provided in one request.`: Die Anzahl der maximal erlaubten Bilder im gesamten übermittelten Context überschreitet die Kapazitäten des Modells. Entweder müssen Bilder aus dem übermittelten Context entfernt oder ein neuer Context muss eröffnet werden.
+  - `max_tokens must be at least…`: Die maximale Context-Länge des Modells wurde für die Generierung von Text überschritten. Die Fehlermeldung gibt zudem die Anzahl der Überschreitung als Differenz (negativer Wert, Anzahl Token) aus. Der Context muss gekürzt werden.
+- `401 Unauthorized`: Es wurde kein API-Key im `Authorization`-Header übermittelt oder der API-Key ist ungültig.
+- `408 Request Timeout`: Die Anfrage hat die maximal erlaubte Laufzeit von 1.800 Sekunden (30 Minuten) überschritten und wurde abgebrochen. Umfangreiche Aufgaben sollten in kleinere, unabhängige Anfragen aufgeteilt werden.
+- `429 Too Many Requests`: Das Rate-Limit wurde erreicht. Weitere Anfragen sind innerhalb des aktuellen Zeitfensters nicht möglich. Nach Ablauf des Fensters wird das Limit zurückgesetzt. Rate-Limit-Antworten enthalten **keinen** `Retry-After`-Header — implementiere in deinem Client eine feste Wartezeit oder ein exponentielles Backoff.
+- `502 Bad Gateway` / `503 Service Unavailable`: Das Modell ist vorübergehend nicht erreichbar, z. B. aufgrund eines Neustarts oder einer Überlastung. Die Anfrage sollte nach einer kurzen Wartezeit erneut gestellt werden.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/20-errors.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/20-errors.mdx
@@ -6,10 +6,10 @@ title: Fehlercodes und Fehlermeldungen
 
 Liefert die API einen Statuscode außerhalb des Intervalls von 200 bis 399 zurück, liegt ein Fehler in der Anfrage vor. Folgende Fehler sind erwartbar:
 
-- `400 Bad Request`: Die Anfrage kann nicht verarbeitet werden. Es sollte eine Fehlernachricht mitgeliefert werden, die die Gründe dafür erläutert:
-  - `At most n image(s) may be provided in one request.`: Die Anzahl der maximal erlaubten Bilder im gesamten übermittelten Context überschreitet die Kapazitäten des Modells. Entweder müssen Bilder aus dem übermittelten Context entfernt oder ein neuer Context muss eröffnet werden.
-  - `max_tokens must be at least…`: Die maximale Context-Länge des Modells wurde für die Generierung von Text überschritten. Die Fehlermeldung gibt zudem die Anzahl der Überschreitung als Differenz (negativer Wert, Anzahl Token) aus. Der Context muss gekürzt werden.
 - `401 Unauthorized`: Es wurde kein API-Key im `Authorization`-Header übermittelt oder der API-Key ist ungültig.
 - `408 Request Timeout`: Die Anfrage hat die maximal erlaubte Laufzeit von 1.800 Sekunden (30 Minuten) überschritten und wurde abgebrochen. Umfangreiche Aufgaben sollten in kleinere, unabhängige Anfragen aufgeteilt werden.
 - `429 Too Many Requests`: Das Rate-Limit wurde erreicht. Weitere Anfragen sind innerhalb des aktuellen Zeitfensters nicht möglich. Nach Ablauf des Fensters wird das Limit zurückgesetzt. Rate-Limit-Antworten enthalten **keinen** `Retry-After`-Header — implementiere in deinem Client eine feste Wartezeit oder ein exponentielles Backoff.
 - `502 Bad Gateway` / `503 Service Unavailable`: Das Modell ist vorübergehend nicht erreichbar, z. B. aufgrund eines Neustarts oder einer Überlastung. Die Anfrage sollte nach einer kurzen Wartezeit erneut gestellt werden.
+- `400 Bad Request`: Die Anfrage kann nicht verarbeitet werden. Es sollte eine Fehlernachricht mitgeliefert werden, die die Gründe dafür erläutert:
+  - `At most n image(s) may be provided in one request.`: Die Anzahl der maximal erlaubten Bilder im gesamten übermittelten Context überschreitet die Kapazitäten des Modells. Entweder müssen Bilder aus dem übermittelten Context entfernt oder ein neuer Context muss eröffnet werden.
+  - `max_tokens must be at least…`: Die maximale Context-Länge des Modells wurde für die Generierung von Text überschritten. Die Fehlermeldung gibt zudem die Anzahl der Überschreitung als Differenz (negativer Wert, Anzahl Token) aus. Der Context muss gekürzt werden.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/20-errors.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/20-errors.mdx
@@ -6,10 +6,10 @@ title: Fehlercodes und Fehlermeldungen
 
 Liefert die API einen Statuscode außerhalb des Intervalls von 200 bis 399 zurück, liegt ein Fehler in der Anfrage vor. Folgende Fehler sind erwartbar:
 
+- `400 Bad Request`: Die Anfrage kann nicht verarbeitet werden. Es sollte eine Fehlernachricht mitgeliefert werden, die die Gründe dafür erläutert:
+  - `At most n image(s) may be provided in one request.`: Die Anzahl der maximal erlaubten Bilder im gesamten übermittelten Context überschreitet die Kapazitäten des Modells. Entweder müssen Bilder aus dem übermittelten Context entfernt oder ein neuer Context muss eröffnet werden.
+  - `max_tokens must be at least…`: Die maximale Context-Länge des Modells wurde für die Generierung von Text überschritten. Die Fehlermeldung gibt zudem die Anzahl der Überschreitung als Differenz (negativer Wert, Anzahl Token) aus. Der Context muss gekürzt werden.
 - `401 Unauthorized`: Es wurde kein API-Key im `Authorization`-Header übermittelt oder der API-Key ist ungültig.
 - `408 Request Timeout`: Die Anfrage hat die maximal erlaubte Laufzeit von 1.800 Sekunden (30 Minuten) überschritten und wurde abgebrochen. Umfangreiche Aufgaben sollten in kleinere, unabhängige Anfragen aufgeteilt werden.
 - `429 Too Many Requests`: Das Rate-Limit wurde erreicht. Weitere Anfragen sind innerhalb des aktuellen Zeitfensters nicht möglich. Nach Ablauf des Fensters wird das Limit zurückgesetzt. Rate-Limit-Antworten enthalten **keinen** `Retry-After`-Header — implementiere in deinem Client eine feste Wartezeit oder ein exponentielles Backoff.
 - `502 Bad Gateway` / `503 Service Unavailable`: Das Modell ist vorübergehend nicht erreichbar, z. B. aufgrund eines Neustarts oder einer Überlastung. Die Anfrage sollte nach einer kurzen Wartezeit erneut gestellt werden.
-- `400 Bad Request`: Die Anfrage kann nicht verarbeitet werden. Es sollte eine Fehlernachricht mitgeliefert werden, die die Gründe dafür erläutert:
-  - `At most n image(s) may be provided in one request.`: Die Anzahl der maximal erlaubten Bilder im gesamten übermittelten Context überschreitet die Kapazitäten des Modells. Entweder müssen Bilder aus dem übermittelten Context entfernt oder ein neuer Context muss eröffnet werden.
-  - `max_tokens must be at least…`: Die maximale Context-Länge des Modells wurde für die Generierung von Text überschritten. Die Fehlermeldung gibt zudem die Anzahl der Überschreitung als Differenz (negativer Wert, Anzahl Token) aus. Der Context muss gekürzt werden.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/30-deviations-and-limitations.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/30-deviations-and-limitations.mdx
@@ -11,11 +11,24 @@ Obwohl unsere API kompatibel zur OpenAI-API ist, gibt es einige Einschränkungen
 - Nur ausgewählte Endpunkte sind implementiert (siehe [Liste](../supported-endpoints/))
 - Einige Parameter wie `n`, `logprobs`, `functions` (je nach Modell) sind nicht verfügbar
 - Vision-Input erfolgt derzeit nur über Base64, nicht über URLs
+- Der Parameter `response_format` akzeptiert ausschließlich den Wert `"text"`. Die OpenAI-Variante `{"type": "json_object"}` wird nicht unterstützt und stillschweigend ignoriert. Um zuverlässig JSON-Ausgaben zu erhalten, formuliere die Anforderung direkt im System-Prompt oder in der Nutzernachricht (z. B. „Antworte ausschließlich mit einem validen JSON-Objekt.").
 
 ## Limitierungen
 
-Alle Anfragen unterliegen einem RateLimit, um eine faire und gleichmäßige Nutzung und Verfügbarkeit der Modelle für alle Nutzer zu gewährleisten. Im Rahmen der Beta-Phase sind dies für einen API-Key 300 Anfragen pro Minute unabhängig vom genutzten Modell. Wird das Limit erreicht, erhält der Nutzer einen HTTP-Status-Code `429 Too Many Requests`. Nach Ablauf einer Minute wird das Limit für den verwendeten API-Key zurückgesetzt.
+Alle Anfragen unterliegen einem RateLimit, um eine faire und gleichmäßige Nutzung und Verfügbarkeit der Modelle für alle Nutzer zu gewährleisten. Die geltenden Limits richten sich nach dem gebuchten Tarif. Die jeweiligen Werte sind den Preisinformationen zu entnehmen.
 
-Alle Modelle unterliegen zudem modellspezifischen Limitierungen. Diese umfassen immer die erlaubte Context-Länge gemessen an der Anzahl an übermitteln Tokens. Bei Vision-fähigen-Modellen zur Verarbeitung von Bildern können je Anfrage und somit im _gesamten übermittelten Context_ nur eine limitierte Anzahl an Bildern übertragen werden. Dies betrifft somit alle in der gesamten Chat-Historie einer Anfrage übermittelten Bilder.
+Alle Modelle unterliegen zudem modellspezifischen Limitierungen. Diese umfassen immer die erlaubte Context-Länge gemessen an der Anzahl an übermittelten Tokens. Bei Vision-fähigen Modellen zur Verarbeitung von Bildern können je Anfrage und somit im _gesamten übermittelten Context_ nur eine limitierte Anzahl an Bildern übertragen werden. Dies betrifft somit alle in der gesamten Chat-Historie einer Anfrage übermittelten Bilder.
+
+### Anfrage-Timeout {#request-timeout}
+
+Jede Anfrage darf maximal **1.800 Sekunden (30 Minuten)** dauern. Anfragen, die diesen Zeitraum überschreiten, werden abgebrochen und liefern einen `408 Request Timeout`-Fehler zurück. Bei umfangreichen Aufgaben wie der FAQ-Generierung mit großen Eingaben empfiehlt es sich, die Arbeit in kleinere, unabhängige Anfragen aufzuteilen.
+
+### Ausgabe-Token-Limit {#output-token-limit}
+
+Es gibt kein künstliches Limit für Output-Tokens unterhalb des Kontextfensters des jeweiligen Modells. Der Parameter `max_tokens` kann auf jeden Wert bis zur vollen Kontextlänge des Modells abzüglich der gesendeten Eingabe-Tokens gesetzt werden. Die maximale Kontextlänge jedes Modells ist auf der jeweiligen [Modellseite](../../models/) aufgeführt.
+
+### System-Prompt-Unterstützung {#system-prompt-support}
+
+Alle Chat-Modelle unterstützen den Nachrichtentyp `role: "system"`. Ein System-Prompt kann als erstes Element im `messages`-Array mit `"role": "system"` übergeben werden.
 
 Gegenwärtig besteht **keine Möglichkeit, Bilder zu generieren**. Eine entsprechende API-Route existiert dementsprechend nicht.


### PR DESCRIPTION
- Add system prompt example (role: system) to supported endpoints
- Fix vision curl example: replace URL with Base64 shell encoding
- Fix Whisper model name casing in first transcription example
- Add 408, 502, 503 error codes and no-Retry-After note to errors doc
- Document response_format deviation (json_object not supported)
- Document 1800s request timeout limit
- Document max_tokens has no artificial cap beyond context window
- Document system prompt support explicitly
- Fix stale beta rate-limit numbers in German deviations doc