### PR TITLE
Task/add q2 model docs

### DIFF
--- a/docs/platform/aihosting/30-models/100-qwen3-vl-reranker-2b.mdx
+++ b/docs/platform/aihosting/30-models/100-qwen3-vl-reranker-2b.mdx
@@ -42,17 +42,19 @@ Qwen3-VL-Reranker-2B is served via the **`/v1/rerank`** endpoint, which follows 
 import os
 import requests
 
+documents = [
+    "Payment is due within 30 days of invoice.",
+    "The vendor must deliver goods within 14 business days.",
+    "Late payments incur a 2% monthly surcharge.",
+]
+
 response = requests.post(
     "https://llm.aihosting.mittwald.de/v1/rerank",
     headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
     json={
         "model": "Qwen3-VL-Reranker-2B",
         "query": "What are the payment terms?",
-        "documents": [
-            "Payment is due within 30 days of invoice.",
-            "The vendor must deliver goods within 14 business days.",
-            "Late payments incur a 2% monthly surcharge.",
-        ],
+        "documents": documents,
     },
     timeout=30,
 )

--- a/docs/platform/aihosting/30-models/100-qwen3-vl-reranker-2b.mdx
+++ b/docs/platform/aihosting/30-models/100-qwen3-vl-reranker-2b.mdx
@@ -1,0 +1,169 @@
+---
+sidebar_label: Qwen3-VL-Reranker-2B
+description: Detailed information about Qwen3-VL-Reranker-2B
+title: Qwen3-VL-Reranker-2B
+slug: /platform/aihosting/models/qwen3-vl-reranker-2b
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Description
+
+"Qwen3-VL-Reranker-2B" is a vision-language cross-encoder reranking model by Alibaba. Given a query and a list of candidate documents, it scores each (query, document) pair by semantic relevance and returns a ranked list. Both the query and documents can contain images, making it suitable for multimodal RAG pipelines.
+
+It supports and is suitable for:
+
+- Reranking text candidates retrieved from a vector index (RAG pipelines)
+- Reranking documents that contain images alongside text
+- Improving retrieval precision as a second pass after embedding-based search
+- Scoring query–document relevance for any ranking task
+
+The following limitations apply:
+
+- Accessible only via `/v1/rerank` — not via `/v1/chat/completions`
+- Maximum context length per (query + document) pair: 32,768 tokens
+- Maximum images per request: 5; maximum videos: 1
+- Maximum image size: 1,310,720 pixels — larger images are downscaled proportionally (1 token per 32 × 32 pixel block)
+- No streaming — all scores are returned in a single response
+- Not for text generation, tool calling, or conversation
+- Write `instruction` values in **English** for best results, even when querying multilingual documents — the model's training data is predominantly English
+
+## API usage
+
+Qwen3-VL-Reranker-2B is served via the **`/v1/rerank`** endpoint, which follows the Cohere-compatible reranking API format.
+
+### Basic reranking
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python">
+
+```python
+import os
+import requests
+
+response = requests.post(
+    "https://llm.aihosting.mittwald.de/v1/rerank",
+    headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+    json={
+        "model": "Qwen3-VL-Reranker-2B",
+        "query": "What are the payment terms?",
+        "documents": [
+            "Payment is due within 30 days of invoice.",
+            "The vendor must deliver goods within 14 business days.",
+            "Late payments incur a 2% monthly surcharge.",
+        ],
+    },
+    timeout=30,
+)
+response.raise_for_status()
+
+for result in sorted(response.json()["results"], key=lambda r: r["relevance_score"], reverse=True):
+    print(f"[{result['relevance_score']:.3f}] {documents[result['index']][:80]}")
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+
+```ts
+const response = await fetch(
+  "https://llm.aihosting.mittwald.de/v1/rerank",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: "Qwen3-VL-Reranker-2B",
+      query: "What are the payment terms?",
+      documents: [
+        "Payment is due within 30 days of invoice.",
+        "The vendor must deliver goods within 14 business days.",
+        "Late payments incur a 2% monthly surcharge.",
+      ],
+    }),
+  }
+);
+
+const { results } = await response.json();
+const ranked = results.sort((a, b) => b.relevance_score - a.relevance_score);
+console.log(ranked);
+```
+
+  </TabItem>
+</Tabs>
+
+### Response format
+
+```json
+{
+  "results": [
+    { "index": 0, "relevance_score": 0.912 },
+    { "index": 2, "relevance_score": 0.874 },
+    { "index": 1, "relevance_score": 0.031 }
+  ]
+}
+```
+
+`index` is the position in the original `documents` array. `relevance_score` is a float between 0 and 1 — higher is more relevant.
+
+### Custom instruction
+
+The optional `instruction` field tells the model which retrieval task to optimise for. Omitting it uses a generic default (`"Given a search query, retrieve relevant candidates that answer the query."`):
+
+```python
+response = requests.post(
+    "https://llm.aihosting.mittwald.de/v1/rerank",
+    headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+    json={
+        "model": "Qwen3-VL-Reranker-2B",
+        "query": "Total amount due on this invoice",
+        "documents": chunks,
+        "instruction": "Given an OCR-extracted invoice, find sections containing payment amounts or totals.",
+    },
+    timeout=30,
+)
+```
+
+Domain-specific instructions yield a 1–5 % precision improvement on specialised corpora (legal, medical, financial). Always write the instruction in **English** — even when querying non-English documents.
+
+## Integrating into a RAG pipeline
+
+Use the reranker as a second pass after vector search. Retrieve a wider candidate set from your vector index, then narrow it down:
+
+```python
+import math
+
+def cosine(a, b):
+    dot = sum(x * y for x, y in zip(a, b))
+    norm = math.sqrt(sum(x**2 for x in a)) * math.sqrt(sum(x**2 for x in b))
+    return dot / (norm + 1e-9)
+
+# Step 1: rough retrieval via embedding similarity (top 10)
+q_vec = embed([query])[0]
+candidates = sorted(index, key=lambda v_c: cosine(q_vec, v_c[0]), reverse=True)[:10]
+candidate_texts = [c for _, c in candidates]
+
+# Step 2: precise reranking (top 3)
+resp = requests.post(
+    "https://llm.aihosting.mittwald.de/v1/rerank",
+    headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+    json={"model": "Qwen3-VL-Reranker-2B", "query": query, "documents": candidate_texts},
+    timeout=30,
+)
+ranked = sorted(resp.json()["results"], key=lambda r: r["relevance_score"], reverse=True)
+top_chunks = [candidate_texts[r["index"]] for r in ranked[:3]]
+```
+
+Combining GLM-OCR for text extraction, Qwen3-Embedding-8B for indexing, Qwen3-VL-Reranker-2B for reranking, and a chat model for answering gives a complete document Q&A pipeline.
+
+:::tip Guide ideas
+- **Two-stage text RAG**: embed → top-10 candidates → rerank to top-3. The reranker's cross-attention over the full (query, document) pair catches relevance signals that pure embedding similarity misses.
+- **Multimodal product search**: index product images alongside their descriptions; rerank results for queries like "dark wooden desk suitable for a small home office" using both text and image content.
+- **Document Q&A precision**: combine with GLM-OCR (text extraction), Qwen3-Embedding-8B (indexing), and a chat model (answering) for a four-stage pipeline where the reranker maximises context quality before the expensive generation step.
+:::
+
+## Terms of use and licensing {#terms-of-use-and-licensing}
+
+The [general terms of use](../../access-and-usage/terms-of-use/) apply. The model is provided by Alibaba under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.html), and reuse of the generated content is not subject to any additional restrictions.

--- a/docs/platform/aihosting/30-models/110-mistral-medium-3-5-128b.mdx
+++ b/docs/platform/aihosting/30-models/110-mistral-medium-3-5-128b.mdx
@@ -1,0 +1,177 @@
+---
+sidebar_label: Mistral-Medium-3.5-128B
+description: Detailed information about Mistral-Medium-3.5-128B
+title: Mistral-Medium-3.5-128B
+slug: /platform/aihosting/models/mistral-medium-3-5-128b
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Description
+
+"Mistral-Medium-3.5-128B" is a 128-billion-parameter multimodal model by Mistral AI. It supports text, vision, and tool calling over a 256,000-token context window and uses EAGLE speculative decoding for fast inference.
+
+It supports and is suitable for:
+
+- Text generation within a chat completion (text to text)
+- Tool-calling for agentic workflows
+- Image understanding (vision) — up to 5 images per request
+- Long-context document analysis and summarisation
+- Multilingual tasks — strong coverage of European languages
+
+The following limitations apply:
+
+- Maximum context length: 256,000 tokens
+- Maximum images per request: 5
+- Images must be submitted as Base64-encoded data URLs (no remote URLs)
+- No audio support
+
+## API usage
+
+### Chat
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+response = client.chat.completions.create(
+    model="Mistral-Medium-3.5-128B",
+    messages=[{"role": "user", "content": "Explain the difference between TCP and UDP."}],
+    temperature=0.7,
+    top_p=0.9,
+    max_tokens=1024,
+)
+
+print(response.choices[0].message.content)
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const response = await client.chat.completions.create({
+  model: "Mistral-Medium-3.5-128B",
+  messages: [{ role: "user", content: "Explain the difference between TCP and UDP." }],
+  temperature: 0.7,
+  top_p: 0.9,
+  max_tokens: 1024,
+});
+
+console.log(response.choices[0].message.content);
+```
+
+  </TabItem>
+</Tabs>
+
+### Vision (image + text)
+
+Images must be submitted as Base64-encoded data URLs. See the [Python examples](../../examples/python/#vision-encoding) or [JavaScript examples](../../examples/javascript/#vision-encoding) for a resizing helper — always resize to a maximum of 1024 px on the longest edge before encoding.
+
+```python
+import base64
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+with open("diagram.jpg", "rb") as f:
+    img_b64 = base64.b64encode(f.read()).decode()
+
+response = client.chat.completions.create(
+    model="Mistral-Medium-3.5-128B",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"}},
+            {"type": "text", "text": "Describe what is shown in this diagram."},
+        ],
+    }],
+    temperature=0.1,
+    max_tokens=1024,
+)
+
+print(response.choices[0].message.content)
+```
+
+### Tool calling (function calling)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get current weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}]
+
+response = client.chat.completions.create(
+    model="Mistral-Medium-3.5-128B",
+    messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+    tools=tools,
+    tool_choice="auto",
+    temperature=0.2,
+)
+
+if response.choices[0].message.tool_calls:
+    call = response.choices[0].message.tool_calls[0]
+    print(f"Function: {call.function.name}")
+    print(f"Arguments: {call.function.arguments}")
+```
+
+## Recommended inference parameters
+
+### General chat
+
+| Parameter     | Value |
+| ------------- | ----- |
+| `temperature` | 0.7   |
+| `top_p`       | 1.0   |
+| `max_tokens`  | 1024–8192 depending on task |
+
+### Vision tasks
+
+| Parameter     | Value |
+| ------------- | ----- |
+| `temperature` | 0.1   |
+| `top_p`       | 1.0   |
+| `max_tokens`  | 512–2048 depending on task |
+
+### Tool calling / structured output
+
+| Parameter     | Value |
+| ------------- | ----- |
+| `temperature` | 0.0–0.3 |
+| `top_p`       | 1.0   |
+
+:::tip Guide ideas
+- **Multilingual agentic assistant**: Mistral Medium handles 40+ languages natively. Build a customer service agent that receives queries in any supported language and calls tools (billing, order lookup, escalation) using native function calling — no translation step needed.
+- **LLM cascade**: Use `Qwen3.5-0.8B` as a cheap router. Route simple queries back to itself, moderate complexity to `Qwen3.6-35B-A3B-FP8`, and only genuinely complex tasks to `Mistral-Medium-3.5-128B`. Well-tuned cascades cut token costs by 40–80% while preserving 95% of quality.
+- **Long-document analysis**: The 256k context window fits entire technical reports, legal contracts, or codebases in a single request — no chunking needed for documents under ~190,000 words.
+:::
+
+## Terms of use and licensing {#terms-of-use-and-licensing}
+
+The [general terms of use](../../access-and-usage/terms-of-use/) apply. The model is provided by Mistral AI under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.html), and reuse of the generated content is not subject to any additional restrictions.

--- a/docs/platform/aihosting/30-models/110-mistral-medium-3-5-128b.mdx
+++ b/docs/platform/aihosting/30-models/110-mistral-medium-3-5-128b.mdx
@@ -10,21 +10,18 @@ import TabItem from "@theme/TabItem";
 
 ## Description
 
-"Mistral-Medium-3.5-128B" is a 128-billion-parameter multimodal model by Mistral AI. It supports text, vision, and tool calling over a 256,000-token context window and uses EAGLE speculative decoding for fast inference.
+"Mistral-Medium-3.5-128B" is a 128-billion-parameter frontier language model by Mistral AI. It supports text and tool calling over a 256,000-token context window and uses EAGLE speculative decoding for fast inference.
 
 It supports and is suitable for:
 
 - Text generation within a chat completion (text to text)
 - Tool-calling for agentic workflows
-- Image understanding (vision) — up to 5 images per request
 - Long-context document analysis and summarisation
 - Multilingual tasks — strong coverage of European languages
 
 The following limitations apply:
 
 - Maximum context length: 256,000 tokens
-- Maximum images per request: 5
-- Images must be submitted as Base64-encoded data URLs (no remote URLs)
 - No audio support
 
 ## API usage
@@ -78,35 +75,6 @@ console.log(response.choices[0].message.content);
   </TabItem>
 </Tabs>
 
-### Vision (image + text)
-
-Images must be submitted as Base64-encoded data URLs. See the [Python examples](../../examples/python/#vision-encoding) or [JavaScript examples](../../examples/javascript/#vision-encoding) for a resizing helper — always resize to a maximum of 1024 px on the longest edge before encoding.
-
-```python
-import base64
-from openai import OpenAI
-
-client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
-
-with open("diagram.jpg", "rb") as f:
-    img_b64 = base64.b64encode(f.read()).decode()
-
-response = client.chat.completions.create(
-    model="Mistral-Medium-3.5-128B",
-    messages=[{
-        "role": "user",
-        "content": [
-            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"}},
-            {"type": "text", "text": "Describe what is shown in this diagram."},
-        ],
-    }],
-    temperature=0.1,
-    max_tokens=1024,
-)
-
-print(response.choices[0].message.content)
-```
-
 ### Tool calling (function calling)
 
 ```python
@@ -150,14 +118,6 @@ if response.choices[0].message.tool_calls:
 | `temperature` | 0.7   |
 | `top_p`       | 1.0   |
 | `max_tokens`  | 1024–8192 depending on task |
-
-### Vision tasks
-
-| Parameter     | Value |
-| ------------- | ----- |
-| `temperature` | 0.1   |
-| `top_p`       | 1.0   |
-| `max_tokens`  | 512–2048 depending on task |
 
 ### Tool calling / structured output
 

--- a/docs/platform/aihosting/30-models/30-qwen3-embedding-8b.mdx
+++ b/docs/platform/aihosting/30-models/30-qwen3-embedding-8b.mdx
@@ -2,6 +2,7 @@
 sidebar_label: Qwen3-Embedding-8B
 description: Detailled information on Qwen3-Embedding-8B
 title: Qwen3-Embedding-8B
+slug: /platform/aihosting/models/qwen3-embedding-8b
 ---
 
 ## Description

--- a/docs/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
+++ b/docs/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
@@ -14,8 +14,9 @@ The following limitations apply to this model on our platform:
 - Maximum file size: 25 MB per upload
 - No explicit context length limit – depends on audio duration and file size
 - Translation is currently not supported (`to_language`)
-- Supported output formats: **`text`**, **`json`**
-  - Other formats (`srt`, `vtt`, `verbose_json`) are currently not supported
+- Supported output formats: **`json`**, **`verbose_json`**
+  - `response_format="text"` is accepted but returns a JSON body regardless — use `"json"` instead
+  - `srt` and `vtt` are not supported (HTTP 400)
 
 ### Supported Input Formats
 
@@ -33,7 +34,7 @@ The following limitations apply to this model on our platform:
 - **`language` like `language="de"`should always be set explicitly** to maximize accuracy.
   If no value is provided, **German (`"de"`)** will be assumed by default, which may result in poorer outcomes for inputs in other languages.
 
-### Example Output (`response_format=json`)
+### Example output — `response_format="json"` {#output-json}
 
 ```json
 {
@@ -45,11 +46,33 @@ The following limitations apply to this model on our platform:
 }
 ```
 
+### Example output — `response_format="verbose_json"` {#output-verbose}
+
+Returns additional metadata including detected language, duration, and per-segment timestamps:
+
+```json
+{
+  "text": "This is the transcribed text.",
+  "language": "en",
+  "duration": "8.0",
+  "words": null,
+  "segments": [
+    {
+      "id": 0,
+      "avg_logprob": -0.45,
+      "text": " This is the transcribed text.",
+      "start": 0.0,
+      "end": 2.4
+    }
+  ]
+}
+```
+
 ### Best Practices
 
 - **Always set the `language` parameter explicitly**, e.g. `language="de"` for German audio files.
 - Segment long audio files into chunks of < 25 MB.
-- For real-time or near-real-time applications, use `response_format="text"`.
+- Use `response_format="verbose_json"` when you need language detection, duration, or segment-level timestamps.
 - For multilingual recordings: transcribe each language separately for better accuracy.
 
 ## Terms of Use and Licensing

--- a/docs/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
+++ b/docs/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
@@ -2,6 +2,7 @@
 sidebar_label: Whisper-Large-V3-Turbo
 description: Detailed information about Whisper-Large-V3-Turbo
 title: Whisper-Large-V3-Turbo
+slug: /platform/aihosting/models/whisper-large-v3-turbo
 ---
 
 ## Description

--- a/docs/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
+++ b/docs/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
@@ -5,6 +5,8 @@ title: Whisper-Large-V3-Turbo
 slug: /platform/aihosting/models/whisper-large-v3-turbo
 ---
 
+The [Speech-to-text guide](../../examples/whisper/) has runnable examples for basic transcription, multi-language usage, large-file chunking, and a transcription + summarisation pipeline.
+
 ## Description
 
 “Whisper-Large-V3-Turbo” is a multilingual automatic speech recognition model (ASR) developed by OpenAI, optimized for speed and efficiency. It is based on the architecture of the well-known “Whisper-Large-V3” model, but uses a lighter decoder structure to significantly reduce latency with only a minimal loss in accuracy. The model supports over 99 languages and is ideal for transcribing speech inputs.
@@ -67,13 +69,6 @@ Returns additional metadata including detected language, duration, and per-segme
   ]
 }
 ```
-
-### Best Practices
-
-- **Always set the `language` parameter explicitly**, e.g. `language="de"` for German audio files.
-- Segment long audio files into chunks of < 25 MB.
-- Use `response_format="verbose_json"` when you need language detection, duration, or segment-level timestamps.
-- For multilingual recordings: transcribe each language separately for better accuracy.
 
 ## Terms of Use and Licensing
 

--- a/docs/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
+++ b/docs/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
@@ -1,0 +1,201 @@
+---
+sidebar_label: Qwen3.5-0.8B
+description: Detailed information about Qwen3.5-0.8B
+title: Qwen3.5-0.8B
+slug: /platform/aihosting/models/qwen3-5-0-8b
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Description
+
+"Qwen3.5-0.8B" is a compact language model by Alibaba with 0.8 billion parameters. Despite its small size it supports a 262,144-token context window and an optional thinking / reasoning mode, making it the most cost-efficient model in the mittwald AI Hosting catalogue.
+
+It supports and is suitable for:
+
+- Text generation within a chat completion (text to text)
+- Tool-calling for agentic workflows
+- Thinking / reasoning for step-by-step problem solving (opt-in)
+- High-throughput, latency-sensitive pipelines
+- Batch processing — classification, routing, summarisation, extraction
+
+The following limitations apply:
+
+- Maximum context length: 262,144 tokens
+- No image / vision support
+- Response quality and reasoning depth are lower than larger models
+- Thinking mode is **disabled by default** — opt in per request via `chat_template_kwargs`
+
+## Thinking mode
+
+Thinking mode is **off by default** on this model — the opposite of `Qwen3.5-122B-A10B-FP8`. Enable it selectively for tasks that benefit from chain-of-thought reasoning:
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+response = client.chat.completions.create(
+    model="Qwen3.5-0.8B",
+    messages=[{"role": "user", "content": "Solve: if 3x + 7 = 22, what is x?"}],
+    temperature=0.6,
+    top_k=20,
+    max_tokens=8192,
+    extra_body={
+        "chat_template_kwargs": {"enable_thinking": True},
+    },
+)
+
+# Thinking response contains both fields:
+print(response.choices[0].message.reasoning_content)  # chain-of-thought
+print(response.choices[0].message.content)             # final answer
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const response = await client.chat.completions.create({
+  model: "Qwen3.5-0.8B",
+  messages: [{ role: "user", content: "Solve: if 3x + 7 = 22, what is x?" }],
+  temperature: 0.6,
+  max_tokens: 8192,
+  // @ts-ignore – vLLM extension
+  chat_template_kwargs: { enable_thinking: true },
+} as any);
+
+console.log(response.choices[0].message.content);
+```
+
+  </TabItem>
+</Tabs>
+
+When thinking is enabled the model returns two fields:
+
+| Field | Contents |
+| ----- | -------- |
+| `choices[0].message.reasoning_content` | Internal chain-of-thought |
+| `choices[0].message.content` | Final answer |
+
+## Recommended inference parameters
+
+### Default mode (thinking off)
+
+**General tasks:**
+
+| Parameter          | Value |
+| ------------------ | ----- |
+| `temperature`      | 1.0   |
+| `top_p`            | 1.0   |
+| `top_k`            | 20    |
+| `presence_penalty` | 2.0   |
+
+Do not use greedy decoding (`temperature: 0`) — it causes repetitions. `presence_penalty` above 1.5 can occasionally trigger language mixing on multilingual prompts.
+
+### Thinking mode (`enable_thinking: true`)
+
+**General tasks:**
+
+| Parameter          | Value |
+| ------------------ | ----- |
+| `temperature`      | 1.0   |
+| `top_p`            | 0.95  |
+| `top_k`            | 20    |
+| `presence_penalty` | 1.5   |
+
+**Coding and precise tasks:**
+
+| Parameter          | Value |
+| ------------------ | ----- |
+| `temperature`      | 0.6   |
+| `top_p`            | 0.95  |
+| `top_k`            | 20    |
+| `presence_penalty` | 0.0   |
+
+### Output length
+
+| Task type                              | Recommended `max_tokens` |
+| -------------------------------------- | ------------------------ |
+| Standard queries                       | 32,768                   |
+| Complex problems (math, step-by-step)  | 81,920                   |
+
+## Tips for specific tasks
+
+### Tool calling
+
+The model supports function calling using the Qwen3 XML format. Pass tools via the standard OpenAI `tools` parameter:
+
+```python
+response = client.chat.completions.create(
+    model="Qwen3.5-0.8B",
+    messages=[{"role": "user", "content": "What is the weather in Berlin?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }],
+    tool_choice="auto",
+    temperature=0.2,
+)
+```
+
+Use low temperature (`0.1–0.3`) for tool calls to reduce hallucinations.
+
+### Routing and classification
+
+The small size makes this model ideal as a first-pass classifier that decides which larger model handles a request:
+
+```python
+response = client.chat.completions.create(
+    model="Qwen3.5-0.8B",
+    messages=[
+        {
+            "role": "system",
+            "content": (
+                "Classify the following user message into exactly one category: "
+                "SIMPLE_QA, CODE, MATH, IMAGE_TASK. Respond with only the category name."
+            ),
+        },
+        {"role": "user", "content": user_message},
+    ],
+    temperature=0.1,
+    max_tokens=10,
+)
+category = response.choices[0].message.content.strip()
+```
+
+:::tip Guide ideas
+- **Cascade routing**: Use `Qwen3.5-0.8B` to classify query complexity (simple / code / math / vision), then route to the appropriate tier:
+  - Simple text → `Qwen3.5-0.8B` handles it directly
+  - Moderate → `Qwen3.6-35B-A3B-FP8` (reasoning + vision, mid cost)
+  - Complex / frontier → `Mistral-Medium-3.5-128B` or `Qwen3.5-122B-A10B-FP8`
+  - Vision only → `Ministral-3-14B-Instruct-2512` (cheapest vision model)
+
+  A well-tuned cascade can cut costs by 40–80% while maintaining quality on 95% of queries.
+- **Batch pre-processing**: Summarise, extract entities, or tag documents at scale before passing a curated subset to a heavier model.
+:::
+
+## Terms of use and licensing {#terms-of-use-and-licensing}
+
+The [general terms of use](../../access-and-usage/terms-of-use/) apply. The model is provided by Alibaba under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.html), and reuse of the generated content is not subject to any additional restrictions.

