### PR TITLE
docs: re-organize picking models section

### DIFF
--- a/docs/platform/aihosting/30-models/index.mdx
+++ b/docs/platform/aihosting/30-models/index.mdx
@@ -20,16 +20,29 @@ We currently offer the following models, which may change or expand over time. E
 
 ## Picking models {#picking-models}
 
-- Start with `Ministral-3-14B-Instruct-2512` for broad, scalable, cost-conscious chat and basic multimodal (text + image) workflows.
-- Use `gpt-oss-120b` for complex text-centric workloads and advanced automations when precision and vast knowledge are required.
-- Choose `Qwen3-Embedding-8B` for all use cases involving search, recommendation, clustering, or knowledge graph building.
-- Use `whisper-large-v3-turbo` for any audio transcription or voice-command needs.
-- Use `Qwen3.5-122B-A10B-FP8` for large-scale reasoning and vision tasks where high model capacity is required.
-- Use `Qwen3.6-35B-A3B-FP8` for workloads that require long context windows with reasoning and vision support at lower cost.
-- Use `GLM-OCR` for extracting text from PDF, DOCX, PPTX, XLSX, HTML, and image documents — including scanned invoices, contracts, and forms.
-- Use `Qwen3.5-0.8B` for high-throughput, cost-sensitive tasks that don't require vision — simple Q&A, routing, classification, and batch processing.
-- Use `Qwen3-VL-Reranker-2B` to improve RAG retrieval precision by adding it as a second-pass reranker after vector search.
-- Use `Mistral-Medium-3.5-128B` for complex reasoning, multilingual tasks, or vision workloads where a large frontier model is required.
+- For complex text-centric workloads and advanced automations when precision and vast knowledge are required \
+  use `gpt-oss-120b`.
+- For high-throughput, cost-sensitive tasks that don't require vision (e.g. simple Q&A, routing, classification, and batch processing) \
+  use `Qwen3.5-0.8B`.
+- For complex reasoning, multilingual tasks, or vision workloads where a large frontier model is required \
+  use `Mistral-Medium-3.5-128B`.
+- For broad, scalable, cost-conscious chat and basic multimodal (text + image) workflows \
+  use `Ministral-3-14B-Instruct-2512`.
+- For large-scale reasoning and vision tasks where high model capacity is required \
+  use `Qwen3.5-122B-A10B-FP8`.
+- For workloads that require long context windows with reasoning and vision support at lower cost \
+  use `Qwen3.6-35B-A3B-FP8`.
+- Special-purpose applications
+  - For extracting text from PDF, DOCX, PPTX, XLSX, HTML, and image documents — including scanned invoices, contracts, and forms – \
+    use `GLM-OCR`
+  - For all use cases involving search, recommendation, clustering, or knowledge graph building \
+    use `Qwen3-Embedding-8B`
+  - For any audio transcription or voice-command needs \
+    use `whisper-large-v3-turbo`
+  - To improve RAG retrieval precision by adding it as a second-pass reranker after vector search \
+    use `Qwen3-VL-Reranker-2B`
+
+For more details and additional tips have a look at the [usage examples and guides](../examples/).
 
 :::tip
 For optimal ROI, start with the smallest model that meets your quality bar—then upgrade _only_ where you need additional depth or reliability!

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
@@ -20,16 +20,29 @@ Wir bieten aktuell die nachfolgenden Modelle an, die sich im Laufe der Zeit änd
 
 ## Modellauswahl {#picking-models}
 
