### PR TITLE
docs: re-arange models list table to make it more comprehensible

### DIFF
--- a/docs/platform/aihosting/30-models/index.mdx
+++ b/docs/platform/aihosting/30-models/index.mdx
@@ -5,18 +5,18 @@ import DocCardList from "@theme/DocCardList";
 
 We currently offer the following models, which may change or expand over time. Each is described along with model-specific parameters.
 
-| Model Name                         | Type                      | Modalities                | Context (Tokens)  | License    |
-| ---------------------------------- | ------------------------- | ------------------------- | ----------------- | ---------- |
-| gpt-oss-120b                       | Chat + reasoning          | Text, tool-calling        | 131,072           | Apache 2.0 |
-| Ministral-3-14B-Instruct-2512      | Chat + vision             | Text, image, tool-calling | 262,144           | Apache 2.0 |
-| Qwen3-Embedding-8B                 | Embedding                 | Text to vector            | 32,768            | Apache 2.0 |
-| whisper-large-v3-turbo             | Speech-to-Text            | Audio to text             | N/A (audio-based) | MIT        |
-| Qwen3.5-122B-A10B-FP8              | Chat + reasoning + vision | Text, image, tool-calling | 245,760           | Apache 2.0 |
-| Qwen3.6-35B-A3B-FP8               | Chat + reasoning + vision | Text, image, tool-calling | 262,144           | Apache 2.0 |
-| GLM-OCR                            | Document OCR              | PDF, DOCX, PPTX, XLSX, HTML, SVG, image to text | 131,072 | MIT |
-| Qwen3.5-0.8B                       | Chat + reasoning          | Text, tool-calling        | 262,144           | Apache 2.0 |
-| Qwen3-VL-Reranker-2B               | Reranking                 | Text, image to score      | 32,768            | Apache 2.0 |
-| Mistral-Medium-3.5-128B            | Chat + vision             | Text, image, tool-calling | 256,000           | Apache 2.0 |
+| Model Name                    | Type                      | Modalities                                      | Context (Tokens)  | License    |
+| ----------------------------- | ------------------------- | ----------------------------------------------- | ----------------- | ---------- |
+| gpt-oss-120b                  | Chat + reasoning          | Text, tool-calling                              | 131,072           | Apache 2.0 |
+| Qwen3.5-0.8B                  | Chat + reasoning          | Text, tool-calling                              | 262,144           | Apache 2.0 |
+| Ministral-3-14B-Instruct-2512 | Chat + vision             | Text, image, tool-calling                       | 262,144           | Apache 2.0 |
+| Mistral-Medium-3.5-128B       | Chat + vision             | Text, image, tool-calling                       | 256,000           | Apache 2.0 |
+| Qwen3.5-122B-A10B-FP8         | Chat + reasoning + vision | Text, image, tool-calling                       | 245,760           | Apache 2.0 |
+| Qwen3.6-35B-A3B-FP8           | Chat + reasoning + vision | Text, image, tool-calling                       | 262,144           | Apache 2.0 |
+| GLM-OCR                       | Document OCR              | PDF, DOCX, PPTX, XLSX, HTML, SVG, image to text | 131,072           | MIT        |
+| Qwen3-Embedding-8B            | Embedding                 | Text to vector                                  | 32,768            | Apache 2.0 |
+| Qwen3-VL-Reranker-2B          | Reranking                 | Text, image to score                            | 32,768            | Apache 2.0 |
+| whisper-large-v3-turbo        | Speech-to-Text            | Audio to text                                   | N/A (audio-based) | MIT        |
 
 ## Picking models {#picking-models}
 
@@ -32,7 +32,7 @@ We currently offer the following models, which may change or expand over time. E
 - Use `Mistral-Medium-3.5-128B` for complex reasoning, multilingual tasks, or vision workloads where a large frontier model is required.
 
 :::tip
-For optimal ROI, start with the smallest model that meets your quality bar—then upgrade *only* where you need additional depth or reliability!
+For optimal ROI, start with the smallest model that meets your quality bar—then upgrade _only_ where you need additional depth or reliability!
 "Small" here refers to the number of parameters a model has, which often correlates with cost and compute requirements.
 The "context size" of a model (measured in tokens) is also a crucial factor to consider, as it determines how much information the model can process at once, which can also impact performance and suitability for certain tasks.
 So when it comes to model selection, it's not just about picking the most powerful model, but rather the one that best fits your specific use case.
@@ -41,4 +41,3 @@ So when it comes to model selection, it's not just about picking the most powerf
 Please have a look at the following pages to gather more information about a specific model:
 
 <DocCardList />
-

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
@@ -5,18 +5,18 @@ import DocCardList from "@theme/DocCardList";
 
 Wir bieten aktuell die nachfolgenden Modelle an, die sich im Laufe der Zeit ändern oder erweitern können. Diese werden beschrieben und modellspezifische Parameter aufgeführt.
 