--- a/docs/platform/aihosting/30-models/index.mdx
+++ b/docs/platform/aihosting/30-models/index.mdx
@@ -13,6 +13,9 @@ We currently offer the following models, which may change or expand over time. E
 | whisper-large-v3-turbo             | Speech-to-Text            | Audio to text             | N/A (audio-based) | MIT        |
 | Qwen3.5-122B-A10B-FP8              | Chat + reasoning + vision | Text, image, tool-calling | 245,760           | Apache 2.0 |
 | Qwen3.6-35B-A3B-FP8               | Chat + reasoning + vision | Text, image, tool-calling | 262,144           | Apache 2.0 |
+| Qwen3.5-0.8B                       | Chat + reasoning          | Text, tool-calling        | 262,144           | Apache 2.0 |
+| Qwen3-VL-Reranker-2B               | Reranking                 | Text, image to score      | 32,768            | Apache 2.0 |
+| Mistral-Medium-3.5-128B            | Chat + vision             | Text, image, tool-calling | 256,000           | Apache 2.0 |
 
 ## Picking models {#picking-models}
 
@@ -22,6 +25,9 @@ We currently offer the following models, which may change or expand over time. E
 - Use `whisper-large-v3-turbo` for any audio transcription or voice-command needs.
 - Use `Qwen3.5-122B-A10B-FP8` for large-scale reasoning and vision tasks where high model capacity is required.
 - Use `Qwen3.6-35B-A3B-FP8` for workloads that require long context windows with reasoning and vision support at lower cost.
+- Use `Qwen3.5-0.8B` for high-throughput, cost-sensitive tasks that don't require vision — simple Q&A, routing, classification, and batch processing.
+- Use `Qwen3-VL-Reranker-2B` to improve RAG retrieval precision by adding it as a second-pass reranker after vector search.
+- Use `Mistral-Medium-3.5-128B` for complex reasoning, multilingual tasks, or vision workloads where a large frontier model is required.
 
 :::tip
 For optimal ROI, start with the smallest model that meets your quality bar—then upgrade *only* where you need additional depth or reliability!

--- a/docs/platform/aihosting/50-examples/50-cascade-routing.mdx
+++ b/docs/platform/aihosting/50-examples/50-cascade-routing.mdx
@@ -12,13 +12,13 @@ This guide builds a three-tier cascade on mittwald AI Hosting using only the `op
 | ---- | ----- | ----------- |
 | 1 — fast | `Qwen3.5-0.8B` | Simple lookups, yes/no, short factual answers |
 | 2 — balanced | `Qwen3.6-35B-A3B-FP8` | Multi-step reasoning, code, comparison |
-| 3 — frontier | `Mistral-Medium-3.5-128B` | Complex analysis, vision, long documents, 40+ languages |
+| 3 — frontier | `Mistral-Medium-3.5-128B` | Complex analysis, long documents, 40+ languages |
 
 For tier 3 you can swap in any large model depending on your workload:
 
 | Tier-3 alternative | Strengths |
 | ------------------ | --------- |
-| `Mistral-Medium-3.5-128B` | 40+ languages, vision, 256k context |
+| `Mistral-Medium-3.5-128B` | 40+ languages, 256k context |
 | `Qwen3.5-122B-A10B-FP8` | Thinking mode, vision, strong coding |
 | `gpt-oss-120b` | Text-centric reasoning, 131k context |
 
@@ -42,7 +42,7 @@ from openai import OpenAI
 client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
 
 # Swap the tier-3 model to match your workload:
-#   "Mistral-Medium-3.5-128B"  — vision, 40+ languages, 256k context
+#   "Mistral-Medium-3.5-128B"  — 40+ languages, 256k context
 #   "Qwen3.5-122B-A10B-FP8"   — thinking mode, vision, strong coding
 #   "gpt-oss-120b"             — text-centric reasoning, 131k context
 TIERS = {
@@ -57,7 +57,7 @@ Classify the complexity of the user's question with exactly one word: simple, mo
 simple   — factual lookup, yes/no, basic definition, short translation
 moderate — multi-step reasoning, code with explanation, structured comparison
 complex  — research-level analysis, multi-file code review, long-document synthesis,
-           vision + reasoning combined, or anything requiring deep domain knowledge
+           or anything requiring deep domain knowledge
 
 Reply with only the single classification word and nothing else."""
 

--- a/docs/platform/aihosting/50-examples/50-cascade-routing.mdx
+++ b/docs/platform/aihosting/50-examples/50-cascade-routing.mdx
@@ -1,0 +1,181 @@
+---
+sidebar_label: LLM cascade routing
+description: Route queries across three model tiers to cut costs while preserving quality
+title: LLM cascade routing
+---
+
+Serving every request with a large frontier model is accurate but expensive. Routing cheap queries to a small model and reserving the large model for genuinely hard requests typically cuts cost by 40–80% with less than 1% quality loss.
+
+This guide builds a three-tier cascade on mittwald AI Hosting using only the `openai` package:
+
+| Tier | Model | When to use |
+| ---- | ----- | ----------- |
+| 1 — fast | `Qwen3.5-0.8B` | Simple lookups, yes/no, short factual answers |
+| 2 — balanced | `Qwen3.6-35B-A3B-FP8` | Multi-step reasoning, code, comparison |
+| 3 — frontier | `Mistral-Medium-3.5-128B` | Complex analysis, vision, long documents, 40+ languages |
+
+For tier 3 you can swap in any large model depending on your workload:
+
+| Tier-3 alternative | Strengths |
+| ------------------ | --------- |
+| `Mistral-Medium-3.5-128B` | 40+ languages, vision, 256k context |
+| `Qwen3.5-122B-A10B-FP8` | Thinking mode, vision, strong coding |
+| `gpt-oss-120b` | Text-centric reasoning, 131k context |
+
+See the model pages for parameter details: [Qwen3.5-0.8B](/docs/v2/platform/aihosting/models/qwen3-5-0-8b), [Qwen3.6-35B-A3B-FP8](/docs/v2/platform/aihosting/models/qwen3-6-35b-a3b-fp8), [Mistral-Medium-3.5-128B](/docs/v2/platform/aihosting/models/mistral-medium-3-5-128b), [Qwen3.5-122B-A10B-FP8](/docs/v2/platform/aihosting/models/qwen3-5-122b-a10b-fp8).
+
+## Setup {#setup}
+
+```shellsession
+user@local $ pip install openai
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+## The router {#router}
+
+The router sends each query to `Qwen3.5-0.8B` and asks it to classify complexity in one word. Because the classifier output is just a single token (`simple`, `moderate`, or `complex`), the cost is negligible — typically less than 0.1% of the total spend.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+# Swap the tier-3 model to match your workload:
+#   "Mistral-Medium-3.5-128B"  — vision, 40+ languages, 256k context
+#   "Qwen3.5-122B-A10B-FP8"   — thinking mode, vision, strong coding
+#   "gpt-oss-120b"             — text-centric reasoning, 131k context
+TIERS = {
+    "simple":   "Qwen3.5-0.8B",
+    "moderate": "Qwen3.6-35B-A3B-FP8",
+    "complex":  "Mistral-Medium-3.5-128B",
+}
+
+CLASSIFIER_SYSTEM = """\
+Classify the complexity of the user's question with exactly one word: simple, moderate, or complex.
+
+simple   — factual lookup, yes/no, basic definition, short translation
+moderate — multi-step reasoning, code with explanation, structured comparison
+complex  — research-level analysis, multi-file code review, long-document synthesis,
+           vision + reasoning combined, or anything requiring deep domain knowledge
+
+Reply with only the single classification word and nothing else."""
+
+
+def classify(query: str) -> str:
+    resp = client.chat.completions.create(
+        model="Qwen3.5-0.8B",
+        messages=[
+            {"role": "system", "content": CLASSIFIER_SYSTEM},
+            {"role": "user", "content": query},
+        ],
+        temperature=0.0,
+        max_tokens=5,
+    )
+    label = resp.choices[0].message.content.strip().lower()
+    return label if label in TIERS else "moderate"
+
+
+def answer(query: str, model: str, **kwargs) -> str:
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": query}],
+        temperature=0.7,
+        **kwargs,
+    )
+    return resp.choices[0].message.content
+
+
+def cascade(query: str) -> dict:
+    tier = classify(query)
+    model = TIERS[tier]
+    text = answer(query, model)
+    return {"tier": tier, "model": model, "answer": text}
+```
+
+## Usage {#usage}
+
+```python
+queries = [
+    "What is the capital of France?",                                    # simple
+    "Write a Python function that merges two sorted lists.",             # moderate
+    "Analyse the architectural tradeoffs between event-driven and "
+    "request-response patterns for a high-volume payment system.",       # complex
+]
+
+for q in queries:
+    result = cascade(q)
+    print(f"[{result['tier']:8s}] {result['model']}")
+    print(f"  Q: {q[:70]}")
+    print(f"  A: {result['answer'][:120]}\n")
+```
+
+Expected output:
+
+```
+[simple  ] Qwen3.5-0.8B
+  Q: What is the capital of France?
+  A: Paris.
+
+[moderate] Qwen3.6-35B-A3B-FP8
+  Q: Write a Python function that merges two sorted lists.
+  A: def merge_sorted(a, b): ...
+
+[complex ] Mistral-Medium-3.5-128B
+  Q: Analyse the architectural tradeoffs between event-driven and request-response…
+  A: Event-driven architectures decouple producers from consumers…
+```
+
+## Escalation on short answers {#escalation}
+
+Some queries are deceptively classified as `simple` but the small model returns an unhelpfully brief answer. Add a word-count guard to automatically escalate:
+
+```python
+def cascade_with_escalation(query: str, min_words: int = 20) -> dict:
+    tier = classify(query)
+    model = TIERS[tier]
+    text = answer(query, model)
+
+    # Escalate if answer is suspiciously short and a bigger tier exists
+    tiers = list(TIERS.keys())
+    current_idx = tiers.index(tier)
+    while len(text.split()) < min_words and current_idx < len(tiers) - 1:
+        current_idx += 1
+        tier = tiers[current_idx]
+        model = TIERS[tier]
+        text = answer(query, model)
+
+    return {"tier": tier, "model": model, "answer": text}
+```
+
+## System prompt passthrough {#system-prompt}
+
+To add a system prompt (e.g. for a customer service persona), pass it through to whichever tier handles the query:
+
+```python
+SYSTEM = "You are a concise support agent for mittwald. Answer in the user's language."
+
+def cascade_with_system(query: str) -> dict:
+    tier = classify(query)
+    model = TIERS[tier]
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": SYSTEM},
+            {"role": "user", "content": query},
+        ],
+        temperature=0.7,
+    )
+    return {"tier": tier, "model": model, "answer": resp.choices[0].message.content}
+```
+
+:::tip Cost estimate
+With a typical support workload (70% simple, 20% moderate, 10% complex) and 100k requests/month at 300 tokens average:
+
+| Scenario | Monthly cost |
+| -------- | ------------ |
+| All requests → Mistral-Medium | ~€30 |
+| Three-tier cascade | ~€8 |
+
+The classifier call costs less than €0.10 total and is not shown separately.
+:::

--- a/docs/platform/aihosting/50-examples/60-document-qa-pipeline.mdx
+++ b/docs/platform/aihosting/50-examples/60-document-qa-pipeline.mdx
@@ -1,0 +1,222 @@
+---
+sidebar_label: Document Q&A pipeline
+description: Four-stage pipeline — OCR → embedding → reranking → answer generation — using mittwald AI Hosting models
+title: Document Q&A pipeline
+---
+
+This guide builds a complete document question-answering pipeline using four mittwald AI Hosting models in sequence:
+
+| Stage | Model | What it does |
+| ----- | ----- | ------------ |
+| 1 — OCR | `GLM-OCR` | Extracts text from PDF, DOCX, PPTX, XLSX, images |
+| 2 — Embed | [Qwen3-Embedding-8B](/docs/v2/platform/aihosting/models/qwen3-embedding-8b) | Turns text chunks into vectors for similarity search |
+| 3 — Rerank | [Qwen3-VL-Reranker-2B](/docs/v2/platform/aihosting/models/qwen3-vl-reranker-2b) | Scores each candidate against the full question |
+| 4 — Answer | [Qwen3.5-122B-A10B-FP8](/docs/v2/platform/aihosting/models/qwen3-5-122b-a10b-fp8) | Generates a grounded answer with citations |
+
+The key advantage over a basic embed → retrieve → answer pipeline is **stage 3**: the reranker reads the actual question against each retrieved passage as a pair, catching relevant text that embedding similarity alone misses.
+
+## Setup {#setup}
+
+```shellsession
+user@local $ pip install openai requests pypdf
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+## Stage 1 — OCR: extract text from a document {#stage-ocr}
+
+Send the file as a Base64 data URI to `GLM-OCR`. The proxy on our platform automatically converts PDF pages and Office documents to images before the model processes them — no manual page splitting required (up to 30 pages per request). For full format support and limitations see the GLM-OCR model page.
+
+```python
+import base64
+import os
+import math
+import re
+import json
+import requests
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+MIME = {
+    "pdf":  "application/pdf",
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "jpg":  "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png":  "image/png",
+}
+
+
+def extract_text(path: str) -> str:
+    """Extract all text from a document using GLM-OCR."""
+    ext = path.rsplit(".", 1)[-1].lower()
+    mime = MIME.get(ext, "application/pdf")
+    with open(path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode()
+
+    resp = client.chat.completions.create(
+        model="GLM-OCR",
+        messages=[{
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{mime};base64,{b64}"},
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "Extract the text from this document and format it as Markdown. "
+                        "Use # for main headings, ## for subheadings, and - for bullet lists."
+                    ),
+                },
+            ],
+        }],
+        temperature=0.1,
+    )
+    return resp.choices[0].message.content
+```
+
+:::note
+For documents longer than 30 pages, split the PDF into batches first. See the [Python examples](/docs/v2/platform/aihosting/examples/python) for a `pypdf`-based batch splitter.
+:::
+
+## Stage 2 — Embed: chunk and index the text {#stage-embed}
+
+Chunk at Markdown headings first, then by word count so each chunk fits in the reranker's 32,768-token window.
+
+```python
+def chunk_text(text: str, size: int = 400, overlap: int = 50) -> list[str]:
+    """Split at top-level Markdown headings, then by word count with overlap."""
+    sections = re.split(r"(?m)^(?=# )", text)
+    chunks: list[str] = []
+    for section in sections:
+        words = section.split()
+        i = 0
+        while i < len(words):
+            chunks.append(" ".join(words[i: i + size]))
+            i += size - overlap
+    return [c for c in chunks if c.strip()]
+
+
+def embed(texts: list[str]) -> list[list[float]]:
+    resp = client.embeddings.create(model="Qwen3-Embedding-8B", input=texts)
+    return [item.embedding for item in resp.data]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    norm = math.sqrt(sum(x * x for x in a)) * math.sqrt(sum(x * x for x in b))
+    return dot / (norm + 1e-9)
+
+
+def build_index(path: str) -> list[tuple[list[float], str]]:
+    """OCR the document, chunk it, and return an in-memory vector index."""
+    text = extract_text(path)
+    chunks = chunk_text(text)
+    vectors = embed(chunks)
+    return list(zip(vectors, chunks))
+
+
+def retrieve(query: str, index: list, top_k: int = 10) -> list[str]:
+    """Return top_k chunks by cosine similarity."""
+    [q_vec] = embed([query])
+    scored = [(cosine(q_vec, vec), chunk) for vec, chunk in index]
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [chunk for _, chunk in scored[:top_k]]
+```
+
+## Stage 3 — Rerank: precision pass {#stage-rerank}
+
+The reranker reads each (question, passage) pair as a whole and assigns a relevance score. Fetch a wider candidate set (top-10) so it has enough to work with, then narrow down to top-3.
+
+```python
+def rerank(query: str, candidates: list[str], top_k: int = 3) -> list[str]:
+    resp = requests.post(
+        "https://llm.aihosting.mittwald.de/v1/rerank",
+        headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+        json={
+            "model": "Qwen3-VL-Reranker-2B",
+            "query": query,
+            "documents": candidates,
+            "instruction": "Given a document question, find the passages most relevant to answering it.",
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+    results = resp.json()["results"]
+    ranked = sorted(results, key=lambda r: r["relevance_score"], reverse=True)
+    return [candidates[r["index"]] for r in ranked[:top_k]]
+```
+
+## Stage 4 — Answer: grounded generation {#stage-answer}
+
+Pass the reranked context to `Qwen3.5-122B-A10B-FP8` with thinking disabled for speed. The model is instructed to cite `[Passage N]` so answers are traceable.
+
+```python
+def answer(question: str, passages: list[str]) -> str:
+    context = "\n\n".join(f"[Passage {i+1}]\n{p}" for i, p in enumerate(passages))
+    resp = client.chat.completions.create(
+        model="Qwen3.5-122B-A10B-FP8",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Answer the question using only the provided passages. "
+                    "Cite sources as [Passage N]. "
+                    "If the answer is not in the passages, say so explicitly."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Passages:\n{context}\n\nQuestion: {question}",
+            },
+        ],
+        temperature=0.7,
+        top_p=0.8,
+        max_tokens=1024,
+        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+    )
+    return resp.choices[0].message.content
+```
+
+## Full pipeline {#full-pipeline}
+
+```python
+def document_qa(doc_path: str, question: str) -> str:
+    index = build_index(doc_path)
+    candidates = retrieve(question, index, top_k=10)
+    top_passages = rerank(question, candidates, top_k=3)
+    return answer(question, top_passages)
+
+
+# Example
+response = document_qa(
+    "annual_report.pdf",
+    "What were the main revenue drivers in the second quarter?",
+)
+print(response)
+```
+
+## Ingesting multiple documents {#multiple-documents}
+
+```python
+# Build one combined index from several documents
+documents = ["contract_a.pdf", "contract_b.docx", "appendix.xlsx"]
+
+combined_index: list[tuple[list[float], str]] = []
+for path in documents:
+    combined_index.extend(build_index(path))
+
+print(f"Indexed {len(combined_index)} chunks from {len(documents)} documents.")
+
+# Query across all documents
+candidates = retrieve("What are the penalty clauses?", combined_index, top_k=10)
+top_passages = rerank("What are the penalty clauses?", candidates, top_k=3)
+print(answer("What are the penalty clauses?", top_passages))
+```
+
+:::tip Scaling to production
+Replace the in-memory index with **pgvector** for persistent, multi-user storage. See the [n8n guide](/docs/v2/guides/apps/n8n/) for a ready-to-deploy Docker Compose stack with pgvector on mittwald Container Hosting.
+:::

