### PR TITLE
Task/qwen thinking mode docs

### DIFF
--- a/docs/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
+++ b/docs/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
@@ -5,6 +5,9 @@ title: Qwen3.5-122B-A10B-FP8
 slug: /platform/aihosting/models/qwen3-5-122b-a10b-fp8
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 ## Description
 
 "Qwen3.5-122B-A10B-FP8" is a Mixture-of-Experts (MoE) language model by Alibaba with 122 billion total parameters, of which approximately 10 billion are active per forward pass. It is designed for high-quality chat, agentic workflows, and reasoning tasks while remaining computationally efficient thanks to the MoE architecture.
@@ -22,7 +25,116 @@ The following limitations apply:
 - Thinking mode requires at least 128,000 tokens of remaining context to function properly
 - Images must be submitted as Base64-encoded data URLs (no remote URLs)
 
-**Thinking mode is enabled by default.** To disable it, pass `"enable_thinking": false` in your API request's extra body parameters.
+**Thinking mode is enabled by default.** See [API usage](#api-usage) below for the correct way to disable it — the parameter must be nested inside `chat_template_kwargs`.
+
+## API usage {#api-usage}
+
+:::warning[Thinking mode is on by default and can cause long response times]
+Before every response the model generates an internal reasoning chain. For complex prompts this can be thousands of tokens long, adding several seconds to the time-to-first-token (TTFT).
+
+**Common mistake:** passing `enable_thinking: false` as a top-level field in the request body — the API silently ignores it and thinking stays on. It must be nested inside `chat_template_kwargs` as shown below.
+:::
+
+### Disabling thinking mode
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+response = client.chat.completions.create(
+    model="Qwen3.5-122B-A10B-FP8",
+    messages=[{"role": "user", "content": "What is 2 + 2?"}],
+    temperature=0.7,
+    top_p=0.8,
+    max_tokens=32768,
+    extra_body={
+        "chat_template_kwargs": {"enable_thinking": False},
+        #                        ^^^^^^^^^^^^^^^^^^^^^^^^
+        # Must be nested here — passing enable_thinking at the top level
+        # is silently ignored by the API.
+    },
+)
+
+print(response.choices[0].message.content)
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const response = await client.chat.completions.create({
+  model: "Qwen3.5-122B-A10B-FP8",
+  messages: [{ role: "user", content: "What is 2 + 2?" }],
+  temperature: 0.7,
+  top_p: 0.8,
+  max_tokens: 32768,
+  // @ts-ignore – vLLM extension; must be nested here, not enable_thinking at top level
+  chat_template_kwargs: { enable_thinking: false },
+} as any);
+
+console.log(response.choices[0].message.content);
+```
+
+  </TabItem>
+  <TabItem value="php" label="PHP">
+
+```php
+<?php
+// composer require openai-php/client guzzlehttp/guzzle
+
+$client = OpenAI::factory()
+    ->withBaseUri('https://llm.aihosting.mittwald.de/v1')
+    ->withApiKey('sk-your-api-key-here')
+    ->make();
+
+$response = $client->chat()->create([
+    'model' => 'Qwen3.5-122B-A10B-FP8',
+    'messages' => [
+        ['role' => 'user', 'content' => 'What is 2 + 2?'],
+    ],
+    'temperature' => 0.7,
+    'top_p' => 0.8,
+    'max_tokens' => 32768,
+    'chat_template_kwargs' => ['enable_thinking' => false],
+    // Must be nested here — passing 'enable_thinking' => false at the top
+    // level of the request is silently ignored by the API.
+]);
+
+echo $response->choices[0]->message->content;
+```
+
+  </TabItem>
+</Tabs>
+
+### Reading the response
+
+When thinking mode is **enabled** (default), the model returns two separate fields:
+
+| Field | Contents |
+| ----- | -------- |
+| `choices[0].message.reasoning_content` | Internal chain-of-thought (may be very long) |
+| `choices[0].message.content` | Final answer |
+
+If `content` is empty, the model placed its answer inside the reasoning block — disable thinking mode to ensure `content` is always populated.
+
+```python
+print(response.choices[0].message.reasoning_content)  # internal chain-of-thought
+print(response.choices[0].message.content)             # final answer
+```
 
 ## Recommended inference parameters
 

--- a/docs/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
+++ b/docs/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
@@ -25,9 +25,7 @@ The following limitations apply:
 - Thinking mode requires at least 128,000 tokens of remaining context to function properly
 - Images must be submitted as Base64-encoded data URLs (no remote URLs)
 
-**Thinking mode is enabled by default.** See [API usage](#api-usage) below for the correct way to disable it — the parameter must be nested inside `chat_template_kwargs`.
-
-## API usage {#api-usage}
+**Thinking mode is enabled by default.** See [Disabling thinking mode](#disable-thinking) below for the correct way — the parameter must be nested inside `chat_template_kwargs`.
 
 :::warning[Thinking mode is on by default and can cause long response times]
 Before every response the model generates an internal reasoning chain. For complex prompts this can be thousands of tokens long, adding several seconds to the time-to-first-token (TTFT).
@@ -35,7 +33,7 @@ Before every response the model generates an internal reasoning chain. For compl
 **Common mistake:** passing `enable_thinking: false` as a top-level field in the request body — the API silently ignores it and thinking stays on. It must be nested inside `chat_template_kwargs` as shown below.
 :::
 
-### Disabling thinking mode
+### Disabling thinking mode {#disable-thinking}
 
 <Tabs groupId="language">
   <TabItem value="python" label="Python">

--- a/docs/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
+++ b/docs/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
@@ -26,9 +26,7 @@ The following limitations apply:
 - Thinking mode requires at least 128,000 tokens of remaining context to function properly
 - Images must be submitted as Base64-encoded data URLs (no remote URLs)
 
-**Thinking mode is enabled by default.** See [API usage](#api-usage) below for the correct way to disable it — the parameter must be nested inside `chat_template_kwargs`.
-
-## API usage {#api-usage}
+**Thinking mode is enabled by default.** See [Disabling thinking mode](#disable-thinking) below for the correct way — the parameter must be nested inside `chat_template_kwargs`.
 
 :::warning[Thinking mode is on by default and can cause long response times]
 Before every response the model generates an internal reasoning chain. For complex prompts this can be thousands of tokens long, adding several seconds to the time-to-first-token (TTFT).
@@ -36,7 +34,7 @@ Before every response the model generates an internal reasoning chain. For compl
 **Common mistake:** passing `enable_thinking: false` as a top-level field in the request body — the API silently ignores it and thinking stays on. It must be nested inside `chat_template_kwargs` as shown below.
 :::
 
-### Disabling thinking mode
+### Disabling thinking mode {#disable-thinking}
 
 <Tabs groupId="language">
   <TabItem value="python" label="Python">

--- a/docs/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
+++ b/docs/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
@@ -5,6 +5,9 @@ title: Qwen3.6-35B-A3B-FP8
 slug: /platform/aihosting/models/qwen3-6-35b-a3b-fp8
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 ## Description
 
 "Qwen3.6-35B-A3B-FP8" is a Mixture-of-Experts (MoE) language model by Alibaba with 35 billion total parameters, of which approximately 3 billion are active per forward pass. It is designed for efficient, high-quality chat and agentic workflows with reasoning and vision capabilities, suitable for long-document analysis and extended multi-turn conversations.
@@ -23,7 +26,116 @@ The following limitations apply:
 - Thinking mode requires at least 128,000 tokens of remaining context to function properly
 - Images must be submitted as Base64-encoded data URLs (no remote URLs)
 
-**Thinking mode is enabled by default.** To disable it, pass `"enable_thinking": false` in your API request's extra body parameters.
+**Thinking mode is enabled by default.** See [API usage](#api-usage) below for the correct way to disable it — the parameter must be nested inside `chat_template_kwargs`.
+
+## API usage {#api-usage}
+
+:::warning[Thinking mode is on by default and can cause long response times]
+Before every response the model generates an internal reasoning chain. For complex prompts this can be thousands of tokens long, adding several seconds to the time-to-first-token (TTFT).
+
+**Common mistake:** passing `enable_thinking: false` as a top-level field in the request body — the API silently ignores it and thinking stays on. It must be nested inside `chat_template_kwargs` as shown below.
+:::
+
+### Disabling thinking mode
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+response = client.chat.completions.create(
+    model="Qwen3.6-35B-A3B-FP8",
+    messages=[{"role": "user", "content": "What is 2 + 2?"}],
+    temperature=0.7,
+    top_p=0.8,
+    max_tokens=32768,
+    extra_body={
+        "chat_template_kwargs": {"enable_thinking": False},
+        #                        ^^^^^^^^^^^^^^^^^^^^^^^^
+        # Must be nested here — passing enable_thinking at the top level
+        # is silently ignored by the API.
+    },
+)
+
+print(response.choices[0].message.content)
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const response = await client.chat.completions.create({
+  model: "Qwen3.6-35B-A3B-FP8",
+  messages: [{ role: "user", content: "What is 2 + 2?" }],
+  temperature: 0.7,
+  top_p: 0.8,
+  max_tokens: 32768,
+  // @ts-ignore – vLLM extension; must be nested here, not enable_thinking at top level
+  chat_template_kwargs: { enable_thinking: false },
+} as any);
+
+console.log(response.choices[0].message.content);
+```
+
+  </TabItem>
+  <TabItem value="php" label="PHP">
+
+```php
+<?php
+// composer require openai-php/client guzzlehttp/guzzle
+
+$client = OpenAI::factory()
+    ->withBaseUri('https://llm.aihosting.mittwald.de/v1')
+    ->withApiKey('sk-your-api-key-here')
+    ->make();
+
+$response = $client->chat()->create([
+    'model' => 'Qwen3.6-35B-A3B-FP8',
+    'messages' => [
+        ['role' => 'user', 'content' => 'What is 2 + 2?'],
+    ],
+    'temperature' => 0.7,
+    'top_p' => 0.8,
+    'max_tokens' => 32768,
+    'chat_template_kwargs' => ['enable_thinking' => false],
+    // Must be nested here — passing 'enable_thinking' => false at the top
+    // level of the request is silently ignored by the API.
+]);
+
+echo $response->choices[0]->message->content;
+```
+
+  </TabItem>
+</Tabs>
+
+### Reading the response
+
+When thinking mode is **enabled** (default), the model returns two separate fields:
+
+| Field | Contents |
+| ----- | -------- |
+| `choices[0].message.reasoning_content` | Internal chain-of-thought (may be very long) |
+| `choices[0].message.content` | Final answer |
+
+If `content` is empty, the model placed its answer inside the reasoning block — disable thinking mode to ensure `content` is always populated.
+
+```python
+print(response.choices[0].message.reasoning_content)  # internal chain-of-thought
+print(response.choices[0].message.content)             # final answer
+```
 
 ## Recommended inference parameters
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
@@ -4,6 +4,9 @@ description: Detaillierte Informationen zu Qwen3.5-122B-A10B-FP8
 title: Qwen3.5-122B-A10B-FP8
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 ## Beschreibung
 
 „Qwen3.5-122B-A10B-FP8" ist ein Mixture-of-Experts-Sprachmodell (MoE) von Alibaba mit 122 Milliarden Gesamtparametern, von denen jeweils ca. 10 Milliarden pro Forward-Pass aktiv sind. Es ist für qualitativ hochwertige Chat-, agentische und Reasoning-Workflows ausgelegt und bleibt dank der MoE-Architektur rechnerisch effizient.
@@ -21,7 +24,116 @@ Folgende Limitierungen gelten:
 - Der Thinking-Modus benötigt mindestens 128.000 Token verbleibenden Context, um korrekt zu funktionieren
 - Bilder müssen als Base64-kodierte Data-URLs übermittelt werden (keine externen URLs)
 
-**Thinking-Modus ist standardmäßig aktiviert.** Um ihn zu deaktivieren, übergib `"enable_thinking": false` in den Extra-Body-Parametern deiner API-Anfrage.
+**Thinking-Modus ist standardmäßig aktiviert.** Wie du ihn korrekt deaktivierst, zeigt der Abschnitt [API-Nutzung](#api-nutzung) — der Parameter muss in `chat_template_kwargs` verschachtelt werden.
+
+## API-Nutzung {#api-nutzung}
+
+:::warning[Thinking-Modus ist standardmäßig aktiviert und kann zu langen Antwortzeiten führen]
+Das Modell generiert vor jeder Antwort eine interne Gedankenkette. Bei komplexen Prompts kann diese Tausende von Tokens umfassen und die Zeit bis zum ersten Token (TTFT) um mehrere Sekunden erhöhen.
+
+**Häufiger Fehler:** `enable_thinking: false` als Top-Level-Feld im Request-Body übergeben — die API ignoriert es stillschweigend und der Thinking-Modus bleibt aktiv. Es muss wie unten gezeigt in `chat_template_kwargs` verschachtelt werden.
+:::
+
+### Thinking-Modus deaktivieren
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+response = client.chat.completions.create(
+    model="Qwen3.5-122B-A10B-FP8",
+    messages=[{"role": "user", "content": "Was ist 2 + 2?"}],
+    temperature=0.7,
+    top_p=0.8,
+    max_tokens=32768,
+    extra_body={
+        "chat_template_kwargs": {"enable_thinking": False},
+        #                        ^^^^^^^^^^^^^^^^^^^^^^^^
+        # Muss hier verschachtelt sein — enable_thinking auf Top-Level-Ebene
+        # wird von der API stillschweigend ignoriert.
+    },
+)
+
+print(response.choices[0].message.content)
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const response = await client.chat.completions.create({
+  model: "Qwen3.5-122B-A10B-FP8",
+  messages: [{ role: "user", content: "Was ist 2 + 2?" }],
+  temperature: 0.7,
+  top_p: 0.8,
+  max_tokens: 32768,
+  // @ts-ignore – vLLM-Erweiterung; muss hier verschachtelt sein, nicht enable_thinking auf Top-Level
+  chat_template_kwargs: { enable_thinking: false },
+} as any);
+
+console.log(response.choices[0].message.content);
+```
+
+  </TabItem>
+  <TabItem value="php" label="PHP">
+
+```php
+<?php
+// composer require openai-php/client guzzlehttp/guzzle
+
+$client = OpenAI::factory()
+    ->withBaseUri('https://llm.aihosting.mittwald.de/v1')
+    ->withApiKey('sk-your-api-key-here')
+    ->make();
+
+$response = $client->chat()->create([
+    'model' => 'Qwen3.5-122B-A10B-FP8',
+    'messages' => [
+        ['role' => 'user', 'content' => 'Was ist 2 + 2?'],
+    ],
+    'temperature' => 0.7,
+    'top_p' => 0.8,
+    'max_tokens' => 32768,
+    'chat_template_kwargs' => ['enable_thinking' => false],
+    // Muss hier verschachtelt sein — 'enable_thinking' => false auf Top-Level-Ebene
+    // wird von der API stillschweigend ignoriert.
+]);
+
+echo $response->choices[0]->message->content;
+```
+
+  </TabItem>
+</Tabs>
+
+### Antwort auslesen
+
+Wenn der Thinking-Modus **aktiviert** ist (Standard), liefert das Modell zwei separate Felder:
+
+| Feld | Inhalt |
+| ---- | ------ |
+| `choices[0].message.reasoning_content` | Interne Gedankenkette (kann sehr lang sein) |
+| `choices[0].message.content` | Endgültige Antwort |
+
+Wenn `content` leer ist, hat das Modell seine Antwort in den Reasoning-Block geschrieben — deaktiviere den Thinking-Modus, damit `content` immer befüllt wird.
+
+```python
+print(response.choices[0].message.reasoning_content)  # interne Gedankenkette
+print(response.choices[0].message.content)             # endgültige Antwort
+```
 
 ## Empfohlene Inferenzparameter
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
@@ -24,9 +24,7 @@ Folgende Limitierungen gelten:
 - Der Thinking-Modus benötigt mindestens 128.000 Token verbleibenden Context, um korrekt zu funktionieren
 - Bilder müssen als Base64-kodierte Data-URLs übermittelt werden (keine externen URLs)
 
-**Thinking-Modus ist standardmäßig aktiviert.** Wie du ihn korrekt deaktivierst, zeigt der Abschnitt [API-Nutzung](#api-nutzung) — der Parameter muss in `chat_template_kwargs` verschachtelt werden.
-
-## API-Nutzung {#api-nutzung}
+**Thinking-Modus ist standardmäßig aktiviert.** Wie du ihn korrekt deaktivierst, zeigt der Abschnitt [Thinking-Modus deaktivieren](#thinking-modus-deaktivieren) — der Parameter muss in `chat_template_kwargs` verschachtelt werden.
 
 :::warning[Thinking-Modus ist standardmäßig aktiviert und kann zu langen Antwortzeiten führen]
 Das Modell generiert vor jeder Antwort eine interne Gedankenkette. Bei komplexen Prompts kann diese Tausende von Tokens umfassen und die Zeit bis zum ersten Token (TTFT) um mehrere Sekunden erhöhen.
@@ -34,7 +32,7 @@ Das Modell generiert vor jeder Antwort eine interne Gedankenkette. Bei komplexen
 **Häufiger Fehler:** `enable_thinking: false` als Top-Level-Feld im Request-Body übergeben — die API ignoriert es stillschweigend und der Thinking-Modus bleibt aktiv. Es muss wie unten gezeigt in `chat_template_kwargs` verschachtelt werden.
 :::
 
-### Thinking-Modus deaktivieren
+### Thinking-Modus deaktivieren {#thinking-modus-deaktivieren}
 
 <Tabs groupId="language">
   <TabItem value="python" label="Python">

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
@@ -4,6 +4,9 @@ description: Detaillierte Informationen zu Qwen3.6-35B-A3B-FP8
 title: Qwen3.6-35B-A3B-FP8
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 ## Beschreibung
 
 „Qwen3.6-35B-A3B-FP8" ist ein Mixture-of-Experts-Sprachmodell (MoE) von Alibaba mit 35 Milliarden Gesamtparametern, von denen jeweils ca. 3 Milliarden pro Forward-Pass aktiv sind. Es ist für effiziente, qualitativ hochwertige Chat- und agentische Workflows mit Reasoning- und Vision-Fähigkeiten ausgelegt und eignet sich für die Analyse langer Dokumente und ausgedehnte Mehrturngespräche.
@@ -22,7 +25,116 @@ Folgende Limitierungen gelten:
 - Der Thinking-Modus benötigt mindestens 128.000 Token verbleibenden Context, um korrekt zu funktionieren
 - Bilder müssen als Base64-kodierte Data-URLs übermittelt werden (keine externen URLs)
 
-**Thinking-Modus ist standardmäßig aktiviert.** Um ihn zu deaktivieren, übergib `"enable_thinking": false` in den Extra-Body-Parametern deiner API-Anfrage.
+**Thinking-Modus ist standardmäßig aktiviert.** Wie du ihn korrekt deaktivierst, zeigt der Abschnitt [API-Nutzung](#api-nutzung) — der Parameter muss in `chat_template_kwargs` verschachtelt werden.
+
+## API-Nutzung {#api-nutzung}
+
+:::warning[Thinking-Modus ist standardmäßig aktiviert und kann zu langen Antwortzeiten führen]
+Das Modell generiert vor jeder Antwort eine interne Gedankenkette. Bei komplexen Prompts kann diese Tausende von Tokens umfassen und die Zeit bis zum ersten Token (TTFT) um mehrere Sekunden erhöhen.
+
+**Häufiger Fehler:** `enable_thinking: false` als Top-Level-Feld im Request-Body übergeben — die API ignoriert es stillschweigend und der Thinking-Modus bleibt aktiv. Es muss wie unten gezeigt in `chat_template_kwargs` verschachtelt werden.
+:::
+
+### Thinking-Modus deaktivieren
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+response = client.chat.completions.create(
+    model="Qwen3.6-35B-A3B-FP8",
+    messages=[{"role": "user", "content": "Was ist 2 + 2?"}],
+    temperature=0.7,
+    top_p=0.8,
+    max_tokens=32768,
+    extra_body={
+        "chat_template_kwargs": {"enable_thinking": False},
+        #                        ^^^^^^^^^^^^^^^^^^^^^^^^
+        # Muss hier verschachtelt sein — enable_thinking auf Top-Level-Ebene
+        # wird von der API stillschweigend ignoriert.
+    },
+)
+
+print(response.choices[0].message.content)
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const response = await client.chat.completions.create({
+  model: "Qwen3.6-35B-A3B-FP8",
+  messages: [{ role: "user", content: "Was ist 2 + 2?" }],
+  temperature: 0.7,
+  top_p: 0.8,
+  max_tokens: 32768,
+  // @ts-ignore – vLLM-Erweiterung; muss hier verschachtelt sein, nicht enable_thinking auf Top-Level
+  chat_template_kwargs: { enable_thinking: false },
+} as any);
+
+console.log(response.choices[0].message.content);
+```
+
+  </TabItem>
+  <TabItem value="php" label="PHP">
+
+```php
+<?php
+// composer require openai-php/client guzzlehttp/guzzle
+
+$client = OpenAI::factory()
+    ->withBaseUri('https://llm.aihosting.mittwald.de/v1')
+    ->withApiKey('sk-your-api-key-here')
+    ->make();
+
+$response = $client->chat()->create([
+    'model' => 'Qwen3.6-35B-A3B-FP8',
+    'messages' => [
+        ['role' => 'user', 'content' => 'Was ist 2 + 2?'],
+    ],
+    'temperature' => 0.7,
+    'top_p' => 0.8,
+    'max_tokens' => 32768,
+    'chat_template_kwargs' => ['enable_thinking' => false],
+    // Muss hier verschachtelt sein — 'enable_thinking' => false auf Top-Level-Ebene
+    // wird von der API stillschweigend ignoriert.
+]);
+
+echo $response->choices[0]->message->content;
+```
+
+  </TabItem>
+</Tabs>
+
+### Antwort auslesen
+
+Wenn der Thinking-Modus **aktiviert** ist (Standard), liefert das Modell zwei separate Felder:
+
+| Feld | Inhalt |
+| ---- | ------ |
+| `choices[0].message.reasoning_content` | Interne Gedankenkette (kann sehr lang sein) |
+| `choices[0].message.content` | Endgültige Antwort |
+
+Wenn `content` leer ist, hat das Modell seine Antwort in den Reasoning-Block geschrieben — deaktiviere den Thinking-Modus, damit `content` immer befüllt wird.
+
+```python
+print(response.choices[0].message.reasoning_content)  # interne Gedankenkette
+print(response.choices[0].message.content)             # endgültige Antwort
+```
 
 ## Empfohlene Inferenzparameter
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
@@ -25,9 +25,7 @@ Folgende Limitierungen gelten:
 - Der Thinking-Modus benötigt mindestens 128.000 Token verbleibenden Context, um korrekt zu funktionieren
 - Bilder müssen als Base64-kodierte Data-URLs übermittelt werden (keine externen URLs)
 
-**Thinking-Modus ist standardmäßig aktiviert.** Wie du ihn korrekt deaktivierst, zeigt der Abschnitt [API-Nutzung](#api-nutzung) — der Parameter muss in `chat_template_kwargs` verschachtelt werden.
-
-## API-Nutzung {#api-nutzung}
+**Thinking-Modus ist standardmäßig aktiviert.** Wie du ihn korrekt deaktivierst, zeigt der Abschnitt [Thinking-Modus deaktivieren](#thinking-modus-deaktivieren) — der Parameter muss in `chat_template_kwargs` verschachtelt werden.
 
 :::warning[Thinking-Modus ist standardmäßig aktiviert und kann zu langen Antwortzeiten führen]
 Das Modell generiert vor jeder Antwort eine interne Gedankenkette. Bei komplexen Prompts kann diese Tausende von Tokens umfassen und die Zeit bis zum ersten Token (TTFT) um mehrere Sekunden erhöhen.
@@ -35,7 +33,7 @@ Das Modell generiert vor jeder Antwort eine interne Gedankenkette. Bei komplexen
 **Häufiger Fehler:** `enable_thinking: false` als Top-Level-Feld im Request-Body übergeben — die API ignoriert es stillschweigend und der Thinking-Modus bleibt aktiv. Es muss wie unten gezeigt in `chat_template_kwargs` verschachtelt werden.
 :::
 
-### Thinking-Modus deaktivieren
+### Thinking-Modus deaktivieren {#thinking-modus-deaktivieren}
 
 <Tabs groupId="language">
   <TabItem value="python" label="Python">


### PR DESCRIPTION
Wegen gehäufter Fragen, warum das Modell bei zB Bildgenerierung so lange braucht hier eine Klarstellung. 

- Fügt zu der Model Card eine große Box hinzu und genaue Anweisungen, wie man Thinking ausstellt. 
- Vorbereitung für Entfernung von Devstral.