### PR TITLE
Fix config path for OpenCode in docs

### DIFF
--- a/docs/platform/development/ai-coding.mdx
+++ b/docs/platform/development/ai-coding.mdx
@@ -151,7 +151,7 @@ Then select Devstral in Kilo Code's model picker for agent tasks.
 ### OpenCode {#opencode}
 
 [OpenCode](https://opencode.ai) supports OpenAI-compatible providers. These
-are either configured globally in the `~/config/opencode/opencode.json` file,
+are either configured globally in the `~/.config/opencode/opencode.json` file,
 or per-project in an `opencode.json` file in the project root.
 
 Regardless of the location, the respective provider configuration could look like this:

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/development/ai-coding.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/development/ai-coding.mdx
@@ -152,7 +152,7 @@ Wähle anschließend Devstral in Kilo Codes Modell-Auswahl für Agent-Aufgaben.
 ### OpenCode {#opencode}
 
 [OpenCode](https://opencode.ai) unterstützt OpenAI-kompatible Anbieter. Diese
-werden entweder global in der Datei `~/config/opencode/opencode.json` oder
+werden entweder global in der Datei `~/.config/opencode/opencode.json` oder
 pro Projekt in einer `opencode.json` Datei im Projekt-Wurzelverzeichnis konfiguriert.
 
 Unabhängig vom Speicherort könnte die jeweilige Provider-Konfiguration wie folgt aussehen:


### PR DESCRIPTION
The correct path according to [the opencode docs](https://opencode.ai/docs/config/#global).