--- a/docs/platform/aihosting/50-examples/70-multilingual-agent.mdx
+++ b/docs/platform/aihosting/50-examples/70-multilingual-agent.mdx
@@ -1,0 +1,199 @@
+---
+sidebar_label: Multilingual tool-calling agent
+description: Build a tool-calling agent that handles 40+ languages natively with Mistral-Medium-3.5-128B
+title: Multilingual tool-calling agent
+---
+
+The tool-calling agent pattern in this guide works with any chat model that supports function calling. The example uses [Mistral-Medium-3.5-128B](/docs/v2/platform/aihosting/models/mistral-medium-3-5-128b), but you can substitute any of the following depending on cost and quality requirements:
+
+| Model | Languages | Notes |
+| ----- | --------- | ----- |
+| `Mistral-Medium-3.5-128B` | 40+ | Best multilingual quality; vision support |
+| `Qwen3.5-122B-A10B-FP8` | 100+ | Thinking mode available; vision support |
+| `Qwen3.6-35B-A3B-FP8` | 100+ | More cost-efficient; reasoning + vision |
+| `gpt-oss-120b` | English-centric | Best for English-only workloads |
+
+All models use the same OpenAI-compatible tool-calling API — changing the model is a single line swap.
+
+This guide shows a complete agentic loop: the model decides which tools to call, you execute them, and you feed the results back until the model has everything it needs.
+
+## Setup {#setup}
+
+```shellsession
+user@local $ pip install openai
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+## Define tools {#define-tools}
+
+Tool names and descriptions are always written in **English**. The model maps any user language onto the correct tool automatically.
+
+```python
+import os
+import json
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_exchange_rate",
+            "description": "Get the current exchange rate between two currencies.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "from_currency": {
+                        "type": "string",
+                        "description": "ISO 4217 source currency code, e.g. EUR",
+                    },
+                    "to_currency": {
+                        "type": "string",
+                        "description": "ISO 4217 target currency code, e.g. USD",
+                    },
+                },
+                "required": ["from_currency", "to_currency"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_order_status",
+            "description": "Return the status and estimated delivery date for a customer order.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "order_id": {
+                        "type": "string",
+                        "description": "The order identifier, e.g. ORD-12345",
+                    },
+                },
+                "required": ["order_id"],
+            },
+        },
+    },
+]
+```
+
+## Implement tool functions {#implement-tools}
+
+Replace these stubs with real database lookups or API calls:
+
+```python
+def get_exchange_rate(from_currency: str, to_currency: str) -> dict:
+    # Stub — replace with a live FX API
+    rates = {
+        ("EUR", "USD"): 1.08,
+        ("USD", "EUR"): 0.93,
+        ("GBP", "EUR"): 1.17,
+        ("EUR", "GBP"): 0.85,
+    }
+    rate = rates.get((from_currency.upper(), to_currency.upper()))
+    if rate is None:
+        return {"error": f"No rate available for {from_currency}/{to_currency}"}
+    return {"from": from_currency, "to": to_currency, "rate": rate}
+
+
+def get_order_status(order_id: str) -> dict:
+    # Stub — replace with a real order DB query
+    orders = {
+        "ORD-12345": {"status": "shipped",    "delivery": "2026-06-04"},
+        "ORD-99999": {"status": "processing", "delivery": "2026-06-07"},
+    }
+    order = orders.get(order_id.upper())
+    if order is None:
+        return {"error": f"Order {order_id} not found"}
+    return {"order_id": order_id, **order}
+
+
+FUNCTIONS = {
+    "get_exchange_rate": get_exchange_rate,
+    "get_order_status":  get_order_status,
+}
+```
+
+## The agent loop {#agent-loop}
+
+The loop runs until the model stops requesting tool calls (`finish_reason != "tool_calls"`):
+
+```python
+def run_agent(user_message: str, system: str | None = None) -> str:
+    messages = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": user_message})
+
+    while True:
+        response = client.chat.completions.create(
+            model="Mistral-Medium-3.5-128B",
+            messages=messages,
+            tools=tools,
+            tool_choice="auto",
+            temperature=0.2,
+        )
+        msg = response.choices[0].message
+        messages.append(msg)
+
+        if response.choices[0].finish_reason != "tool_calls":
+            return msg.content
+
+        # Execute each requested tool and return results
+        for call in msg.tool_calls:
+            args = json.loads(call.function.arguments)
+            result = FUNCTIONS[call.function.name](**args)
+            messages.append({
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": json.dumps(result),
+            })
+```
+
+## Test in multiple languages {#test-languages}
+
+```python
+queries = [
+    "Was ist der aktuelle EUR/USD-Wechselkurs?",          # German
+    "Quel est le taux de change EUR vers GBP?",           # French
+    "¿Cuál es el estado de mi pedido ORD-12345?",         # Spanish
+    "What is the status of order ORD-99999?",             # English
+    "Wie is de status van mijn bestelling ORD-12345?",    # Dutch
+]
+
+for q in queries:
+    print(f"Q: {q}")
+    print(f"A: {run_agent(q)}\n")
+```
+
+The model answers in the same language the user wrote in, without any explicit language detection or translation in your code.
+
+## Adding a persona via system prompt {#persona}
+
+```python
+SYSTEM = (
+    "You are a friendly customer support agent for mittwald. "
+    "Always reply in the same language the user writes in. "
+    "Be concise and professional."
+)
+
+answer = run_agent("Mein Paket ORD-12345 — wann kommt es an?", system=SYSTEM)
+print(answer)
+# "Ihr Paket ORD-12345 ist bereits versandt und wird voraussichtlich am 4. Juni 2026 geliefert."
+```
+
+## Parallel tool calls {#parallel-tools}
+
+When the user asks a question that requires multiple tools at once, the model may return several `tool_calls` in a single response. The loop above already handles this correctly — it iterates over all calls before making the next model request.
+
+```python
+# This query triggers both tools in one shot
+answer = run_agent(
+    "What is the EUR/USD rate and what is the status of order ORD-12345?"
+)
+print(answer)
+```
+
+:::note
+Tool definitions must be in English for best results across languages. The model reliably maps non-English queries to English-named functions regardless of the user's language.
+:::

--- a/docs/platform/aihosting/50-examples/70-multilingual-agent.mdx
+++ b/docs/platform/aihosting/50-examples/70-multilingual-agent.mdx
@@ -8,7 +8,7 @@ The tool-calling agent pattern in this guide works with any chat model that supp
 
 | Model | Languages | Notes |
 | ----- | --------- | ----- |
-| `Mistral-Medium-3.5-128B` | 40+ | Best multilingual quality; vision support |
+| `Mistral-Medium-3.5-128B` | 40+ | Best multilingual quality |
 | `Qwen3.5-122B-A10B-FP8` | 100+ | Thinking mode available; vision support |
 | `Qwen3.6-35B-A3B-FP8` | 100+ | More cost-efficient; reasoning + vision |
 | `gpt-oss-120b` | English-centric | Best for English-only workloads |

--- a/docs/platform/aihosting/50-examples/80-multimodal-search.mdx
+++ b/docs/platform/aihosting/50-examples/80-multimodal-search.mdx
@@ -1,0 +1,190 @@
+---
+sidebar_label: Multimodal product search
+description: Index product images and descriptions, then rerank results with Qwen3-VL-Reranker-2B
+title: Multimodal product search
+---
+
+Standard keyword and vector search works well for text, but product catalogues contain images. [Qwen3-VL-Reranker-2B](/docs/v2/platform/aihosting/models/qwen3-vl-reranker-2b) can score a query against documents that contain both text and images, giving you richer relevance signals than text alone.
+
+This guide builds a catalogue search that:
+1. Embeds product descriptions with [Qwen3-Embedding-8B](/docs/v2/platform/aihosting/models/qwen3-embedding-8b) for fast candidate retrieval
+2. Reranks the top candidates using `Qwen3-VL-Reranker-2B` with product images included
+
+## Setup {#setup}
+
+```shellsession
+user@local $ pip install openai requests
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+## Catalogue structure
+
+Each product has a text description and an image (Base64-encoded JPEG). Always resize images to a maximum of 1024 px on the longest edge before encoding — large images increase latency without improving ranking quality.
+
+```python
+import os
+import base64
+import math
+import requests
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+def encode_image(path: str) -> str:
+    """Return a Base64 data URI for a JPEG image."""
+    with open(path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode()
+    return f"data:image/jpeg;base64,{b64}"
+
+
+# Example catalogue — replace image paths and descriptions with your actual data
+CATALOGUE = [
+    {
+        "id": "DESK-01",
+        "description": "Standing desk, dark walnut top, adjustable height 70–120 cm, 160×80 cm surface",
+        "image": "products/desk_walnut.jpg",
+    },
+    {
+        "id": "CHAIR-07",
+        "description": "Ergonomic office chair, mesh back, lumbar support, armrests, black",
+        "image": "products/chair_black.jpg",
+    },
+    {
+        "id": "LAMP-03",
+        "description": "LED desk lamp, warm white, USB-C charging port, touch dimmer, white",
+        "image": "products/lamp_white.jpg",
+    },
+    {
+        "id": "SHELF-12",
+        "description": "Floating wall shelf, solid oak, 80 cm, load capacity 25 kg",
+        "image": "products/shelf_oak.jpg",
+    },
+]
+```
+
+## Step 1 — Build an embedding index {#build-index}
+
+Use `Qwen3-Embedding-8B` to embed descriptions for fast first-pass retrieval. See the [Python examples](/docs/v2/platform/aihosting/examples/python) for the full embedding setup.
+
+```python
+def embed(texts: list[str]) -> list[list[float]]:
+    resp = client.embeddings.create(model="Qwen3-Embedding-8B", input=texts)
+    return [item.embedding for item in resp.data]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    norm = math.sqrt(sum(x * x for x in a)) * math.sqrt(sum(x * x for x in b))
+    return dot / (norm + 1e-9)
+
+
+# Build index at startup — run this before calling retrieve() or search()
+descriptions = [p["description"] for p in CATALOGUE]
+index_vectors = embed(descriptions)
+```
+
+## Step 2 — Retrieve candidates by embedding similarity {#retrieve}
+
+```python
+def retrieve(query: str, top_k: int = 10) -> list[dict]:
+    """Return top_k products by cosine similarity to the query."""
+    [q_vec] = embed([query])
+    scored = [
+        (cosine(q_vec, vec), product)
+        for vec, product in zip(index_vectors, CATALOGUE)
+    ]
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [product for _, product in scored[:top_k]]
+```
+
+## Step 3 — Rerank with images {#rerank}
+
+`Qwen3-VL-Reranker-2B` accepts multimodal documents. Pass each candidate as a content list containing the text description **and** the product image. This lets the reranker catch visual signals (colour, shape, style) that the text description may not fully capture.
+
+```python
+def rerank(
+    query: str,
+    candidates: list[dict],
+    top_k: int = 3,
+    instruction: str | None = None,
+) -> list[dict]:
+    """Rerank candidates using text + image content."""
+    documents = []
+    for product in candidates:
+        content = [
+            {"type": "text", "text": product["description"]},
+            {
+                "type": "image_url",
+                "image_url": {"url": encode_image(product["image"])},
+            },
+        ]
+        documents.append({"content": content})
+
+    payload: dict = {
+        "model": "Qwen3-VL-Reranker-2B",
+        "query": query,
+        "documents": documents,
+    }
+    if instruction:
+        payload["instruction"] = instruction
+
+    resp = requests.post(
+        "https://llm.aihosting.mittwald.de/v1/rerank",
+        headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+        json=payload,
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+    results = resp.json()["results"]
+    ranked = sorted(results, key=lambda r: r["relevance_score"], reverse=True)
+    return [candidates[r["index"]] for r in ranked[:top_k]]
+```
+
+## Complete search pipeline {#search-pipeline}
+
+```python
+def search(query: str, top_k: int = 3) -> list[dict]:
+    candidates = retrieve(query, top_k=min(10, len(CATALOGUE)))
+    return rerank(
+        query,
+        candidates,
+        top_k=top_k,
+        instruction="Given a product search query, find the most visually and functionally relevant items.",
+    )
+
+
+# Example queries
+for query in [
+    "dark wood desk for a home office",
+    "white lamp with USB charging",
+    "ergonomic seating for long work sessions",
+]:
+    results = search(query)
+    print(f"\nQuery: {query}")
+    for i, product in enumerate(results, 1):
+        print(f"  {i}. [{product['id']}] {product['description'][:70]}")
+```
+
+## Text-only reranking {#text-only}
+
+If you don't have images, omit the image content and pass plain strings:
+
+```python
+def rerank_text_only(query: str, candidates: list[dict], top_k: int = 3) -> list[dict]:
+    documents = [p["description"] for p in candidates]
+    resp = requests.post(
+        "https://llm.aihosting.mittwald.de/v1/rerank",
+        headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+        json={"model": "Qwen3-VL-Reranker-2B", "query": query, "documents": documents},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    results = resp.json()["results"]
+    ranked = sorted(results, key=lambda r: r["relevance_score"], reverse=True)
+    return [candidates[r["index"]] for r in ranked[:top_k]]
+```
+
+:::tip
+Always write the `instruction` value in **English**, even when the search query is in another language. See the [Qwen3-VL-Reranker-2B model page](/docs/v2/platform/aihosting/models/qwen3-vl-reranker-2b) for details on instruction format and image size limits.
+:::