-- Beginne mit `Ministral-3-14B-Instruct-2512` für breite, skalierbare, kostenbewusste Chat- und einfache multimodale Workflows (Text + Bild).
-- Verwende `gpt-oss-120b` für komplexe textbasierte Workloads und fortgeschrittene Automatisierungen, die eine hohe Präzision und umfangreiches Wissen erfordern.
-- Wähle `Qwen3-Embedding-8B` für alle Anwendungsfälle mit Suche, Empfehlung, Clustering oder Knowledge-Graph-Aufbau.
-- Setze `whisper-large-v3-turbo` für alle Transkriptions- oder Sprachbefehl-Anforderungen ein.
-- Verwende `Qwen3.5-122B-A10B-FP8` für umfangreiche Reasoning- und Vision-Aufgaben, bei denen hohe Modellkapazität erforderlich ist.
-- Verwende `Qwen3.6-35B-A3B-FP8` für Workloads, die lange Kontextfenster mit Reasoning- und Vision-Unterstützung bei niedrigeren Kosten erfordern.
-- Verwende `GLM-OCR` zum Extrahieren von Text aus PDF-, DOCX-, PPTX-, XLSX-, HTML- und Bilddokumenten – einschließlich gescannter Rechnungen, Verträge und Formulare.
-- Verwende `Qwen3.5-0.8B` für hochdurchsatz- und kostensensitive Aufgaben ohne Vision-Bedarf – einfache Frage-Antwort, Routing, Klassifizierung und Batch-Verarbeitung.
-- Verwende `Qwen3-VL-Reranker-2B`, um die RAG-Retrievalpräzision durch einen zweiten Reranking-Schritt nach der Vektorsuche zu verbessern.
-- Verwende `Mistral-Medium-3.5-128B` für komplexe Reasoning-, mehrsprachige oder Vision-Aufgaben, bei denen ein großes Frontier-Modell erforderlich ist.
+- Für komplexe textzentrierte Workloads und fortgeschrittene Automatisierungen, bei denen hohe Präzision und umfangreiches Wissen erforderlich sind \
+  verwende `gpt-oss-120b`.
+- Für hochdurchsatz- und kostensensitive Aufgaben ohne Vision-Bedarf, etwa einfache Frage-Antwort-Szenarien, Routing, Klassifizierung und Batch-Verarbeitung \
+  verwende `Qwen3.5-0.8B`.
+- Für komplexe Reasoning-, mehrsprachige oder Vision-Aufgaben, bei denen ein großes Frontier-Modell erforderlich ist \
+  verwende `Mistral-Medium-3.5-128B`.
+- Für generelle, skalierbare und kostenbewusste Chat- sowie einfache multimodale Workflows (Text + Bild) \
+  verwende `Ministral-3-14B-Instruct-2512`.
+- Für umfangreiche Reasoning- und Vision-Aufgaben, bei denen hohe Modellkapazität erforderlich ist \
+  verwende `Qwen3.5-122B-A10B-FP8`.
+- Für Workloads, die lange Kontextfenster mit Reasoning- und Vision-Unterstützung bei niedrigeren Kosten erfordern \
+  verwende `Qwen3.6-35B-A3B-FP8`.
+- Spezialanwendungen
+  - Für das Extrahieren von Text aus PDF-, DOCX-, PPTX-, XLSX-, HTML- und Bilddokumenten, einschließlich gescannter Rechnungen, Verträge und Formulare \
+    verwende `GLM-OCR`
+  - Für alle Anwendungsfälle mit Suche, Empfehlung, Clustering oder dem Aufbau von Knowledge Graphen \
+    verwende `Qwen3-Embedding-8B`
+  - Für alle Transkriptions- oder Sprachbefehl-Anforderungen \
+    verwende `whisper-large-v3-turbo`
+  - Für eine verbesserte Präzision beim RAG-Retrieval durch einen zweiten Reranking-Schritt nach der Vektorsuche \
+    verwende `Qwen3-VL-Reranker-2B`
+
+Für weitere Details und zusätzliche Hinweise wirf einen Blick in die [Beispiele und Anleitungen](../examples/).
 
 :::tip
 Für optimalen ROI beginne mit dem kleinsten Modell, das deinen Qualitätsanforderungen entspricht – steige _nur dann_ auf ein größeres Modell um, wenn du zusätzliche Tiefe oder Zuverlässigkeit benötigst!


### PR DESCRIPTION
* Reihenfolge sortiert wie hier im Thread Beschrieben
* Formulierung umgedreht von »Use .. for ..« zu »For .. use ..«
* »use Model-Name« steht immer nach nem Linebreak, um die Übersichtlichkeit zu erhöhen
* Link zu Examples unter der Liste hinzugefügt
* Verbesserungen / Änderungen in der deutschen Übersetzung
  * Ministral: breite → generelle
  * Qwen3-Embedding: oder Knowledge-Graph-Aufbau → oder dem Aufbau von Knowledge Graphen
  * Qwen3-VL-Reranker-2B: Umstellung des Satzes um besser der neuen Struktur zu entsprechen