-| Modellname                         | Typ                               | Modalitäten              | Context (Tokens)    | Lizenz     |
-| ---------------------------------- | --------------------------------- | ------------------------ | ------------------- | ---------- |
-| gpt-oss-120b                       | Chat + Reasoning                  | Text, Tool-Calling       | 131.072             | Apache 2.0 |
-| Ministral-3-14B-Instruct-2512      | Chat + Vision                     | Text, Bild, Tool-Calling | 262.144             | Apache 2.0 |
-| Qwen3-Embedding-8B                 | Embedding                         | Text → Vektor            | 32.768              | Apache 2.0 |
-| whisper-large-v3-turbo             | Speech-to-Text                    | Audio → Text             | n/a (Audio-basiert) | MIT        |
-| Qwen3.5-122B-A10B-FP8              | Chat + Reasoning + Vision         | Text, Bild, Tool-Calling | 245.760             | Apache 2.0 |
-| Qwen3.6-35B-A3B-FP8               | Chat + Reasoning + Vision         | Text, Bild, Tool-Calling | 256.000             | Apache 2.0 |
-| GLM-OCR                            | Dokument-OCR                      | PDF, DOCX, PPTX, XLSX, HTML, SVG, Bild → Text | 131.072 | MIT |
-| Qwen3.5-0.8B                       | Chat + Reasoning                  | Text, Tool-Calling       | 262.144             | Apache 2.0 |
-| Qwen3-VL-Reranker-2B               | Reranking                         | Text, Bild → Score       | 32.768              | Apache 2.0 |
-| Mistral-Medium-3.5-128B            | Chat + Vision                     | Text, Bild, Tool-Calling | 256.000             | Apache 2.0 |
+| Modellname                    | Typ                       | Modalitäten                                   | Context (Tokens)    | Lizenz     |
+| ----------------------------- | ------------------------- | --------------------------------------------- | ------------------- | ---------- |
+| gpt-oss-120b                  | Chat + Reasoning          | Text, Tool-Calling                            | 131.072             | Apache 2.0 |
+| Qwen3.5-0.8B                  | Chat + Reasoning          | Text, Tool-Calling                            | 262.144             | Apache 2.0 |
+| Ministral-3-14B-Instruct-2512 | Chat + Vision             | Text, Bild, Tool-Calling                      | 262.144             | Apache 2.0 |
+| Mistral-Medium-3.5-128B       | Chat + Vision             | Text, Bild, Tool-Calling                      | 256.000             | Apache 2.0 |
+| Qwen3.5-122B-A10B-FP8         | Chat + Reasoning + Vision | Text, Bild, Tool-Calling                      | 245.760             | Apache 2.0 |
+| Qwen3.6-35B-A3B-FP8           | Chat + Reasoning + Vision | Text, Bild, Tool-Calling                      | 256.000             | Apache 2.0 |
+| GLM-OCR                       | Dokument OCR              | PDF, DOCX, PPTX, XLSX, HTML, SVG, Bild → Text | 131.072             | MIT        |
+| Qwen3-Embedding-8B            | Embedding                 | Text → Vektor                                 | 32.768              | Apache 2.0 |
+| Qwen3-VL-Reranker-2B          | Reranking                 | Text, Bild → Score                            | 32.768              | Apache 2.0 |
+| whisper-large-v3-turbo        | Speech-to-Text            | Audio → Text                                  | n/a (Audio-basiert) | MIT        |
 
 ## Modellauswahl {#picking-models}
 
@@ -32,7 +32,7 @@ Wir bieten aktuell die nachfolgenden Modelle an, die sich im Laufe der Zeit änd
 - Verwende `Mistral-Medium-3.5-128B` für komplexe Reasoning-, mehrsprachige oder Vision-Aufgaben, bei denen ein großes Frontier-Modell erforderlich ist.
 
 :::tip
-Für optimalen ROI beginne mit dem kleinsten Modell, das deinen Qualitätsanforderungen entspricht – steige *nur dann* auf ein größeres Modell um, wenn du zusätzliche Tiefe oder Zuverlässigkeit benötigst!
+Für optimalen ROI beginne mit dem kleinsten Modell, das deinen Qualitätsanforderungen entspricht – steige _nur dann_ auf ein größeres Modell um, wenn du zusätzliche Tiefe oder Zuverlässigkeit benötigst!
 "Klein" bezieht sich hier auf die Anzahl der Parameter, die ein Modell hat, was oft mit Kosten und Rechenanforderungen korreliert.
 Die Größe des Kontextes eines Modells (gemessen in Tokens) ist ebenfalls ein entscheidender Faktor, da sie bestimmt, wie viele Informationen das Modell auf einmal verarbeiten kann, was sich auch auf die Leistung und Eignung für bestimmte Aufgaben auswirken kann.
 Bei der Modellauswahl geht es also nicht nur darum, das leistungsstärkste Modell auszuwählen, sondern vielmehr dasjenige, das am besten zu deinem spezifischen Anwendungsfall passt.


### PR DESCRIPTION
Just change the order in the models table to make it easier to get an overview of the models