--- a/docs/platform/aihosting/50-examples/90-whisper.mdx
+++ b/docs/platform/aihosting/50-examples/90-whisper.mdx
@@ -1,0 +1,180 @@
+---
+sidebar_label: Speech-to-text with Whisper
+description: Transcribe audio files using whisper-large-v3-turbo via the OpenAI-compatible API
+title: Speech-to-text with Whisper
+---
+
+`whisper-large-v3-turbo` is accessible via the same `/v1/audio/transcriptions` endpoint as the OpenAI Whisper API, so any code written for OpenAI works as a drop-in replacement by changing `base_url`. See the [Whisper model page](/docs/v2/platform/aihosting/models/whisper-large-v3-turbo) for supported formats, language codes, and inference parameters.
+
+## Setup {#setup}
+
+```shellsession
+user@local $ pip install openai
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+For large-file chunking (files over 25 MB):
+
+```shellsession
+user@local $ pip install pydub
+# pydub requires ffmpeg
+user@local $ brew install ffmpeg          # macOS
+user@local $ apt-get install ffmpeg       # Debian/Ubuntu
+```
+
+## Basic transcription {#basic}
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+with open("recording.mp3", "rb") as f:
+    result = client.audio.transcriptions.create(
+        model="whisper-large-v3-turbo",
+        file=f,
+        language="en",             # Always set explicitly — default is "de"
+        response_format="json",
+        temperature=1.0,
+    )
+
+print(result.text)
+```
+
+:::warning Always set `language`
+If `language` is omitted, the model defaults to German (`"de"`). Transcribing English audio without setting `language="en"` will produce inaccurate results. See the [model page](/docs/v2/platform/aihosting/models/whisper-large-v3-turbo) for the full list of ISO-639-1 codes.
+:::
+
+## Multiple languages {#multiple-languages}
+
+```python
+files_and_languages = [
+    ("meeting_de.mp3", "de"),
+    ("interview_fr.wav", "fr"),
+    ("podcast_en.ogg", "en"),
+    ("lecture_ja.flac", "ja"),
+]
+
+for filename, lang in files_and_languages:
+    with open(filename, "rb") as f:
+        result = client.audio.transcriptions.create(
+            model="whisper-large-v3-turbo",
+            file=f,
+            language=lang,
+            response_format="json",
+            temperature=1.0,
+        )
+    print(f"[{lang}] {result.text[:120]}")
+```
+
+## Large files (> 25 MB) {#large-files}
+
+The API accepts files up to 25 MB. Split larger recordings at silence points using `pydub` so that each chunk is well under the limit and no words are cut mid-utterance:
+
+```python
+from pydub import AudioSegment
+from pydub.silence import split_on_silence
+from io import BytesIO
+
+
+def transcribe_large_file(path: str, language: str = "en") -> str:
+    """Transcribe a file of any size by splitting at silence points."""
+    audio = AudioSegment.from_file(path)
+
+    # Split at pauses longer than 700 ms with silence below -40 dBFS
+    chunks = split_on_silence(
+        audio,
+        min_silence_len=700,
+        silence_thresh=-40,
+        keep_silence=300,   # Keep 300 ms of silence at each edge for context
+    )
+
+    # Guard: if no silence found, fall back to fixed 60-second chunks
+    if not chunks:
+        chunk_ms = 60_000
+        chunks = [audio[i: i + chunk_ms] for i in range(0, len(audio), chunk_ms)]
+
+    transcripts: list[str] = []
+    for chunk in chunks:
+        buf = BytesIO()
+        chunk.export(buf, format="mp3")
+        buf.seek(0)
+        buf.name = "chunk.mp3"   # openai SDK reads the .name attribute for MIME type
+
+        result = client.audio.transcriptions.create(
+            model="whisper-large-v3-turbo",
+            file=buf,
+            language=language,
+            response_format="json",
+            temperature=1.0,
+        )
+        transcripts.append(result.text)
+
+    return " ".join(transcripts)
+
+
+full_text = transcribe_large_file("long_interview.mp3", language="de")
+print(full_text)
+```
+
+## Transcription + summarisation pipeline {#transcription-pipeline}
+
+Chain Whisper with a chat model to go directly from audio to a written summary:
+
+```python
+def transcribe_and_summarise(audio_path: str, language: str = "en") -> dict:
+    # Step 1: transcribe
+    with open(audio_path, "rb") as f:
+        result = client.audio.transcriptions.create(
+            model="whisper-large-v3-turbo",
+            file=f,
+            language=language,
+            response_format="json",
+            temperature=1.0,
+        )
+    transcript = result.text
+
+    # Step 2: summarise
+    summary_resp = client.chat.completions.create(
+        model="Qwen3.6-35B-A3B-FP8",
+        messages=[
+            {
+                "role": "system",
+                "content": "Summarise the transcript concisely. Use bullet points for key topics.",
+            },
+            {"role": "user", "content": transcript},
+        ],
+        temperature=0.7,
+        max_tokens=512,
+        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+    )
+
+    return {
+        "transcript": transcript,
+        "summary": summary_resp.choices[0].message.content,
+    }
+
+
+output = transcribe_and_summarise("team_standup.mp3", language="en")
+print("Transcript:\n", output["transcript"])
+print("\nSummary:\n", output["summary"])
+```
+
+## Drop-in replacement for OpenAI {#openai-replacement}
+
+Existing code written for the OpenAI Whisper API requires only a `base_url` change:
+
+```python
+# Before (OpenAI)
+client = OpenAI()
+
+# After (mittwald AI Hosting)
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+```
+
+All other code — file handling, `response_format`, `language`, `temperature` — stays identical.
+
+:::note Unsupported formats
+The `response_format` values `srt`, `vtt`, and `verbose_json` are not currently supported. Use `json` (default) or `text`.
+:::

--- a/docs/platform/aihosting/50-examples/90-whisper.mdx
+++ b/docs/platform/aihosting/50-examples/90-whisper.mdx
@@ -175,6 +175,27 @@ client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
 
 All other code — file handling, `response_format`, `language`, `temperature` — stays identical.
 
+## Timestamps and language detection with verbose_json {#verbose-json}
+
+`response_format="verbose_json"` returns per-segment timestamps, detected language, and total duration:
+
+```python
+with open("recording.mp3", "rb") as f:
+    result = client.audio.transcriptions.create(
+        model="whisper-large-v3-turbo",
+        file=f,
+        language="en",
+        response_format="verbose_json",
+        temperature=1.0,
+    )
+
+print(result.text)
+print(f"Language: {result.language}")
+print(f"Duration: {result.duration}s")
+for seg in (result.segments or []):
+    print(f"  [{seg['start']:.1f}s–{seg['end']:.1f}s] {seg['text']}")
+```
+
 :::note Unsupported formats
