### PR TITLE
fix: adjust package, throw warning on mismatch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ You can use the following commands to build this project locally:
 If you run into unwanted changes of `package-lock.json` in local installations, there is a
 high chance that your `node` / `npm` versions are not within the specified boundaries.
 
-Use `nvm` in order to run correct versions, avoiding suprises:
+Use `nvm` in order to run correct versions, avoiding surprises:
 
 ```bash
 nvm install 20

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,20 @@ You can use the following commands to build this project locally:
 - `npm run build` to build a production release (this may be necessary to work with multi-lingual content).
 - `npm run serve` to serve a production release locally.
 
+If you run into unwanted changes of `package-lock.json` in local installations, there is a
+high chance that your `node` / `npm` versions are not within the specified boundaries.
+
+Use `nvm` in order to run correct versions, avoiding suprises:
+
+```bash
+nvm install 20
+nvm use 20
+
+# check versions
+node --version
+npm --version
+```
+
 ## How-Tos
 
 ### Working with the changelog

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
         "yaml": "^2.8.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20",
+        "npm": ">=9 <11"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     ]
   },
   "engines": {
-    "node": ">=20"
-  }
+    "node": ">=20",
+    "npm": ">=9 <11"
+  },
+  "engine-strict": true
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,5 @@
   "engines": {
     "node": ">=20",
     "npm": ">=9 <11"
-  },
-  "engine-strict": true
+  }
 }


### PR DESCRIPTION
To avoid myself and others doing rather useless package-lock churn, i'd rather document current versions and throw a warning on mismatch. As i am switching node version all day like crazy, such warning helps me to realize i just picked the wrong version. Behind the scenes, `npm` version 11+ seems to treat dependencies more carefully, specifically adding `peer: true` fields to all peers deps found. Up until today i just ignored these, now i understand better and suggest this change for soft warnings.