-The `response_format` values `srt`, `vtt`, and `verbose_json` are not currently supported. Use `json` (default) or `text`.
+`srt` and `vtt` are not supported (HTTP 400). `response_format="text"` is accepted but returns a JSON body regardless — use `"json"` or `"verbose_json"` instead.
 :::

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/100-qwen3-vl-reranker-2b.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/100-qwen3-vl-reranker-2b.mdx
@@ -119,7 +119,7 @@ response = requests.post(
         "model": "Qwen3-VL-Reranker-2B",
         "query": "Gesamtbetrag dieser Rechnung",
         "documents": abschnitte,
-        "instruction": "Gegeben eine OCR-extrahierte Rechnung, finde Abschnitte mit Zahlungsbeträgen oder Gesamtsummen.",
+        "instruction": "Given an OCR-extracted invoice, find sections containing payment amounts or totals.",
     },
     timeout=30,
 )

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/100-qwen3-vl-reranker-2b.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/100-qwen3-vl-reranker-2b.mdx
@@ -1,0 +1,168 @@
+---
+sidebar_label: Qwen3-VL-Reranker-2B
+description: Detaillierte Informationen zu Qwen3-VL-Reranker-2B
+title: Qwen3-VL-Reranker-2B
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Beschreibung
+
+„Qwen3-VL-Reranker-2B" ist ein vision-sprachliches Cross-Encoder-Reranking-Modell von Alibaba. Zu einer Anfrage und einer Liste von Kandidatendokumenten bewertet es jedes (Anfrage, Dokument)-Paar nach semantischer Relevanz und gibt eine geordnete Liste zurück. Sowohl die Anfrage als auch die Dokumente können Bilder enthalten, wodurch es für multimodale RAG-Pipelines geeignet ist.
+
+Geeignet für und unterstützt:
+
+- Neugewichtung von Textkandidaten aus einem Vektorindex (RAG-Pipelines)
+- Neugewichtung von Dokumenten, die Bilder enthalten
+- Verbesserung der Retrievalpräzision als zweiter Schritt nach Embedding-basierter Suche
+- Bewertung der Anfrage-Dokument-Relevanz für beliebige Ranking-Aufgaben
+
+Folgende Einschränkungen gelten:
+
+- Nur über `/v1/rerank` zugänglich – nicht über `/v1/chat/completions`
+- Maximale Kontextlänge pro (Anfrage + Dokument)-Paar: 32.768 Token
+- Maximale Bilder pro Anfrage: 5; maximale Videos: 1
+- Maximale Bildgröße: 1.310.720 Pixel – größere Bilder werden proportional skaliert (1 Token pro 32 × 32 Pixel)
+- Kein Streaming – alle Scores werden in einer einzigen Antwort zurückgegeben
+- Nicht für Textgenerierung, Tool-Calling oder Konversation
+- `instruction`-Werte sollten immer auf **Englisch** verfasst werden, auch bei mehrsprachigen Dokumenten – der Großteil der Trainingsdaten ist englischsprachig
+
+## API-Nutzung
+
+Qwen3-VL-Reranker-2B ist über den **`/v1/rerank`**-Endpunkt verfügbar, der dem Cohere-kompatiblen Reranking-API-Format folgt.
+
+### Basis-Reranking
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python">
+
+```python
+import os
+import requests
+
+response = requests.post(
+    "https://llm.aihosting.mittwald.de/v1/rerank",
+    headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+    json={
+        "model": "Qwen3-VL-Reranker-2B",
+        "query": "Was sind die Zahlungsbedingungen?",
+        "documents": [
+            "Zahlung ist innerhalb von 30 Tagen nach Rechnungsstellung fällig.",
+            "Der Lieferant muss die Ware innerhalb von 14 Werktagen liefern.",
+            "Verspätete Zahlungen werden mit 2 % monatlichem Aufschlag berechnet.",
+        ],
+    },
+    timeout=30,
+)
+response.raise_for_status()
+
+for result in sorted(response.json()["results"], key=lambda r: r["relevance_score"], reverse=True):
+    print(f"[{result['relevance_score']:.3f}] index={result['index']}")
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+
+```ts
+const response = await fetch(
+  "https://llm.aihosting.mittwald.de/v1/rerank",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: "Qwen3-VL-Reranker-2B",
+      query: "Was sind die Zahlungsbedingungen?",
+      documents: [
+        "Zahlung ist innerhalb von 30 Tagen nach Rechnungsstellung fällig.",
+        "Der Lieferant muss die Ware innerhalb von 14 Werktagen liefern.",
+        "Verspätete Zahlungen werden mit 2 % monatlichem Aufschlag berechnet.",
+      ],
+    }),
+  }
+);
+
+const { results } = await response.json();
+const ranked = results.sort((a, b) => b.relevance_score - a.relevance_score);
+console.log(ranked);
+```
+
+  </TabItem>
+</Tabs>
+
+### Antwortformat
+
+```json
+{
+  "results": [
+    { "index": 0, "relevance_score": 0.912 },
+    { "index": 2, "relevance_score": 0.874 },
+    { "index": 1, "relevance_score": 0.031 }
+  ]
+}
+```
+
+`index` ist die Position im ursprünglichen `documents`-Array. `relevance_score` ist ein Float zwischen 0 und 1 – höher bedeutet relevanter.
+
+### Benutzerdefinierte Anweisung
+
+Das optionale `instruction`-Feld teilt dem Modell mit, für welche Retrievalaufgabe es optimieren soll. Ohne Angabe wird ein generischer Standard verwendet (`"Given a search query, retrieve relevant candidates that answer the query."`):
+
+```python
+response = requests.post(
+    "https://llm.aihosting.mittwald.de/v1/rerank",
+    headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+    json={
+        "model": "Qwen3-VL-Reranker-2B",
+        "query": "Gesamtbetrag dieser Rechnung",
+        "documents": abschnitte,
+        "instruction": "Gegeben eine OCR-extrahierte Rechnung, finde Abschnitte mit Zahlungsbeträgen oder Gesamtsummen.",
+    },
+    timeout=30,
+)
+```
+
+Domänenspezifische Anweisungen verbessern die Präzision bei spezialisierten Korpora (Recht, Medizin, Finanzen) um 1–5 %. Die Anweisung immer auf **Englisch** formulieren – auch bei nicht-englischen Dokumenten.
+
+## Integration in eine RAG-Pipeline
+
+Verwende den Reranker als zweiten Schritt nach der Vektorsuche. Hole zunächst mehr Kandidaten aus dem Index, schränke dann ein:
+
+```python
+import math
+
+def kosinus(a, b):
+    skalar = sum(x * y for x, y in zip(a, b))
+    norm = math.sqrt(sum(x**2 for x in a)) * math.sqrt(sum(x**2 for x in b))
+    return skalar / (norm + 1e-9)
+
+# Schritt 1: Grob-Retrieval via Embedding-Ähnlichkeit (Top 10)
+anfrage_vektor = einbetten([anfrage])[0]
+kandidaten = sorted(index, key=lambda v_c: kosinus(anfrage_vektor, v_c[0]), reverse=True)[:10]
+kandidaten_texte = [c for _, c in kandidaten]
+
+# Schritt 2: Präzises Reranking (Top 3)
+resp = requests.post(
+    "https://llm.aihosting.mittwald.de/v1/rerank",
+    headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+    json={"model": "Qwen3-VL-Reranker-2B", "query": anfrage, "documents": kandidaten_texte},
+    timeout=30,
+)
+sortiert = sorted(resp.json()["results"], key=lambda r: r["relevance_score"], reverse=True)
+beste_abschnitte = [kandidaten_texte[r["index"]] for r in sortiert[:3]]
+```
+
+Du kannst GLM-OCR für Textextraktion, Qwen3-Embedding-8B für die Indizierung, Qwen3-VL-Reranker-2B für das Reranking und ein Chat-Modell für die Antwortgenerierung zusammenschalten. Dies ergibt eine vollständige Dokumenten-Frage-Antwort-Pipeline.
+
+:::tip Guide-Ideen
+- **Zweistufige Text-RAG**: Einbetten → Top-10-Kandidaten → Reranking auf Top-3. Die Cross-Attention des Rerankers über das vollständige (Anfrage, Dokument)-Paar erfasst Relevanzsignale, die die reine Embedding-Ähnlichkeit übersieht.
+- **Multimodale Produktsuche**: Produktbilder zusammen mit ihren Beschreibungen indizieren; Ergebnisse für Anfragen wie „dunkel gebeizte Holz-Arbeitsfläche für kleines Home Office" anhand von Text- und Bildinhalt neu ordnen.
+- **Dokument-Q&A-Präzision**: Kombination mit GLM-OCR (Textextraktion), Qwen3-Embedding-8B (Indizierung) und einem Chat-Modell (Antwortgenerierung) ergibt eine vierstufige Pipeline, bei der der Reranker die Kontextqualität vor dem teuren Generierungsschritt maximiert.
+:::
+
+## Nutzungsbedingungen und Lizenzhinweise {#nutzungsbedingungen-und-lizenzhinweise}
+
+Es gelten die [allgemeinen Nutzungsbedingungen](../../access-and-usage/terms-of-use/). Das Modell wird von Alibaba unter der [Apache 2.0-Lizenz](https://www.apache.org/licenses/LICENSE-2.0.html) bereitgestellt. Die Weiternutzung der generierten Inhalte unterliegt keinen zusätzlichen Einschränkungen.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/110-mistral-medium-3-5-128b.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/110-mistral-medium-3-5-128b.mdx
@@ -1,0 +1,176 @@
+---
+sidebar_label: Mistral-Medium-3.5-128B
+description: Detaillierte Informationen zu Mistral-Medium-3.5-128B
+title: Mistral-Medium-3.5-128B
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Beschreibung
+
+„Mistral-Medium-3.5-128B" ist ein multimodales Sprachmodell von Mistral AI mit 128 Milliarden Parametern. Es unterstützt Text, Vision und Tool-Calling über ein Kontextfenster von 256.000 Token und nutzt EAGLE-spekulatives Decoding für schnelle Inferenz.
+
+Geeignet für und unterstützt:
+
+- Textgenerierung innerhalb einer Chat-Completion (Text zu Text)
+- Tool-Calling für agentische Workflows
+- Bildverständnis (Vision) – bis zu 5 Bilder pro Anfrage
+- Langkontext-Dokumentenanalyse und Zusammenfassung
+- Mehrsprachige Aufgaben – starke Abdeckung europäischer Sprachen
+
+Folgende Einschränkungen gelten:
+
+- Maximale Kontextlänge: 256.000 Token
+- Maximale Bilder pro Anfrage: 5
+- Bilder müssen als Base64-kodierte Data-URLs übermittelt werden (keine externen URLs)
+- Keine Audio-Unterstützung
+
+## API-Nutzung
+
+### Chat
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-dein-api-key",
+)
+
+response = client.chat.completions.create(
+    model="Mistral-Medium-3.5-128B",
+    messages=[{"role": "user", "content": "Erkläre den Unterschied zwischen TCP und UDP."}],
+    temperature=0.7,
+    top_p=0.9,
+    max_tokens=1024,
+)
+
+print(response.choices[0].message.content)
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-dein-api-key",
+});
+
+const response = await client.chat.completions.create({
+  model: "Mistral-Medium-3.5-128B",
+  messages: [{ role: "user", content: "Erkläre den Unterschied zwischen TCP und UDP." }],
+  temperature: 0.7,
+  top_p: 0.9,
+  max_tokens: 1024,
+});
+
+console.log(response.choices[0].message.content);
+```
+
+  </TabItem>
+</Tabs>
+
+### Vision (Bild + Text)
+
+Bilder müssen als Base64-kodierte Data-URLs übermittelt werden. Fertige Hilfsfunktionen zum Skalieren und Enkodieren sind in den [Python-Beispielen](../../examples/python/#vision-encoding) und [JavaScript-Beispielen](../../examples/javascript/#vision-encoding) zu finden – Bilder sollten auf maximal 1024 px an der längsten Seite verkleinert werden.
+
+```python
+import base64
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+with open("diagramm.jpg", "rb") as f:
+    img_b64 = base64.b64encode(f.read()).decode()
+
+response = client.chat.completions.create(
+    model="Mistral-Medium-3.5-128B",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"}},
+            {"type": "text", "text": "Beschreibe, was in diesem Diagramm dargestellt ist."},
+        ],
+    }],
+    temperature=0.1,
+    max_tokens=1024,
+)
+
+print(response.choices[0].message.content)
+```
+
+### Tool-Calling (Funktionsaufrufe)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Aktuelles Wetter für eine Stadt abrufen",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}]
+
+response = client.chat.completions.create(
+    model="Mistral-Medium-3.5-128B",
+    messages=[{"role": "user", "content": "Wie ist das Wetter in Paris?"}],
+    tools=tools,
+    tool_choice="auto",
+    temperature=0.2,
+)
+
+if response.choices[0].message.tool_calls:
+    call = response.choices[0].message.tool_calls[0]
+    print(f"Funktion: {call.function.name}")
+    print(f"Argumente: {call.function.arguments}")
+```
+
+## Empfohlene Inferenzparameter
+
+### Allgemeiner Chat
+
+| Parameter     | Wert |
+| ------------- | ---- |
+| `temperature` | 0.7  |
+| `top_p`       | 1.0  |
+| `max_tokens`  | 1024–8192 je nach Aufgabe |
+
+### Vision-Aufgaben
+
+| Parameter     | Wert |
+| ------------- | ---- |
+| `temperature` | 0.1  |
+| `top_p`       | 1.0  |
+| `max_tokens`  | 512–2048 je nach Aufgabe |
+
+### Tool-Calling / strukturierte Ausgabe
+
+| Parameter     | Wert |
+| ------------- | ---- |
+| `temperature` | 0.0–0.3 |
+| `top_p`       | 1.0  |
+
+:::tip Guide-Ideen
+- **Mehrsprachiger agentischer Assistent**: Mistral Medium unterstützt nativ 40+ Sprachen. Baue einen Kundenservice-Agenten, der Anfragen in jeder unterstützten Sprache entgegennimmt und Tools (Abrechnung, Bestellabfrage, Eskalation) über native Funktionsaufrufe anspricht – kein Übersetzungsschritt notwendig.
+- **LLM-Kaskade**: `Qwen3.5-0.8B` als günstigen Router einsetzen. Einfache Anfragen direkt beantworten, mittlere Komplexität an `Qwen3.6-35B-A3B-FP8` weiterleiten und nur wirklich komplexe Aufgaben an `Mistral-Medium-3.5-128B`. Gut abgestimmte Kaskaden senken die Token-Kosten um 40–80 % bei 95 % erhaltener Qualität.
+- **Langdokumentenanalyse**: Das 256k-Kontextfenster fasst vollständige technische Berichte, Rechtsverträge oder Codebases in einer einzigen Anfrage – kein Chunking für Dokumente unter ~190.000 Wörtern nötig.
+:::
+
+## Nutzungsbedingungen und Lizenzhinweise {#nutzungsbedingungen-und-lizenzhinweise}
+
+Es gelten die [allgemeinen Nutzungsbedingungen](../../access-and-usage/terms-of-use/). Das Modell wird von Mistral AI unter der [Apache 2.0-Lizenz](https://www.apache.org/licenses/LICENSE-2.0.html) bereitgestellt. Die Weiternutzung der generierten Inhalte unterliegt keinen zusätzlichen Einschränkungen.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/110-mistral-medium-3-5-128b.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/110-mistral-medium-3-5-128b.mdx
@@ -9,21 +9,18 @@ import TabItem from "@theme/TabItem";
 
 ## Beschreibung
 
-„Mistral-Medium-3.5-128B" ist ein multimodales Sprachmodell von Mistral AI mit 128 Milliarden Parametern. Es unterstützt Text, Vision und Tool-Calling über ein Kontextfenster von 256.000 Token und nutzt EAGLE-spekulatives Decoding für schnelle Inferenz.
+„Mistral-Medium-3.5-128B" ist ein Frontier-Sprachmodell von Mistral AI mit 128 Milliarden Parametern. Es unterstützt Text und Tool-Calling über ein Kontextfenster von 256.000 Token und nutzt EAGLE-spekulatives Decoding für schnelle Inferenz.
 
 Geeignet für und unterstützt:
 
 - Textgenerierung innerhalb einer Chat-Completion (Text zu Text)
 - Tool-Calling für agentische Workflows
-- Bildverständnis (Vision) – bis zu 5 Bilder pro Anfrage
 - Langkontext-Dokumentenanalyse und Zusammenfassung
 - Mehrsprachige Aufgaben – starke Abdeckung europäischer Sprachen
 
 Folgende Einschränkungen gelten:
 
 - Maximale Kontextlänge: 256.000 Token
-- Maximale Bilder pro Anfrage: 5
-- Bilder müssen als Base64-kodierte Data-URLs übermittelt werden (keine externen URLs)
 - Keine Audio-Unterstützung
 
 ## API-Nutzung
@@ -77,35 +74,6 @@ console.log(response.choices[0].message.content);
   </TabItem>
 </Tabs>
 
-### Vision (Bild + Text)
-
-Bilder müssen als Base64-kodierte Data-URLs übermittelt werden. Fertige Hilfsfunktionen zum Skalieren und Enkodieren sind in den [Python-Beispielen](../../examples/python/#vision-encoding) und [JavaScript-Beispielen](../../examples/javascript/#vision-encoding) zu finden – Bilder sollten auf maximal 1024 px an der längsten Seite verkleinert werden.
-
-```python
-import base64
-from openai import OpenAI
-
-client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
-
-with open("diagramm.jpg", "rb") as f:
-    img_b64 = base64.b64encode(f.read()).decode()
-
-response = client.chat.completions.create(
-    model="Mistral-Medium-3.5-128B",
-    messages=[{
-        "role": "user",
-        "content": [
-            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"}},
-            {"type": "text", "text": "Beschreibe, was in diesem Diagramm dargestellt ist."},
-        ],
-    }],
-    temperature=0.1,
-    max_tokens=1024,
-)
-
-print(response.choices[0].message.content)
-```
-
 ### Tool-Calling (Funktionsaufrufe)
 
 ```python
@@ -149,14 +117,6 @@ if response.choices[0].message.tool_calls:
 | `temperature` | 0.7  |
 | `top_p`       | 1.0  |
 | `max_tokens`  | 1024–8192 je nach Aufgabe |
-
-### Vision-Aufgaben
-
-| Parameter     | Wert |
-| ------------- | ---- |
-| `temperature` | 0.1  |
-| `top_p`       | 1.0  |
-| `max_tokens`  | 512–2048 je nach Aufgabe |
 
 ### Tool-Calling / strukturierte Ausgabe
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
@@ -4,9 +4,11 @@ description: Detaillierte Informationen zu Whisper-Large-V3-Turbo
 title: Whisper-Large-V3-Turbo
 ---
 
+Der [Spracherkennungs-Guide](../../examples/whisper/) enthält lauffähige Beispiele für einfache Transkription, Mehrsprachigkeit, die Verarbeitung großer Dateien und eine Transkriptions- und Zusammenfassungs-Pipeline.
+
 ## Beschreibung
 
-„Whisper-Large-V3-Turbo“ ist ein mehrsprachiges automatisches Spracherkennungsmodell (ASR – _Automatic Speech Recognition_) von OpenAI, optimiert für Geschwindigkeit und Effizienz. Es basiert auf der Architektur des bekannten „Whisper-Large-V3“-Modells, verwendet jedoch eine leichtere Decoder-Struktur für deutlich geringere Latenz bei nur minimalem Genauigkeitsverlust. Das Modell unterstützt über 99 Sprachen und ist ideal für die Transkription von Spracheingaben.
+„Whisper-Large-V3-Turbo” ist ein mehrsprachiges automatisches Spracherkennungsmodell (ASR – _Automatic Speech Recognition_) von OpenAI, optimiert für Geschwindigkeit und Effizienz. Es basiert auf der Architektur des bekannten „Whisper-Large-V3“-Modells, verwendet jedoch eine leichtere Decoder-Struktur für deutlich geringere Latenz bei nur minimalem Genauigkeitsverlust. Das Modell unterstützt über 99 Sprachen und ist ideal für die Transkription von Spracheingaben.
 
 Die folgenden Einschränkungen gelten für dieses Modell bei unserer Plattform:
 
@@ -66,13 +68,6 @@ Gibt zusätzliche Metadaten zurück, darunter erkannte Sprache, Dauer und segmen
   ]
 }
 ```
-
-### Best Practices
-
-- **Setze den Parameter `language` immer explizit**, z. B. `language="de"` für deutschsprachige Audiodateien.
-- Segmentiere lange Audiodateien in < 25 MB-Chunks.
-- `response_format="verbose_json"` verwenden, wenn Spracherkennung, Dauer oder segmentgenaue Zeitstempel benötigt werden.
-- Bei mehrsprachigen Aufnahmen: einzelne Sprachen separat transkribieren für bessere Präzision.
 
 ## Nutzungsbedingungen und Lizenzierung
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
@@ -13,8 +13,9 @@ Die folgenden Einschränkungen gelten für dieses Modell bei unserer Plattform:
 - Maximale Dateigröße: 25 MB pro Upload
 - Keine explizite Kontextlängenbegrenzung – abhängig von Audiodauer und Dateigröße
 - Es ist derzeit keine Übersetzung möglich (`to_language`)
-- Unterstützte Ausgabeformate: **`text`**, **`json`**
-  - Andere Formate (`srt`, `vtt`, `verbose_json`) werden aktuell nicht unterstützt
+- Unterstützte Ausgabeformate: **`json`**, **`verbose_json`**
+  - `response_format="text"` wird akzeptiert, gibt aber immer einen JSON-Body zurück – stattdessen `"json"` verwenden
+  - `srt` und `vtt` werden nicht unterstützt (HTTP 400)
 
 ### Unterstützte Eingabeformate
 
@@ -32,7 +33,7 @@ Die folgenden Einschränkungen gelten für dieses Modell bei unserer Plattform:
 - **`language` wie `language="de"`sollte immer explizit gesetzt werden**, um die Genauigkeit zu maximieren.
   Wird kein Wert angegeben, wird **standardmäßig Deutsch (`"de"`)** angenommen, kann aber für anderssprachige Eingaben dann schlechtere Ergebnisse liefern.
 
-### Beispielausgabe (`response_format=json`)
+### Beispielausgabe — `response_format="json"` {#output-json}
 
 ```json
 {
@@ -44,11 +45,33 @@ Die folgenden Einschränkungen gelten für dieses Modell bei unserer Plattform:
 }
 ```
 
+### Beispielausgabe — `response_format="verbose_json"` {#output-verbose}
+
+Gibt zusätzliche Metadaten zurück, darunter erkannte Sprache, Dauer und segmentgenaue Zeitstempel:
+
+```json
+{
+  "text": "Das ist der transkribierte Text.",
+  "language": "de",
+  "duration": "8.0",
+  "words": null,
+  "segments": [
+    {
+      "id": 0,
+      "avg_logprob": -0.45,
+      "text": " Das ist der transkribierte Text.",
+      "start": 0.0,
+      "end": 2.4
+    }
+  ]
+}
+```
+
 ### Best Practices
 
 - **Setze den Parameter `language` immer explizit**, z. B. `language="de"` für deutschsprachige Audiodateien.
 - Segmentiere lange Audiodateien in < 25 MB-Chunks.
-- Für Echtzeit- oder near-real-time-Anwendungen `response_format="text"` verwenden.
+- `response_format="verbose_json"` verwenden, wenn Spracherkennung, Dauer oder segmentgenaue Zeitstempel benötigt werden.
 - Bei mehrsprachigen Aufnahmen: einzelne Sprachen separat transkribieren für bessere Präzision.
 
 ## Nutzungsbedingungen und Lizenzierung

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
@@ -1,0 +1,199 @@
+---
+sidebar_label: Qwen3.5-0.8B
+description: Detaillierte Informationen zu Qwen3.5-0.8B
+title: Qwen3.5-0.8B
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Beschreibung
+
+„Qwen3.5-0.8B" ist ein kompaktes Sprachmodell von Alibaba mit 0,8 Milliarden Parametern. Trotz seiner geringen Größe unterstützt es ein Kontextfenster von 262.144 Token und bietet einen optionalen Thinking-/Reasoning-Modus – und ist damit das kosteneffizienteste Modell im mittwald AI-Hosting-Katalog.
+
+Geeignet für und unterstützt:
+
+- Textgenerierung innerhalb einer Chat-Completion (Text zu Text)
+- Tool-Calling für agentische Workflows
+- Thinking / Reasoning für schrittweises Problemlösen (opt-in)
+- Hochdurchsatz- und latenzempfindliche Pipelines
+- Batch-Verarbeitung: Klassifizierung, Routing, Zusammenfassung, Extraktion
+
+Folgende Einschränkungen gelten:
+
+- Maximale Kontextlänge: 262.144 Token
+- Keine Bild-/Vision-Unterstützung
+- Antwortqualität und Reasoning-Tiefe sind geringer als bei größeren Modellen
+- Thinking-Modus ist standardmäßig **deaktiviert** – opt-in pro Anfrage via `chat_template_kwargs`
+
+## Thinking-Modus
+
+Der Thinking-Modus ist bei diesem Modell **standardmäßig deaktiviert** – anders als bei `Qwen3.5-122B-A10B-FP8`. Aktiviere ihn gezielt für Aufgaben, die von Chain-of-Thought-Reasoning profitieren:
+
+<Tabs groupId="language">
+  <TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-dein-api-key",
+)
+
+response = client.chat.completions.create(
+    model="Qwen3.5-0.8B",
+    messages=[{"role": "user", "content": "Löse: Wenn 3x + 7 = 22, was ist x?"}],
+    temperature=0.6,
+    top_k=20,
+    max_tokens=8192,
+    extra_body={
+        "chat_template_kwargs": {"enable_thinking": True},
+    },
+)
+
+print(response.choices[0].message.reasoning_content)  # Chain-of-Thought
+print(response.choices[0].message.content)             # Endantwort
+```
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-dein-api-key",
+});
+
+const response = await client.chat.completions.create({
+  model: "Qwen3.5-0.8B",
+  messages: [{ role: "user", content: "Löse: Wenn 3x + 7 = 22, was ist x?" }],
+  temperature: 0.6,
+  max_tokens: 8192,
+  // @ts-ignore – vLLM-Erweiterung
+  chat_template_kwargs: { enable_thinking: true },
+} as any);
+
+console.log(response.choices[0].message.content);
+```
+
+  </TabItem>
+</Tabs>
+
+Bei aktiviertem Thinking gibt das Modell zwei Felder zurück:
+
+| Feld | Inhalt |
+| ---- | ------ |
+| `choices[0].message.reasoning_content` | Interner Chain-of-Thought |
+| `choices[0].message.content` | Endantwort |
+
+## Empfohlene Inferenzparameter
+
+### Standardmodus (Thinking aus)
+
+**Allgemeine Aufgaben:**
+
+| Parameter          | Wert |
+| ------------------ | ---- |
+| `temperature`      | 1.0  |
+| `top_p`            | 1.0  |
+| `top_k`            | 20   |
+| `presence_penalty` | 2.0  |
+
+Greedy Decoding (`temperature: 0`) vermeiden – führt zu Wiederholungen. `presence_penalty` über 1,5 kann bei mehrsprachigen Prompts gelegentlich Sprachmischungen auslösen.
+
+### Thinking-Modus (`enable_thinking: true`)
+
+**Allgemeine Aufgaben:**
+
+| Parameter          | Wert |
+| ------------------ | ---- |
+| `temperature`      | 1.0  |
+| `top_p`            | 0.95 |
+| `top_k`            | 20   |
+| `presence_penalty` | 1.5  |
+
+**Coding und präzise Aufgaben:**
+
+| Parameter          | Wert |
+| ------------------ | ---- |
+| `temperature`      | 0.6  |
+| `top_p`            | 0.95 |
+| `top_k`            | 20   |
+| `presence_penalty` | 0.0  |
+
+### Ausgabelänge
+
+| Aufgabentyp                              | Empfohlene `max_tokens` |
+| ---------------------------------------- | ----------------------- |
+| Standardanfragen                         | 32.768                  |
+| Komplexe Probleme (Mathe, Schritt-für-Schritt) | 81.920            |
+
+## Tipps für spezifische Aufgaben
+
+### Tool-Calling
+
+Das Modell unterstützt Funktionsaufrufe im Qwen3-XML-Format. Tools werden über den standardmäßigen OpenAI-`tools`-Parameter übergeben:
+
+```python
+response = client.chat.completions.create(
+    model="Qwen3.5-0.8B",
+    messages=[{"role": "user", "content": "Wie ist das Wetter in Berlin?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Aktuelles Wetter für eine Stadt abrufen",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }],
+    tool_choice="auto",
+    temperature=0.2,
+)
+```
+
+Niedrige Temperatur (`0,1–0,3`) für Tool-Calls verwenden, um Halluzinationen zu reduzieren.
+
+### Routing und Klassifizierung
+
+Die geringe Größe macht dieses Modell ideal als First-Pass-Klassifizierer, der entscheidet, welches größere Modell eine Anfrage bearbeitet:
+
+```python
+response = client.chat.completions.create(
+    model="Qwen3.5-0.8B",
+    messages=[
+        {
+            "role": "system",
+            "content": (
+                "Klassifiziere die folgende Benutzernachricht in genau eine Kategorie: "
+                "SIMPLE_QA, CODE, MATH, IMAGE_TASK. Antworte nur mit dem Kategorienamen."
+            ),
+        },
+        {"role": "user", "content": user_message},
+    ],
+    temperature=0.1,
+    max_tokens=10,
+)
+category = response.choices[0].message.content.strip()
+```
+
+:::tip Guide-Ideen
+- **Cascade-Routing**: `Qwen3.5-0.8B` klassifiziert die Anfragekomplexität und leitet an die passende Stufe weiter:
+  - Einfacher Text → `Qwen3.5-0.8B` beantwortet direkt
+  - Mittelstufe → `Qwen3.6-35B-A3B-FP8` (Reasoning + Vision, mittlere Kosten)
+  - Komplex / Frontier → `Mistral-Medium-3.5-128B` oder `Qwen3.5-122B-A10B-FP8`
+  - Nur Vision → `Ministral-3-14B-Instruct-2512` (günstigstes Vision-Modell)
+
+  Eine gut abgestimmte Kaskade kann Kosten um 40–80 % senken und gleichzeitig bei 95 % der Anfragen die Qualität erhalten.
+- **Batch-Vorverarbeitung**: Dokumente in großem Umfang zusammenfassen, Entitäten extrahieren oder taggen, bevor eine kuratierte Teilmenge an ein leistungsstärkeres Modell übergeben wird.
+:::
+
+## Nutzungsbedingungen und Lizenzhinweise {#nutzungsbedingungen-und-lizenzhinweise}
+
+Es gelten die [allgemeinen Nutzungsbedingungen](../../access-and-usage/terms-of-use/). Das Modell wird von Alibaba unter der [Apache 2.0-Lizenz](https://www.apache.org/licenses/LICENSE-2.0.html) bereitgestellt. Die Weiternutzung der generierten Inhalte unterliegt keinen zusätzlichen Einschränkungen.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
@@ -13,6 +13,9 @@ Wir bieten aktuell die nachfolgenden Modelle an, die sich im Laufe der Zeit änd
 | whisper-large-v3-turbo             | Speech-to-Text                    | Audio → Text             | n/a (Audio-basiert) | MIT        |
 | Qwen3.5-122B-A10B-FP8              | Chat + Reasoning + Vision         | Text, Bild, Tool-Calling | 245.760             | Apache 2.0 |
 | Qwen3.6-35B-A3B-FP8               | Chat + Reasoning + Vision         | Text, Bild, Tool-Calling | 256.000             | Apache 2.0 |
+| Qwen3.5-0.8B                       | Chat + Reasoning                  | Text, Tool-Calling       | 262.144             | Apache 2.0 |
+| Qwen3-VL-Reranker-2B               | Reranking                         | Text, Bild → Score       | 32.768              | Apache 2.0 |
+| Mistral-Medium-3.5-128B            | Chat + Vision                     | Text, Bild, Tool-Calling | 256.000             | Apache 2.0 |
 
 ## Modellauswahl {#picking-models}
 
@@ -22,6 +25,9 @@ Wir bieten aktuell die nachfolgenden Modelle an, die sich im Laufe der Zeit änd
 - Setze `whisper-large-v3-turbo` für alle Transkriptions- oder Sprachbefehl-Anforderungen ein.
 - Verwende `Qwen3.5-122B-A10B-FP8` für umfangreiche Reasoning- und Vision-Aufgaben, bei denen hohe Modellkapazität erforderlich ist.
 - Verwende `Qwen3.6-35B-A3B-FP8` für Workloads, die lange Kontextfenster mit Reasoning- und Vision-Unterstützung bei niedrigeren Kosten erfordern.
+- Verwende `Qwen3.5-0.8B` für hochdurchsatz- und kostensensitive Aufgaben ohne Vision-Bedarf – einfache Frage-Antwort, Routing, Klassifizierung und Batch-Verarbeitung.
+- Verwende `Qwen3-VL-Reranker-2B`, um die RAG-Retrievalpräzision durch einen zweiten Reranking-Schritt nach der Vektorsuche zu verbessern.
+- Verwende `Mistral-Medium-3.5-128B` für komplexe Reasoning-, mehrsprachige oder Vision-Aufgaben, bei denen ein großes Frontier-Modell erforderlich ist.
 
 :::tip
 Für optimalen ROI beginne mit dem kleinsten Modell, das deinen Qualitätsanforderungen entspricht – steige *nur dann* auf ein größeres Modell um, wenn du zusätzliche Tiefe oder Zuverlässigkeit benötigst!

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/50-cascade-routing.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/50-cascade-routing.mdx
@@ -1,0 +1,165 @@
+---
+sidebar_label: LLM-Cascade-Routing
+description: Anfragen über drei Modellstufen routen – Kosten senken und Qualität erhalten
+title: LLM-Cascade-Routing
+---
+
+Jede Anfrage mit einem großen Frontier-Modell zu beantworten ist präzise, aber teuer. Günstige Anfragen an ein kleines Modell zu routen und das große Modell für wirklich schwierige Fälle zu reservieren, senkt die Kosten typischerweise um 40–80 % bei weniger als 1 % Qualitätsverlust.
+
+Dieser Guide baut eine dreistufige Kaskade auf mittwald AI Hosting mit nur dem `openai`-Paket:
+
+| Stufe | Modell | Wann einsetzen |
+| ----- | ------ | -------------- |
+| 1 — schnell | `Qwen3.5-0.8B` | Einfache Nachschlagefragen, Ja/Nein, kurze Faktenantworten |
+| 2 — ausgewogen | `Qwen3.6-35B-A3B-FP8` | Mehrschrittiges Reasoning, Code, Vergleiche |
+| 3 — Frontier | `Mistral-Medium-3.5-128B` | Komplexe Analysen, Vision, lange Dokumente, 40+ Sprachen |
+
+Für Stufe 3 kann je nach Workload ein beliebiges großes Modell eingesetzt werden:
+
+| Alternative für Stufe 3 | Stärken |
+| ----------------------- | ------- |
+| `Mistral-Medium-3.5-128B` | 40+ Sprachen, Vision, 256k Context |
+| `Qwen3.5-122B-A10B-FP8` | Thinking-Modus, Vision, starkes Coding |
+| `gpt-oss-120b` | Textbasiertes Reasoning, 131k Context |
+
+Die Modellseiten für Parameterdetails: [Qwen3.5-0.8B](/docs/v2/platform/aihosting/models/qwen3-5-0-8b), [Qwen3.6-35B-A3B-FP8](/docs/v2/platform/aihosting/models/qwen3-6-35b-a3b-fp8), [Mistral-Medium-3.5-128B](/docs/v2/platform/aihosting/models/mistral-medium-3-5-128b), [Qwen3.5-122B-A10B-FP8](/docs/v2/platform/aihosting/models/qwen3-5-122b-a10b-fp8).
+
+## Einrichtung {#einrichtung}
+
+```shellsession
+user@local $ pip install openai
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+## Der Router
+
+Der Router sendet jede Anfrage an `Qwen3.5-0.8B` und lässt die Komplexität in einem Wort klassifizieren. Da die Klassifizierer-Ausgabe nur ein einzelnes Token ist (`simple`, `moderate` oder `complex`), sind die Kosten vernachlässigbar – typischerweise weniger als 0,1 % der Gesamtausgaben.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+# Stufe-3-Modell je nach Workload tauschen:
+#   "Mistral-Medium-3.5-128B"  — Vision, 40+ Sprachen, 256k Context
+#   "Qwen3.5-122B-A10B-FP8"   — Thinking-Modus, Vision, starkes Coding
+#   "gpt-oss-120b"             — Textbasiertes Reasoning, 131k Context
+TIERS = {
+    "simple":   "Qwen3.5-0.8B",
+    "moderate": "Qwen3.6-35B-A3B-FP8",
+    "complex":  "Mistral-Medium-3.5-128B",
+}
+
+CLASSIFIER_SYSTEM = """\
+Classify the complexity of the user's question with exactly one word: simple, moderate, or complex.
+
+simple   — factual lookup, yes/no, basic definition, short translation
+moderate — multi-step reasoning, code with explanation, structured comparison
+complex  — research-level analysis, multi-file code review, long-document synthesis,
+           vision + reasoning combined, or anything requiring deep domain knowledge
+
+Reply with only the single classification word and nothing else."""
+
+
+def classify(query: str) -> str:
+    resp = client.chat.completions.create(
+        model="Qwen3.5-0.8B",
+        messages=[
+            {"role": "system", "content": CLASSIFIER_SYSTEM},
+            {"role": "user", "content": query},
+        ],
+        temperature=0.0,
+        max_tokens=5,
+    )
+    label = resp.choices[0].message.content.strip().lower()
+    return label if label in TIERS else "moderate"
+
+
+def answer(query: str, model: str, **kwargs) -> str:
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": query}],
+        temperature=0.7,
+        **kwargs,
+    )
+    return resp.choices[0].message.content
+
+
+def cascade(query: str) -> dict:
+    tier = classify(query)
+    model = TIERS[tier]
+    text = answer(query, model)
+    return {"tier": tier, "model": model, "answer": text}
+```
+
+## Verwendung
+
+```python
+queries = [
+    "Was ist die Hauptstadt von Frankreich?",                            # simple
+    "Schreibe eine Python-Funktion, die zwei sortierte Listen zusammenführt.",  # moderate
+    "Analysiere die Architektur-Tradeoffs zwischen event-getriebenen und "
+    "Request-Response-Mustern für ein hochvolumiges Zahlungssystem.",    # complex
+]
+
+for q in queries:
+    result = cascade(q)
+    print(f"[{result['tier']:8s}] {result['model']}")
+    print(f"  F: {q[:70]}")
+    print(f"  A: {result['answer'][:120]}\n")
+```
+
+## Eskalation bei kurzen Antworten
+
+Manche Anfragen werden fälschlicherweise als `simple` klassifiziert, aber das kleine Modell liefert eine unbefriedigend kurze Antwort. Mit einer Wortanzahl-Prüfung kann automatisch eskaliert werden:
+
+```python
+def cascade_with_escalation(query: str, min_words: int = 20) -> dict:
+    tier = classify(query)
+    model = TIERS[tier]
+    text = answer(query, model)
+
+    # Eskalieren, wenn Antwort verdächtig kurz und eine größere Stufe verfügbar ist
+    tiers = list(TIERS.keys())
+    current_idx = tiers.index(tier)
+    while len(text.split()) < min_words and current_idx < len(tiers) - 1:
+        current_idx += 1
+        tier = tiers[current_idx]
+        model = TIERS[tier]
+        text = answer(query, model)
+
+    return {"tier": tier, "model": model, "answer": text}
+```
+
+## System-Prompt durchreichen
+
+Um einen System-Prompt hinzuzufügen (z. B. für eine Kundensupport-Persona), diesen an die jeweilige Stufe weitergeben:
+
+```python
+SYSTEM = "Du bist ein knapper Support-Agent für mittwald. Antworte in der Sprache des Nutzers."
+
+def cascade_with_system(query: str) -> dict:
+    tier = classify(query)
+    model = TIERS[tier]
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": SYSTEM},
+            {"role": "user", "content": query},
+        ],
+        temperature=0.7,
+    )
+    return {"tier": tier, "model": model, "answer": resp.choices[0].message.content}
+```
+
+:::tip Kostenschätzung
+Bei einer typischen Support-Workload (70 % einfach, 20 % mittel, 10 % komplex) und 100.000 Anfragen/Monat bei durchschnittlich 300 Token:
+
+| Szenario | Monatliche Kosten |
+| -------- | ----------------- |
+| Alle Anfragen → Mistral-Medium | ~30 € |
+| Dreistufige Kaskade | ~8 € |
+
+Die Klassifizierer-Anfrage kostet insgesamt weniger als 0,10 € und ist nicht separat aufgeführt.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/50-cascade-routing.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/50-cascade-routing.mdx
@@ -12,13 +12,13 @@ Dieser Guide baut eine dreistufige Kaskade auf mittwald AI Hosting mit nur dem `
 | ----- | ------ | -------------- |
 | 1 — schnell | `Qwen3.5-0.8B` | Einfache Nachschlagefragen, Ja/Nein, kurze Faktenantworten |
 | 2 — ausgewogen | `Qwen3.6-35B-A3B-FP8` | Mehrschrittiges Reasoning, Code, Vergleiche |
-| 3 — Frontier | `Mistral-Medium-3.5-128B` | Komplexe Analysen, Vision, lange Dokumente, 40+ Sprachen |
+| 3 — Frontier | `Mistral-Medium-3.5-128B` | Komplexe Analysen, lange Dokumente, 40+ Sprachen |
 
 Für Stufe 3 kann je nach Workload ein beliebiges großes Modell eingesetzt werden:
 
 | Alternative für Stufe 3 | Stärken |
 | ----------------------- | ------- |
-| `Mistral-Medium-3.5-128B` | 40+ Sprachen, Vision, 256k Context |
+| `Mistral-Medium-3.5-128B` | 40+ Sprachen, 256k Context |
 | `Qwen3.5-122B-A10B-FP8` | Thinking-Modus, Vision, starkes Coding |
 | `gpt-oss-120b` | Textbasiertes Reasoning, 131k Context |
 
@@ -42,7 +42,7 @@ from openai import OpenAI
 client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
 
 # Stufe-3-Modell je nach Workload tauschen:
-#   "Mistral-Medium-3.5-128B"  — Vision, 40+ Sprachen, 256k Context
+#   "Mistral-Medium-3.5-128B"  — 40+ Sprachen, 256k Context
 #   "Qwen3.5-122B-A10B-FP8"   — Thinking-Modus, Vision, starkes Coding
 #   "gpt-oss-120b"             — Textbasiertes Reasoning, 131k Context
 TIERS = {
@@ -57,7 +57,7 @@ Classify the complexity of the user's question with exactly one word: simple, mo
 simple   — factual lookup, yes/no, basic definition, short translation
 moderate — multi-step reasoning, code with explanation, structured comparison
 complex  — research-level analysis, multi-file code review, long-document synthesis,
-           vision + reasoning combined, or anything requiring deep domain knowledge
+           or anything requiring deep domain knowledge
 
 Reply with only the single classification word and nothing else."""
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/60-document-qa-pipeline.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/60-document-qa-pipeline.mdx
@@ -1,0 +1,223 @@
+---
+sidebar_label: Dokument-Q&A-Pipeline
+description: Vierstufige Pipeline – OCR → Einbettung → Reranking → Antwortgenerierung – mit mittwald AI-Hosting-Modellen
+title: Dokument-Q&A-Pipeline
+---
+
+Dieser Guide baut eine vollständige Dokumenten-Frage-Antwort-Pipeline mit vier mittwald AI-Hosting-Modellen in Folge:
+
+| Stufe | Modell | Was es tut |
+| ----- | ------ | ---------- |
+| 1 — OCR | `GLM-OCR` | Extrahiert Text aus PDF, DOCX, PPTX, XLSX, Bildern |
+| 2 — Einbetten | [Qwen3-Embedding-8B](/docs/v2/platform/aihosting/models/qwen3-embedding-8b) | Wandelt Textabschnitte in Vektoren für die Ähnlichkeitssuche um |
+| 3 — Reranking | [Qwen3-VL-Reranker-2B](/docs/v2/platform/aihosting/models/qwen3-vl-reranker-2b) | Bewertet jeden Kandidaten gegen die vollständige Frage |
+| 4 — Antwort | [Qwen3.5-122B-A10B-FP8](/docs/v2/platform/aihosting/models/qwen3-5-122b-a10b-fp8) | Generiert eine fundierte Antwort mit Quellenangaben |
+
+Der Hauptvorteil gegenüber einer einfachen Einbetten → Abrufen → Antworten-Pipeline ist **Stufe 3**: Der Reranker liest die tatsächliche Frage gegen jeden abgerufenen Abschnitt als Paar und erkennt relevanten Text, den die Embedding-Ähnlichkeit allein übersieht.
+
+## Einrichtung {#einrichtung}
+
+```shellsession
+user@local $ pip install openai requests pypdf
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+## Stufe 1 — OCR: Text aus einem Dokument extrahieren
+
+Die Datei als Base64-Data-URI an `GLM-OCR` senden. Der Proxy auf unserer Plattform wandelt PDF-Seiten und Office-Dokumente automatisch in Bilder um, bevor das Modell sie verarbeitet – kein manuelles Aufteilen notwendig (bis zu 30 Seiten pro Anfrage). Vollständige Formatunterstützung und Einschränkungen auf der GLM-OCR-Modellseite.
+
+```python
+import base64
+import os
+import math
+import re
+import json
+import requests
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+MIME = {
+    "pdf":  "application/pdf",
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "jpg":  "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png":  "image/png",
+}
+
+
+def extract_text(path: str) -> str:
+    """Gesamten Text aus einem Dokument mit GLM-OCR extrahieren."""
+    ext = path.rsplit(".", 1)[-1].lower()
+    mime = MIME.get(ext, "application/pdf")
+    with open(path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode()
+
+    resp = client.chat.completions.create(
+        model="GLM-OCR",
+        messages=[{
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{mime};base64,{b64}"},
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "Extrahiere den Text aus diesem Dokument und formatiere ihn als Markdown. "
+                        "Verwende # für Hauptüberschriften, ## für Unterüberschriften und - für Aufzählungen."
+                    ),
+                },
+            ],
+        }],
+        temperature=0.1,
+    )
+    return resp.choices[0].message.content
+```
+
+:::note
+Bei Dokumenten mit mehr als 30 Seiten das PDF zuerst in Batches aufteilen. Siehe die [Python-Beispiele](/docs/v2/platform/aihosting/examples/python) für einen `pypdf`-basierten Batch-Splitter.
+:::
+
+## Stufe 2 — Einbetten: Text aufteilen und indizieren
+
+An Markdown-Überschriften aufteilen, dann nach Wortanzahl, damit jeder Abschnitt in das 32.768-Token-Fenster des Rerankers passt.
+
+```python
+def chunk_text(text: str, size: int = 400, overlap: int = 50) -> list[str]:
+    """An oberster Markdown-Überschriftenebene aufteilen, dann nach Wortanzahl mit Überlappung."""
+    sections = re.split(r"(?m)^(?=# )", text)
+    chunks: list[str] = []
+    for section in sections:
+        words = section.split()
+        i = 0
+        while i < len(words):
+            chunks.append(" ".join(words[i: i + size]))
+            i += size - overlap
+    return [c for c in chunks if c.strip()]
+
+
+def embed(texts: list[str]) -> list[list[float]]:
+    resp = client.embeddings.create(model="Qwen3-Embedding-8B", input=texts)
+    return [item.embedding for item in resp.data]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    norm = math.sqrt(sum(x * x for x in a)) * math.sqrt(sum(x * x for x in b))
+    return dot / (norm + 1e-9)
+
+
+def build_index(path: str) -> list[tuple[list[float], str]]:
+    """Dokument per OCR einlesen, aufteilen und In-Memory-Vektorindex zurückgeben."""
+    text = extract_text(path)
+    chunks = chunk_text(text)
+    vectors = embed(chunks)
+    return list(zip(vectors, chunks))
+
+
+def retrieve(query: str, index: list, top_k: int = 10) -> list[str]:
+    """Top_k Abschnitte nach Kosinus-Ähnlichkeit zurückgeben."""
+    [q_vec] = embed([query])
+    scored = [(cosine(q_vec, vec), chunk) for vec, chunk in index]
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [chunk for _, chunk in scored[:top_k]]
+```
+
+## Stufe 3 — Reranking: Präzisionsdurchlauf
+
+Der Reranker liest jedes (Frage, Abschnitt)-Paar als Ganzes und vergibt einen Relevanzscore. Einen größeren Kandidatenpool abrufen (Top-10), damit er genug zum Arbeiten hat, und dann auf Top-3 einschränken.
+
+```python
+def rerank(query: str, candidates: list[str], top_k: int = 3) -> list[str]:
+    resp = requests.post(
+        "https://llm.aihosting.mittwald.de/v1/rerank",
+        headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+        json={
+            "model": "Qwen3-VL-Reranker-2B",
+            "query": query,
+            "documents": candidates,
+            "instruction": "Given a document question, find the passages most relevant to answering it.",
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+    results = resp.json()["results"]
+    ranked = sorted(results, key=lambda r: r["relevance_score"], reverse=True)
+    return [candidates[r["index"]] for r in ranked[:top_k]]
+```
+
+## Stufe 4 — Antwort: fundierte Generierung
+
+Den neu geordneten Kontext an `Qwen3.5-122B-A10B-FP8` übergeben, mit deaktiviertem Thinking-Modus für schnellere Antworten. Das Modell wird angewiesen, `[Abschnitt N]` zu zitieren, damit Antworten nachvollziehbar sind.
+
+```python
+def answer(question: str, passages: list[str]) -> str:
+    context = "\n\n".join(f"[Abschnitt {i+1}]\n{p}" for i, p in enumerate(passages))
+    resp = client.chat.completions.create(
+        model="Qwen3.5-122B-A10B-FP8",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Beantworte die Frage ausschließlich anhand der bereitgestellten Abschnitte. "
+                    "Zitiere Quellen als [Abschnitt N]. "
+                    "Falls die Antwort nicht in den Abschnitten enthalten ist, erkläre dies explizit."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Abschnitte:\n{context}\n\nFrage: {question}",
+            },
+        ],
+        temperature=0.7,
+        top_p=0.8,
+        max_tokens=1024,
+        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+    )
+    return resp.choices[0].message.content
+```
+
+## Vollständige Pipeline
+
+```python
+def document_qa(doc_path: str, question: str) -> str:
+    index = build_index(doc_path)
+    candidates = retrieve(question, index, top_k=10)
+    top_passages = rerank(question, candidates, top_k=3)
+    return answer(question, top_passages)
+
+
+# Beispiel
+response = document_qa(
+    "jahresbericht.pdf",
+    "Was waren die wichtigsten Umsatztreiber im zweiten Quartal?",
+)
+print(response)
+```
+
+## Mehrere Dokumente indizieren
+
+```python
+# Einen kombinierten Index aus mehreren Dokumenten aufbauen
+documents = ["vertrag_a.pdf", "vertrag_b.docx", "anhang.xlsx"]
+
+combined_index: list[tuple[list[float], str]] = []
+for path in documents:
+    combined_index.extend(build_index(path))
+
+print(f"{len(combined_index)} Abschnitte aus {len(documents)} Dokumenten indiziert.")
+
+# Über alle Dokumente abfragen
+frage = "Was sind die Vertragsstrafen?"
+kandidaten = retrieve(frage, combined_index, top_k=10)
+top_abschnitte = rerank(frage, kandidaten, top_k=3)
+print(answer(frage, top_abschnitte))
+```
+
+:::tip Skalierung für den Produktionseinsatz
+Den In-Memory-Index durch **pgvector** ersetzen für persistente, mandantenfähige Speicherung. Siehe den [n8n-Guide](/docs/v2/guides/apps/n8n/) für einen sofort einsetzbaren Docker-Compose-Stack mit pgvector auf mittwald Container Hosting.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/70-multilingual-agent.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/70-multilingual-agent.mdx
@@ -1,0 +1,199 @@
+---
+sidebar_label: Mehrsprachiger Tool-Calling-Agent
+description: Einen Tool-Calling-Agenten bauen, der mit Mistral-Medium-3.5-128B über 40 Sprachen nativ unterstützt
+title: Mehrsprachiger Tool-Calling-Agent
+---
+
+Das Tool-Calling-Agenten-Muster in diesem Guide funktioniert mit jedem Chat-Modell, das Funktionsaufrufe unterstützt. Das Beispiel verwendet [Mistral-Medium-3.5-128B](/docs/v2/platform/aihosting/models/mistral-medium-3-5-128b), aber es kann je nach Kosten- und Qualitätsanforderungen ein beliebiges der folgenden Modelle eingesetzt werden:
+
+| Modell | Sprachen | Hinweise |
+| ------ | -------- | -------- |
+| `Mistral-Medium-3.5-128B` | 40+ | Beste mehrsprachige Qualität; Vision |
+| `Qwen3.5-122B-A10B-FP8` | 100+ | Thinking-Modus verfügbar; Vision |
+| `Qwen3.6-35B-A3B-FP8` | 100+ | Kosteneffizienter; Reasoning + Vision |
+| `gpt-oss-120b` | Englisch-zentriert | Am besten für rein englische Workloads |
+
+Alle Modelle nutzen dieselbe OpenAI-kompatible Tool-Calling-API – ein Modellwechsel erfordert nur eine einzige Codezeile. Nutzer können auf Deutsch, Französisch, Spanisch oder einer anderen unterstützten Sprache fragen – das Modell versteht die Anfrage, ruft die richtigen Tools auf (die auf Englisch definiert sind) und antwortet in der Sprache des Nutzers ohne jeglichen Übersetzungsschritt.
+
+Dieser Guide zeigt eine vollständige Agenten-Schleife: Das Modell entscheidet, welche Tools aufgerufen werden sollen, du führst sie aus und gibst die Ergebnisse zurück, bis das Modell alles hat, was es benötigt.
+
+## Einrichtung {#einrichtung}
+
+```shellsession
+user@local $ pip install openai
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+## Tools definieren
+
+Tool-Namen und -Beschreibungen werden immer auf **Englisch** verfasst. Das Modell ordnet jede Nutzersprache automatisch dem richtigen Tool zu.
+
+```python
+import os
+import json
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_exchange_rate",
+            "description": "Get the current exchange rate between two currencies.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "from_currency": {
+                        "type": "string",
+                        "description": "ISO 4217 source currency code, e.g. EUR",
+                    },
+                    "to_currency": {
+                        "type": "string",
+                        "description": "ISO 4217 target currency code, e.g. USD",
+                    },
+                },
+                "required": ["from_currency", "to_currency"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_order_status",
+            "description": "Return the status and estimated delivery date for a customer order.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "order_id": {
+                        "type": "string",
+                        "description": "The order identifier, e.g. ORD-12345",
+                    },
+                },
+                "required": ["order_id"],
+            },
+        },
+    },
+]
+```
+
+## Tool-Funktionen implementieren
+
+Diese Stubs durch echte Datenbankabfragen oder API-Aufrufe ersetzen:
+
+```python
+def get_exchange_rate(from_currency: str, to_currency: str) -> dict:
+    # Stub — durch echten FX-API-Aufruf ersetzen
+    rates = {
+        ("EUR", "USD"): 1.08,
+        ("USD", "EUR"): 0.93,
+        ("GBP", "EUR"): 1.17,
+        ("EUR", "GBP"): 0.85,
+    }
+    rate = rates.get((from_currency.upper(), to_currency.upper()))
+    if rate is None:
+        return {"error": f"Kein Kurs verfügbar für {from_currency}/{to_currency}"}
+    return {"from": from_currency, "to": to_currency, "rate": rate}
+
+
+def get_order_status(order_id: str) -> dict:
+    # Stub — durch echte Datenbankabfrage ersetzen
+    orders = {
+        "ORD-12345": {"status": "versandt",       "lieferung": "2026-06-04"},
+        "ORD-99999": {"status": "in Bearbeitung", "lieferung": "2026-06-07"},
+    }
+    order = orders.get(order_id.upper())
+    if order is None:
+        return {"error": f"Bestellung {order_id} nicht gefunden"}
+    return {"order_id": order_id, **order}
+
+
+FUNCTIONS = {
+    "get_exchange_rate": get_exchange_rate,
+    "get_order_status":  get_order_status,
+}
+```
+
+## Die Agenten-Schleife
+
+Die Schleife läuft, bis das Modell keine weiteren Tool-Aufrufe mehr anfordert (`finish_reason != "tool_calls"`):
+
+```python
+def run_agent(user_message: str, system: str | None = None) -> str:
+    messages = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": user_message})
+
+    while True:
+        response = client.chat.completions.create(
+            model="Mistral-Medium-3.5-128B",
+            messages=messages,
+            tools=tools,
+            tool_choice="auto",
+            temperature=0.2,
+        )
+        msg = response.choices[0].message
+        messages.append(msg)
+
+        if response.choices[0].finish_reason != "tool_calls":
+            return msg.content
+
+        # Jedes angeforderte Tool ausführen und Ergebnis zurückgeben
+        for call in msg.tool_calls:
+            args = json.loads(call.function.arguments)
+            result = FUNCTIONS[call.function.name](**args)
+            messages.append({
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": json.dumps(result),
+            })
+```
+
+## Test in mehreren Sprachen
+
+```python
+queries = [
+    "Was ist der aktuelle EUR/USD-Wechselkurs?",          # Deutsch
+    "Quel est le taux de change EUR vers GBP?",           # Französisch
+    "¿Cuál es el estado de mi pedido ORD-12345?",         # Spanisch
+    "What is the status of order ORD-99999?",             # Englisch
+    "Wie is de status van mijn bestelling ORD-12345?",    # Niederländisch
+]
+
+for q in queries:
+    print(f"F: {q}")
+    print(f"A: {run_agent(q)}\n")
+```
+
+Das Modell antwortet in der Sprache, in der der Nutzer geschrieben hat – ohne explizite Spracherkennung oder Übersetzung im Code.
+
+## Persona über System-Prompt
+
+```python
+SYSTEM = (
+    "Du bist ein freundlicher Kundensupport-Agent für mittwald. "
+    "Antworte immer in der Sprache, in der der Nutzer schreibt. "
+    "Sei knapp und professionell."
+)
+
+answer = run_agent("Mein Paket ORD-12345 — wann kommt es an?", system=SYSTEM)
+print(answer)
+# "Ihr Paket ORD-12345 ist bereits versandt und wird voraussichtlich am 4. Juni 2026 geliefert."
+```
+
+## Parallele Tool-Aufrufe
+
+Wenn eine Frage mehrere Tools gleichzeitig erfordert, kann das Modell mehrere `tool_calls` in einer einzigen Antwort zurückgeben. Die obige Schleife verarbeitet das bereits korrekt – sie iteriert über alle Aufrufe, bevor die nächste Modellanfrage gestellt wird.
+
+```python
+# Diese Anfrage löst beide Tools in einem Durchgang aus
+answer = run_agent(
+    "Wie ist der EUR/USD-Kurs und was ist der Status von Bestellung ORD-12345?"
+)
+print(answer)
+```
+
+:::note
+Tool-Definitionen sollten für beste sprachübergreifende Ergebnisse auf **Englisch** verfasst werden. Das Modell ordnet nicht-englische Anfragen zuverlässig englischsprachigen Funktionen zu, unabhängig von der Nutzersprache.
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/70-multilingual-agent.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/70-multilingual-agent.mdx
@@ -8,7 +8,7 @@ Das Tool-Calling-Agenten-Muster in diesem Guide funktioniert mit jedem Chat-Mode
 
 | Modell | Sprachen | Hinweise |
 | ------ | -------- | -------- |
-| `Mistral-Medium-3.5-128B` | 40+ | Beste mehrsprachige Qualität; Vision |
+| `Mistral-Medium-3.5-128B` | 40+ | Beste mehrsprachige Qualität |
 | `Qwen3.5-122B-A10B-FP8` | 100+ | Thinking-Modus verfügbar; Vision |
 | `Qwen3.6-35B-A3B-FP8` | 100+ | Kosteneffizienter; Reasoning + Vision |
 | `gpt-oss-120b` | Englisch-zentriert | Am besten für rein englische Workloads |

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/80-multimodal-search.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/80-multimodal-search.mdx
@@ -1,0 +1,190 @@
+---
+sidebar_label: Multimodale Produktsuche
+description: Produktbilder und -beschreibungen indizieren und Ergebnisse mit Qwen3-VL-Reranker-2B neu ordnen
+title: Multimodale Produktsuche
+---
+
+Standard-Keyword- und Vektorsuche funktioniert gut für Text, aber Produktkataloge enthalten Bilder. [Qwen3-VL-Reranker-2B](/docs/v2/platform/aihosting/models/qwen3-vl-reranker-2b) kann eine Anfrage gegen Dokumente bewerten, die sowohl Text als auch Bilder enthalten, und liefert damit reichhaltigere Relevanzsignale als reiner Text.
+
+Dieser Guide baut eine Katalogsuche, die:
+1. Produktbeschreibungen mit [Qwen3-Embedding-8B](/docs/v2/platform/aihosting/models/qwen3-embedding-8b) für schnelles Kandidaten-Retrieval einbettet
+2. Die Top-Kandidaten mit `Qwen3-VL-Reranker-2B` unter Einbeziehung der Produktbilder neu ordnet
+
+## Einrichtung {#einrichtung}
+
+```shellsession
+user@local $ pip install openai requests
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+## Katalogstruktur
+
+Jedes Produkt hat eine Textbeschreibung und ein Bild (Base64-kodiertes JPEG). Bilder sollten vor dem Kodieren auf maximal 1024 px an der längsten Seite skaliert werden – große Bilder erhöhen die Latenz ohne die Ranking-Qualität zu verbessern.
+
+```python
+import os
+import base64
+import math
+import requests
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+def encode_image(path: str) -> str:
+    """Base64-Data-URI für ein JPEG zurückgeben."""
+    with open(path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode()
+    return f"data:image/jpeg;base64,{b64}"
+
+
+# Beispielkatalog — Bildpfade und Beschreibungen durch echte Daten ersetzen
+CATALOGUE = [
+    {
+        "id": "SCHREIBTISCH-01",
+        "description": "Stehschreibtisch, dunkle Walnuss-Platte, höhenverstellbar 70–120 cm, 160×80 cm Arbeitsfläche",
+        "image": "products/schreibtisch_walnuss.jpg",
+    },
+    {
+        "id": "STUHL-07",
+        "description": "Ergonomischer Bürostuhl, Netzrücken, Lendenwirbelstütze, Armlehnen, schwarz",
+        "image": "products/stuhl_schwarz.jpg",
+    },
+    {
+        "id": "LAMPE-03",
+        "description": "LED-Schreibtischlampe, warmweiß, USB-C-Ladeanschluss, Touch-Dimmer, weiß",
+        "image": "products/lampe_weiss.jpg",
+    },
+    {
+        "id": "REGAL-12",
+        "description": "Wandregal schwebend, Massivholz Eiche, 80 cm, Traglast 25 kg",
+        "image": "products/regal_eiche.jpg",
+    },
+]
+```
+
+## Schritt 1 — Embedding-Index aufbauen
+
+`Qwen3-Embedding-8B` nutzen, um Beschreibungen für den schnellen Erst-Durchlauf einzubetten. Siehe die [Python-Beispiele](/docs/v2/platform/aihosting/examples/python) für das vollständige Embedding-Setup.
+
+```python
+def embed(texts: list[str]) -> list[list[float]]:
+    resp = client.embeddings.create(model="Qwen3-Embedding-8B", input=texts)
+    return [item.embedding for item in resp.data]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    norm = math.sqrt(sum(x * x for x in a)) * math.sqrt(sum(x * x for x in b))
+    return dot / (norm + 1e-9)
+
+
+# Index beim Start aufbauen
+descriptions = [p["description"] for p in CATALOGUE]
+index_vectors = embed(descriptions)
+```
+
+## Schritt 2 — Kandidaten per Embedding-Ähnlichkeit abrufen
+
+```python
+def retrieve(query: str, top_k: int = 10) -> list[dict]:
+    """Top_k Produkte nach Kosinus-Ähnlichkeit zur Anfrage zurückgeben."""
+    [q_vec] = embed([query])
+    scored = [
+        (cosine(q_vec, vec), product)
+        for vec, product in zip(index_vectors, CATALOGUE)
+    ]
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [product for _, product in scored[:top_k]]
+```
+
+## Schritt 3 — Mit Bildern neu ordnen
+
+`Qwen3-VL-Reranker-2B` akzeptiert multimodale Dokumente. Jeder Kandidat wird als Content-Liste übergeben, die Textbeschreibung **und** Produktbild enthält. So kann der Reranker visuelle Signale (Farbe, Form, Stil) erfassen, die die Textbeschreibung möglicherweise nicht vollständig abbildet.
+
+```python
+def rerank(
+    query: str,
+    candidates: list[dict],
+    top_k: int = 3,
+    instruction: str | None = None,
+) -> list[dict]:
+    """Kandidaten anhand von Text + Bild neu ordnen."""
+    documents = []
+    for product in candidates:
+        content = [
+            {"type": "text", "text": product["description"]},
+            {
+                "type": "image_url",
+                "image_url": {"url": encode_image(product["image"])},
+            },
+        ]
+        documents.append({"content": content})
+
+    payload: dict = {
+        "model": "Qwen3-VL-Reranker-2B",
+        "query": query,
+        "documents": documents,
+    }
+    if instruction:
+        payload["instruction"] = instruction
+
+    resp = requests.post(
+        "https://llm.aihosting.mittwald.de/v1/rerank",
+        headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+        json=payload,
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+    results = resp.json()["results"]
+    ranked = sorted(results, key=lambda r: r["relevance_score"], reverse=True)
+    return [candidates[r["index"]] for r in ranked[:top_k]]
+```
+
+## Vollständige Such-Pipeline
+
+```python
+def search(query: str, top_k: int = 3) -> list[dict]:
+    candidates = retrieve(query, top_k=min(10, len(CATALOGUE)))
+    return rerank(
+        query,
+        candidates,
+        top_k=top_k,
+        instruction="Given a product search query, find the most visually and functionally relevant items.",
+    )
+
+
+# Beispielanfragen
+for query in [
+    "dunkler Holzschreibtisch für das Home Office",
+    "weiße Lampe mit USB-Ladung",
+    "ergonomischer Sitzplatz für lange Arbeitssitzungen",
+]:
+    results = search(query)
+    print(f"\nAnfrage: {query}")
+    for i, product in enumerate(results, 1):
+        print(f"  {i}. [{product['id']}] {product['description'][:70]}")
+```
+
+## Nur Text-Reranking
+
+Ohne Bilder einfach Zeichenketten übergeben:
+
+```python
+def rerank_text_only(query: str, candidates: list[dict], top_k: int = 3) -> list[dict]:
+    documents = [p["description"] for p in candidates]
+    resp = requests.post(
+        "https://llm.aihosting.mittwald.de/v1/rerank",
+        headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+        json={"model": "Qwen3-VL-Reranker-2B", "query": query, "documents": documents},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    results = resp.json()["results"]
+    ranked = sorted(results, key=lambda r: r["relevance_score"], reverse=True)
+    return [candidates[r["index"]] for r in ranked[:top_k]]
+```
+
+:::tip
+Den `instruction`-Wert immer auf **Englisch** formulieren, auch wenn die Suchanfrage auf Deutsch ist. Weitere Details zu Anweisungsformat und Bildgrößenlimits auf der [Qwen3-VL-Reranker-2B-Modellseite](/docs/v2/platform/aihosting/models/qwen3-vl-reranker-2b).
+:::

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/90-whisper.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/90-whisper.mdx
@@ -175,6 +175,27 @@ client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
 
 Der gesamte übrige Code – Dateiverarbeitung, `response_format`, `language`, `temperature` – bleibt identisch.
 
+## Zeitstempel und Spracherkennung mit verbose_json {#verbose-json}
+
+`response_format="verbose_json"` gibt segmentgenaue Zeitstempel, die erkannte Sprache und die Gesamtdauer zurück:
+
+```python
+with open("aufnahme.mp3", "rb") as f:
+    result = client.audio.transcriptions.create(
+        model="whisper-large-v3-turbo",
+        file=f,
+        language="de",
+        response_format="verbose_json",
+        temperature=1.0,
+    )
+
+print(result.text)
+print(f"Sprache: {result.language}")
+print(f"Dauer: {result.duration}s")
+for seg in (result.segments or []):
+    print(f"  [{seg['start']:.1f}s–{seg['end']:.1f}s] {seg['text']}")
+```
+
 :::note Nicht unterstützte Formate
-Die `response_format`-Werte `srt`, `vtt` und `verbose_json` werden derzeit nicht unterstützt. `json` (Standard) oder `text` verwenden.
+`srt` und `vtt` werden nicht unterstützt (HTTP 400). `response_format="text"` wird akzeptiert, gibt aber immer einen JSON-Body zurück – stattdessen `"json"` oder `"verbose_json"` verwenden.
 :::

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/90-whisper.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/90-whisper.mdx
@@ -1,0 +1,180 @@
+---
+sidebar_label: Spracherkennung mit Whisper
+description: Audiodateien mit whisper-large-v3-turbo über die OpenAI-kompatible API transkribieren
+title: Spracherkennung mit Whisper
+---
+
+`whisper-large-v3-turbo` ist über denselben `/v1/audio/transcriptions`-Endpunkt wie die OpenAI Whisper API zugänglich, sodass jeder für OpenAI geschriebene Code durch Änderung der `base_url` direkt übernommen werden kann. Unterstützte Formate, Sprachcodes und Inferenzparameter auf der [Whisper-Modellseite](/docs/v2/platform/aihosting/models/whisper-large-v3-turbo).
+
+## Einrichtung {#einrichtung}
+
+```shellsession
+user@local $ pip install openai
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+Für das Aufteilen großer Dateien (über 25 MB):
+
+```shellsession
+user@local $ pip install pydub
+# pydub benötigt ffmpeg
+user@local $ brew install ffmpeg          # macOS
+user@local $ apt-get install ffmpeg       # Debian/Ubuntu
+```
+
+## Grundlegende Transkription
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+with open("aufnahme.mp3", "rb") as f:
+    result = client.audio.transcriptions.create(
+        model="whisper-large-v3-turbo",
+        file=f,
+        language="de",             # Immer explizit setzen — Standard ist "de"
+        response_format="json",
+        temperature=1.0,
+    )
+
+print(result.text)
+```
+
+:::warning `language` immer setzen
+Wird `language` nicht angegeben, nimmt das Modell standardmäßig Deutsch (`"de"`) an. Das Transkribieren englischer Audio-Dateien ohne `language="en"` liefert ungenaue Ergebnisse. Die vollständige Liste der ISO-639-1-Codes auf der [Modellseite](/docs/v2/platform/aihosting/models/whisper-large-v3-turbo).
+:::
+
+## Mehrere Sprachen
+
+```python
+dateien_und_sprachen = [
+    ("meeting_de.mp3", "de"),
+    ("interview_fr.wav", "fr"),
+    ("podcast_en.ogg", "en"),
+    ("vortrag_ja.flac", "ja"),
+]
+
+for dateiname, sprache in dateien_und_sprachen:
+    with open(dateiname, "rb") as f:
+        result = client.audio.transcriptions.create(
+            model="whisper-large-v3-turbo",
+            file=f,
+            language=sprache,
+            response_format="json",
+            temperature=1.0,
+        )
+    print(f"[{sprache}] {result.text[:120]}")
+```
+
+## Große Dateien (> 25 MB) {#grosse-dateien}
+
+Die API akzeptiert Dateien bis zu 25 MB. Größere Aufnahmen mit `pydub` an Stille-Stellen aufteilen, damit jeder Abschnitt sicher unter dem Limit bleibt und keine Wörter mittendrin geschnitten werden:
+
+```python
+from pydub import AudioSegment
+from pydub.silence import split_on_silence
+from io import BytesIO
+
+
+def grosse_datei_transkribieren(path: str, language: str = "de") -> str:
+    """Datei beliebiger Größe transkribieren durch Aufteilen an Stille-Stellen."""
+    audio = AudioSegment.from_file(path)
+
+    # An Pausen von mehr als 700 ms mit Stille unter -40 dBFS aufteilen
+    chunks = split_on_silence(
+        audio,
+        min_silence_len=700,
+        silence_thresh=-40,
+        keep_silence=300,   # 300 ms Stille an jeder Kante für Kontext beibehalten
+    )
+
+    # Fallback: wenn keine Stille gefunden, in feste 60-Sekunden-Abschnitte aufteilen
+    if not chunks:
+        chunk_ms = 60_000
+        chunks = [audio[i: i + chunk_ms] for i in range(0, len(audio), chunk_ms)]
+
+    transkripte: list[str] = []
+    for chunk in chunks:
+        buf = BytesIO()
+        chunk.export(buf, format="mp3")
+        buf.seek(0)
+        buf.name = "chunk.mp3"   # openai SDK liest das .name-Attribut für den MIME-Typ
+
+        result = client.audio.transcriptions.create(
+            model="whisper-large-v3-turbo",
+            file=buf,
+            language=language,
+            response_format="json",
+            temperature=1.0,
+        )
+        transkripte.append(result.text)
+
+    return " ".join(transkripte)
+
+
+volltext = grosse_datei_transkribieren("langes_interview.mp3", language="de")
+print(volltext)
+```
+
+## Transkription + Zusammenfassungs-Pipeline
+
+Whisper mit einem Chat-Modell verknüpfen, um direkt von Audio zu einer schriftlichen Zusammenfassung zu gelangen:
+
+```python
+def transkribieren_und_zusammenfassen(audio_path: str, language: str = "de") -> dict:
+    # Schritt 1: Transkribieren
+    with open(audio_path, "rb") as f:
+        result = client.audio.transcriptions.create(
+            model="whisper-large-v3-turbo",
+            file=f,
+            language=language,
+            response_format="json",
+            temperature=1.0,
+        )
+    transkript = result.text
+
+    # Schritt 2: Zusammenfassen
+    zusammenfassung_resp = client.chat.completions.create(
+        model="Qwen3.6-35B-A3B-FP8",
+        messages=[
+            {
+                "role": "system",
+                "content": "Fasse das Transkript prägnant zusammen. Verwende Stichpunkte für die wichtigsten Themen.",
+            },
+            {"role": "user", "content": transkript},
+        ],
+        temperature=0.7,
+        max_tokens=512,
+        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+    )
+
+    return {
+        "transkript": transkript,
+        "zusammenfassung": zusammenfassung_resp.choices[0].message.content,
+    }
+
+
+ausgabe = transkribieren_und_zusammenfassen("team_standup.mp3", language="de")
+print("Transkript:\n", ausgabe["transkript"])
+print("\nZusammenfassung:\n", ausgabe["zusammenfassung"])
+```
+
+## Drop-in-Ersatz für OpenAI
+
+Bestehender Code für die OpenAI Whisper API benötigt nur eine `base_url`-Änderung:
+
+```python
+# Vorher (OpenAI)
+client = OpenAI()
+
+# Nachher (mittwald AI Hosting)
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+```
+
+Der gesamte übrige Code – Dateiverarbeitung, `response_format`, `language`, `temperature` – bleibt identisch.
+
+:::note Nicht unterstützte Formate
+Die `response_format`-Werte `srt`, `vtt` und `verbose_json` werden derzeit nicht unterstützt. `json` (Standard) oder `text` verwenden.
+:::


### PR DESCRIPTION

### Neue Modellseiten (EN + DE)

- **Qwen3.5-0.8B** – Ultra-kleines Chat- und Reasoning-Modell (262k Context, Thinking opt-in, Tool-Calling)
- **Qwen3-VL-Reranker-2B** – Multimodaler Reranker über `/v1/rerank`, akzeptiert Text + Bilder
- **Mistral-Medium-3.5-128B** – 128B-Frontier-Modell, Vision, Tool-Calling, 40+ Sprachen, 256k Context

### Neue Beispiel-Guides (EN + DE)

| Guide | Modelle |
|-------|---------|
| LLM-Cascade-Routing | Qwen3.5-0.8B → Qwen3.6-35B → Mistral-Medium (+ Alternativen gpt-oss-120b, Qwen3.5-122B) |
| Dokument-Q&A-Pipeline | GLM-OCR → Qwen3-Embedding-8B → Qwen3-VL-Reranker-2B → Qwen3.5-122B |
| Mehrsprachiger Tool-Calling-Agent | Mistral-Medium-3.5-128B (auch mit Qwen3.5-122B / Qwen3.6-35B verwendbar) |
| Multimodale Produktsuche | Qwen3-Embedding-8B + Qwen3-VL-Reranker-2B mit Bild-Dokumenten |
| Spracherkennung mit Whisper | whisper-large-v3-turbo – Transkription, Chunking großer Dateien, Pipeline mit Zusammenfassung |

### Fixes & Korrekturen

- `response_format="verbose_json"` bei Whisper funktioniert und gibt Sprache/Zeitstempel zurück — war fälschlicherweise als nicht unterstützt dokumentiert
- `response_format="text"` gibt JSON-Body zurück — Empfehlung entfernt, Warnung ergänzt
- `documents` NameError im Reranker-Beispiel behoben
- Deutsche `instruction`-Strings im Reranker-Beispiel auf Englisch korrigiert (Modell-Requirement)
- Fehlende `slug:`-Felder in Qwen3-Embedding-8B- und Whisper-Modellseiten ergänzt
- Whisper-Modellkarte um redundante Best-Practices-Sektion bereinigt, Link auf Guide ergänzt