### PR TITLE
docs: update WordPress AI documentation for WordPress 7.0

### DIFF
--- a/docs/platform/aihosting/60-cms/30-wordpress.mdx
+++ b/docs/platform/aihosting/60-cms/30-wordpress.mdx
@@ -1,36 +1,26 @@
 ---
 sidebar_label: WordPress
-description: Learn how to use the mittwald AI provider with WordPress AI Experiments
+description: Learn how to use the mittwald AI provider with WordPress AI
 title: WordPress
 ---
 
 ## Using the mittwald AI provider for WordPress {#using-mittwald-ai-provider}
 
-The mittwald AI provider plugin enables integration between [WordPress AI Experiments](https://wordpress.org/plugins/ai/) and mittwald AI Hosting. This allows you to leverage mittwald's AI models directly within the WordPress editor for content generation tasks such as generating titles, excerpts, and alt texts. You can find the official plugin on the [WordPress plugin directory](https://wordpress.org/plugins/mittwald-ai-provider).
+The [AI Provider for mittwald](https://wordpress.org/plugins/mittwald-ai-provider) plugin enables integration between WordPress and mittwald AI Hosting. This allows you to leverage mittwald's AI models directly within WordPress for content generation tasks such as generating titles, excerpts, and alt texts.
 
 ### Prerequisites {#prerequisites}
 
-Before installing the mittwald AI provider, you need to have the WordPress AI Experiments plugin installed and activated. This base plugin provides the AI framework that the mittwald provider extends with mittwald-hosted models.
+The mittwald AI provider requires WordPress 7.0 or higher. WordPress 7.0 includes the AI Client and Connectors screen as part of core, which the mittwald provider uses to register as an AI connector.
 
-The AI Experiments plugin requires WordPress 6.9 or higher and PHP 7.4 or higher. It brings experimental AI-powered features into the WordPress editing experience, including title generation, excerpt creation, and alt text suggestions.
+Optionally, you can install the [AI plugin](https://wordpress.org/plugins/ai/) by WordPress.org to access additional AI-powered features in the WordPress editor, such as title generation, excerpt creation, alt text suggestions, image generation, and comment moderation.
 
 ### Installation {#installation}
 
-The installation process involves two plugins: first the AI Experiments base plugin, then the mittwald AI provider.
+WordPress 7.0 includes the AI Client and Connectors screen as part of core. The mittwald AI provider registers as a connector in this screen. Optionally, you can install the AI plugin to access additional AI-powered features in the WordPress editor.
 
-#### Step 1: Install the AI Experiments plugin {#step-1-install-ai-experiments}
+#### Step 1: Install the AI Provider for mittwald {#step-1-install-mittwald-provider}
 
-Navigate to **Plugins** -> **Add New** in your WordPress admin interface and search for "AI Experiments". Install and activate the plugin.
-
-Alternatively, you can use WP-CLI to install and activate the plugin from the command line:
-
-```shellsession
-user@ssh $ wp plugin install ai --activate
-```
-
-#### Step 2: Install the mittwald AI provider {#step-2-install-mittwald-provider}
-
-With the AI Experiments plugin active, install the mittwald AI provider. In your WordPress admin, navigate to **Plugins** -> **Add New** and search for "mittwald AI provider". Install and activate the plugin to enable mittwald AI Hosting as a provider option.
+Navigate to **Plugins** -> **Add New** in your WordPress admin interface and search for "AI Provider for mittwald". Install and activate the plugin to enable mittwald AI Hosting as a connector option.
 
 Using WP-CLI, you can accomplish this with:
 
@@ -38,9 +28,19 @@ Using WP-CLI, you can accomplish this with:
 user@ssh $ wp plugin install mittwald-ai-provider --activate
 ```
 
+#### Step 2 (optional): Install the AI plugin {#step-2-install-ai}
+
+The [AI plugin](https://wordpress.org/plugins/ai/) by WordPress.org provides additional AI-powered features in the WordPress editor, such as title generation, excerpt creation, alt text suggestions, image generation, and comment moderation. Navigate to **Plugins** -> **Add New** and search for "AI" by WordPress.org.
+
+Alternatively, use WP-CLI:
+
+```shellsession
+user@ssh $ wp plugin install ai --activate
+```
+
 ### Configuration {#configuration}
 
-Once both plugins are installed, you'll need to configure your mittwald API credentials and enable the AI experiments you want to use.
+Once the mittwald AI provider is installed, you'll need to configure your API credentials. If you installed the AI plugin, you can also enable its features.
 
 #### Step 1: Obtain your API key {#step-1-obtain-api-key}
 
@@ -48,18 +48,22 @@ If you don't have an API key yet, follow the [mittwald AI Hosting access guide](
 
 #### Step 2: Store your API credentials {#step-2-store-credentials}
 
-Navigate to **Settings** -> **AI Credentials** in your WordPress admin interface. Enter your mittwald AI Hosting API key in the appropriate field and save your settings. This establishes the connection between your WordPress site and mittwald's AI services.
+Navigate to **Settings** -> **Connectors** in your WordPress admin interface. Enter your mittwald AI Hosting API key in the mittwald connector field and save your settings. This establishes the connection between your WordPress site and mittwald's AI services.
 
-#### Step 3: Enable AI experiments {#step-3-enable-experiments}
+Alternatively, you can configure the API key via `wp-config.php` by defining the `MITTWALD_API_KEY` constant, or via environment variables.
 
-Navigate to **Settings** -> **AI Experiments** and click the button to enable experiments globally. You can then toggle individual experiments based on which features you want to use. Available experiments include:
+#### Step 3: Enable AI features (if using the AI plugin) {#step-3-enable-features}
+
+If you installed the AI plugin, navigate to **Settings** -> **AI** and enable the features you want to use. Available features include:
 
 - **Title Generation**: Generate title suggestions with a single click in the post editor
 - **Excerpt Generation**: Automatically create concise summaries for your posts
 - **Content Summarization**: Summarize long-form content into digestible overviews
 - **Alt Text Generation**: Generate descriptive alt text for images to improve accessibility
+- **Image Generation**: Create and edit images from post content
+- **Comment Moderation**: Automatically moderate comments based on toxicity detection
 
-Save your settings after enabling the desired experiments.
+Save your settings after enabling the desired features.
 
 ### Using AI features {#using-ai-features}
 
@@ -71,9 +75,15 @@ When editing a post, you'll find AI-powered buttons in relevant locations throug
 
 The mittwald AI provider supports chat completions with several models optimized for different tasks:
 
-- **GPT-OSS models**: Open-source GPT-compatible models for general content generation
-- **Ministral**: Supports vision and image input capabilities
-These models support standard text generation, JSON output formatting, tool calling, and streaming responses. The Ministral models additionally support image vision capabilities for analyzing and describing images.
+- **gpt-oss-120b**: Open-source GPT-compatible model for general content generation and advanced reasoning
+- **Qwen3.5-122B-A10B-FP8** and **Qwen3.6-35B-A3B-FP8**: Large models with reasoning and vision capabilities
+- **Qwen3.5-0.8B**: Lightweight model for cost-sensitive tasks
+- **Ministral-3-14B-Instruct-2512**: Chat model with vision and image input capabilities
+- **Mistral-Medium-3.5-128B**: Frontier model for complex reasoning and vision workloads
+
+These models support standard text generation, JSON output formatting, tool calling, and streaming responses. The Ministral, Mistral-Medium, and Qwen models additionally support image vision capabilities for analyzing and describing images.
+
+For a complete list of available models and their capabilities, see the [available models](../../models/) documentation.
 
 ### Usage limits {#usage-limits}
 

--- a/docs/platform/aihosting/60-cms/30-wordpress.mdx
+++ b/docs/platform/aihosting/60-cms/30-wordpress.mdx
@@ -50,7 +50,7 @@ If you don't have an API key yet, follow the [mittwald AI Hosting access guide](
 
 Navigate to **Settings** -> **Connectors** in your WordPress admin interface. Enter your mittwald AI Hosting API key in the mittwald connector field and save your settings. This establishes the connection between your WordPress site and mittwald's AI services.
 
-Alternatively, you can configure the API key via `wp-config.php` by defining the `MITTWALD_API_KEY` constant, or via environment variables.
+Alternatively, you can configure the API key via `wp-config.php` by defining the `MITTWALD_API_KEY` constant, or by setting the `MITTWALD_API_KEY` environment variable. WordPress [resolves API keys](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/) in this order: environment variable, then PHP constant, then database (admin UI).
 
 #### Step 3: Enable AI features (if using the AI plugin) {#step-3-enable-features}
 
@@ -62,6 +62,8 @@ If you installed the AI plugin, navigate to **Settings** -> **AI** and enable th
 - **Alt Text Generation**: Generate descriptive alt text for images to improve accessibility
 - **Image Generation**: Create and edit images from post content
 - **Comment Moderation**: Automatically moderate comments based on toxicity detection
+
+For a complete list of all features currently available, refer to the [official plugin page](https://wordpress.org/plugins/ai/).
 
 Save your settings after enabling the desired features.
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/60-cms/30-wordpress.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/60-cms/30-wordpress.mdx
@@ -20,7 +20,7 @@ WordPress 7.0 enthält den AI Client und die Connectors-Oberfläche als Teil des
 
 #### Schritt 1: AI Provider for mittwald installieren {#step-1-install-mittwald-provider}
 
-Navigiere zu **Plugins** -> **Installieren** in deiner WordPress-Administrationsoberfläche und suche nach „AI Provider for mittwald". Installiere und aktiviere das Plugin, um mittwald AI Hosting als Connector-Option zu aktivieren.
+Navigiere zu **Plugins** -> **Installieren** in deiner WordPress-Administrationsoberfläche und suche nach „AI Provider for mittwald“. Installiere und aktiviere das Plugin, um mittwald AI Hosting als Connector-Option zu aktivieren.
 
 Mit WP-CLI kannst du dies folgendermaßen erreichen:
 
@@ -30,7 +30,7 @@ user@ssh $ wp plugin install mittwald-ai-provider --activate
 
 #### Schritt 2 (optional): AI-Plugin installieren {#step-2-install-ai}
 
-Das [AI-Plugin](https://wordpress.org/plugins/ai/) von WordPress.org bietet zusätzliche KI-gestützte Funktionen im WordPress-Editor, wie Titelgenerierung, Auszugserstellung, Alt-Text-Vorschläge, Bildgenerierung und Kommentarmoderation. Navigiere zu **Plugins** -> **Installieren** und suche nach „AI" von WordPress.org.
+Das [AI-Plugin](https://wordpress.org/plugins/ai/) von WordPress.org bietet zusätzliche KI-gestützte Funktionen im WordPress-Editor, wie Titelgenerierung, Auszugserstellung, Alt-Text-Vorschläge, Bildgenerierung und Kommentarmoderation. Navigiere zu **Plugins** -> **Installieren** und suche nach „AI“ von WordPress.org.
 
 Alternativ mit WP-CLI:
 
@@ -50,7 +50,7 @@ Falls du noch keinen API-Schlüssel hast, folge der [mittwald AI Hosting Zugangs
 
 Navigiere zu **Einstellungen** -> **Connectors** in deiner WordPress-Administrationsoberfläche. Gib deinen mittwald AI Hosting API-Schlüssel in das mittwald-Connector-Feld ein und speichere deine Einstellungen. Dies stellt die Verbindung zwischen deiner WordPress-Website und den mittwald AI-Diensten her.
 
-Alternativ kannst du den API-Schlüssel über `wp-config.php` konfigurieren, indem du die Konstante `MITTWALD_API_KEY` definierst, oder über Umgebungsvariablen.
+Alternativ kannst du den API-Schlüssel über `wp-config.php` konfigurieren, indem du die Konstante `MITTWALD_API_KEY` definierst, oder über die Umgebungsvariable `MITTWALD_API_KEY`. WordPress [löst API-Schlüssel](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/) in dieser Reihenfolge auf: Umgebungsvariable, dann PHP-Konstante, dann Datenbank (Admin-Oberfläche).
 
 #### Schritt 3: KI-Funktionen aktivieren (bei Verwendung des AI-Plugins) {#step-3-enable-features}
 
@@ -63,13 +63,15 @@ Falls du das AI-Plugin installiert hast, navigiere zu **Einstellungen** -> **AI*
 - **Bildgenerierung**: Erstelle und bearbeite Bilder aus Beitragsinhalten
 - **Kommentarmoderation**: Moderiere Kommentare automatisch basierend auf Toxizitätserkennung
 
+Eine vollständige Liste aller aktuell verfügbaren Funktionen findest du auf der [offiziellen Plugin-Seite](https://wordpress.org/plugins/ai/).
+
 Speichere deine Einstellungen nach dem Aktivieren der gewünschten Funktionen.
 
 ### KI-Funktionen verwenden {#using-ai-features}
 
 Alle KI-Funktionen in WordPress sind Opt-in und erfordern manuelle Auslösung. Nichts geschieht automatisch ohne deine ausdrückliche Aktion.
 
-Beim Bearbeiten eines Beitrags findest du KI-gestützte Schaltflächen an relevanten Stellen im Editor. Beispielsweise erhält das Titelfeld eine „Generieren"-Schaltfläche, die ein Modal mit KI-generierten Titelvorschlägen öffnet. Die Beitrags-Seitenleiste enthält eine „Auszug generieren"-Schaltfläche für die automatische Zusammenfassungserstellung. Bildblöcke zeigen eine „Alt-Text generieren"-Option zur Erstellung barrierefreier Beschreibungen.
+Beim Bearbeiten eines Beitrags findest du KI-gestützte Schaltflächen an relevanten Stellen im Editor. Beispielsweise erhält das Titelfeld eine „Generieren“-Schaltfläche, die ein Modal mit KI-generierten Titelvorschlägen öffnet. Die Beitrags-Seitenleiste enthält eine „Auszug generieren“-Schaltfläche für die automatische Zusammenfassungserstellung. Bildblöcke zeigen eine „Alt-Text generieren“-Option zur Erstellung barrierefreier Beschreibungen.
 
 ### Unterstützte Modelle und Funktionen {#supported-models}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/60-cms/30-wordpress.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/60-cms/30-wordpress.mdx
@@ -1,36 +1,26 @@
 ---
 sidebar_label: WordPress
-description: Erfahre, wie du den mittwald AI Provider mit WordPress AI Experiments verwendest
+description: Erfahre, wie du den mittwald AI Provider mit WordPress AI verwendest
 title: WordPress
 ---
 
 ## Den mittwald AI Provider für WordPress verwenden {#using-mittwald-ai-provider}
 
-Das mittwald AI Provider-Plugin ermöglicht die Integration zwischen [WordPress AI Experiments](https://wordpress.org/plugins/ai/) und mittwald AI Hosting. Dies erlaubt es dir, die KI-Modelle von mittwald direkt im WordPress-Editor für Content-Generierungsaufgaben wie das Erstellen von Titeln, Auszügen und Alt-Texten zu nutzen. Das offizielle Plugin findest du im [WordPress-Plugin-Verzeichnis](https://wordpress.org/plugins/mittwald-ai-provider).
+Das Plugin [AI Provider for mittwald](https://wordpress.org/plugins/mittwald-ai-provider) ermöglicht die Integration zwischen WordPress und mittwald AI Hosting. Dies erlaubt es dir, die KI-Modelle von mittwald direkt in WordPress für Content-Generierungsaufgaben wie das Erstellen von Titeln, Auszügen und Alt-Texten zu nutzen.
 
 ### Voraussetzungen {#prerequisites}
 
-Vor der Installation des mittwald AI Providers musst du das WordPress AI Experiments-Plugin installiert und aktiviert haben. Dieses Basis-Plugin stellt das KI-Framework bereit, das der mittwald-Provider mit mittwald-gehosteten Modellen erweitert.
+Der mittwald AI Provider erfordert WordPress 7.0 oder höher. WordPress 7.0 enthält den AI Client und die Connectors-Oberfläche als Teil des Cores, die der mittwald-Provider nutzt, um sich als AI-Connector zu registrieren.
 
-Das AI Experiments-Plugin erfordert WordPress 6.9 oder höher und PHP 7.4 oder höher. Es bringt experimentelle KI-gestützte Funktionen in die WordPress-Bearbeitungsoberfläche, einschließlich Titelgenerierung, Auszugserstellung und Alt-Text-Vorschläge.
+Optional kannst du das [AI-Plugin](https://wordpress.org/plugins/ai/) von WordPress.org installieren, um zusätzliche KI-gestützte Funktionen im WordPress-Editor zu nutzen, wie Titelgenerierung, Auszugserstellung, Alt-Text-Vorschläge, Bildgenerierung und Kommentarmoderation.
 
 ### Installation {#installation}
 
-Der Installationsprozess umfasst zwei Plugins: zuerst das AI Experiments-Basis-Plugin, dann den mittwald AI Provider.
+WordPress 7.0 enthält den AI Client und die Connectors-Oberfläche als Teil des Cores. Der mittwald AI Provider registriert sich als Connector in dieser Oberfläche. Optional kannst du das AI-Plugin installieren, um zusätzliche KI-gestützte Funktionen im WordPress-Editor zu nutzen.
 
-#### Schritt 1: AI Experiments-Plugin installieren {#step-1-install-ai-experiments}
+#### Schritt 1: AI Provider for mittwald installieren {#step-1-install-mittwald-provider}
 
-Navigiere zu **Plugins** -> **Installieren** in deiner WordPress-Administrationsoberfläche und suche nach „AI Experiments". Installiere und aktiviere das Plugin.
-
-Alternativ kannst du WP-CLI verwenden, um das Plugin über die Kommandozeile zu installieren und zu aktivieren:
-
-```shellsession
-user@ssh $ wp plugin install ai --activate
-```
-
-#### Schritt 2: mittwald AI Provider installieren {#step-2-install-mittwald-provider}
-
-Mit aktiviertem AI Experiments-Plugin installierst du den mittwald AI Provider. Navigiere in deiner WordPress-Administration zu **Plugins** -> **Installieren** und suche nach „mittwald AI provider". Installiere und aktiviere das Plugin, um mittwald AI Hosting als Provider-Option zu aktivieren.
+Navigiere zu **Plugins** -> **Installieren** in deiner WordPress-Administrationsoberfläche und suche nach „AI Provider for mittwald". Installiere und aktiviere das Plugin, um mittwald AI Hosting als Connector-Option zu aktivieren.
 
 Mit WP-CLI kannst du dies folgendermaßen erreichen:
 
@@ -38,9 +28,19 @@ Mit WP-CLI kannst du dies folgendermaßen erreichen:
 user@ssh $ wp plugin install mittwald-ai-provider --activate
 ```
 
+#### Schritt 2 (optional): AI-Plugin installieren {#step-2-install-ai}
+
+Das [AI-Plugin](https://wordpress.org/plugins/ai/) von WordPress.org bietet zusätzliche KI-gestützte Funktionen im WordPress-Editor, wie Titelgenerierung, Auszugserstellung, Alt-Text-Vorschläge, Bildgenerierung und Kommentarmoderation. Navigiere zu **Plugins** -> **Installieren** und suche nach „AI" von WordPress.org.
+
+Alternativ mit WP-CLI:
+
+```shellsession
+user@ssh $ wp plugin install ai --activate
+```
+
 ### Konfiguration {#configuration}
 
-Sobald beide Plugins installiert sind, musst du deine mittwald-API-Zugangsdaten konfigurieren und die gewünschten KI-Experimente aktivieren.
+Sobald der mittwald AI Provider installiert ist, musst du deine API-Zugangsdaten konfigurieren. Falls du das AI-Plugin installiert hast, kannst du auch dessen Funktionen aktivieren.
 
 #### Schritt 1: API-Schlüssel beschaffen {#step-1-obtain-api-key}
 
@@ -48,18 +48,22 @@ Falls du noch keinen API-Schlüssel hast, folge der [mittwald AI Hosting Zugangs
 
 #### Schritt 2: API-Zugangsdaten speichern {#step-2-store-credentials}
 
-Navigiere zu **Einstellungen** -> **AI Credentials** in deiner WordPress-Administrationsoberfläche. Gib deinen mittwald AI Hosting API-Schlüssel in das entsprechende Feld ein und speichere deine Einstellungen. Dies stellt die Verbindung zwischen deiner WordPress-Website und den mittwald AI-Diensten her.
+Navigiere zu **Einstellungen** -> **Connectors** in deiner WordPress-Administrationsoberfläche. Gib deinen mittwald AI Hosting API-Schlüssel in das mittwald-Connector-Feld ein und speichere deine Einstellungen. Dies stellt die Verbindung zwischen deiner WordPress-Website und den mittwald AI-Diensten her.
 
-#### Schritt 3: KI-Experimente aktivieren {#step-3-enable-experiments}
+Alternativ kannst du den API-Schlüssel über `wp-config.php` konfigurieren, indem du die Konstante `MITTWALD_API_KEY` definierst, oder über Umgebungsvariablen.
 
-Navigiere zu **Einstellungen** -> **AI Experiments** und klicke auf die Schaltfläche, um Experimente global zu aktivieren. Anschließend kannst du einzelne Experimente je nach gewünschten Funktionen ein- oder ausschalten. Verfügbare Experimente umfassen:
+#### Schritt 3: KI-Funktionen aktivieren (bei Verwendung des AI-Plugins) {#step-3-enable-features}
+
+Falls du das AI-Plugin installiert hast, navigiere zu **Einstellungen** -> **AI** und aktiviere die gewünschten Funktionen. Verfügbare Funktionen umfassen:
 
 - **Titelgenerierung**: Generiere Titelvorschläge mit einem einzigen Klick im Beitragseditor
 - **Auszugsgenerierung**: Erstelle automatisch prägnante Zusammenfassungen für deine Beiträge
 - **Inhaltszusammenfassung**: Fasse lange Inhalte in übersichtliche Übersichten zusammen
 - **Alt-Text-Generierung**: Generiere beschreibende Alt-Texte für Bilder zur Verbesserung der Barrierefreiheit
+- **Bildgenerierung**: Erstelle und bearbeite Bilder aus Beitragsinhalten
+- **Kommentarmoderation**: Moderiere Kommentare automatisch basierend auf Toxizitätserkennung
 
-Speichere deine Einstellungen nach dem Aktivieren der gewünschten Experimente.
+Speichere deine Einstellungen nach dem Aktivieren der gewünschten Funktionen.
 
 ### KI-Funktionen verwenden {#using-ai-features}
 
@@ -71,9 +75,15 @@ Beim Bearbeiten eines Beitrags findest du KI-gestützte Schaltflächen an releva
 
 Der mittwald AI Provider unterstützt Chat-Completions mit mehreren für unterschiedliche Aufgaben optimierten Modellen:
 
-- **GPT-OSS-Modelle**: Open-Source GPT-kompatible Modelle für allgemeine Content-Generierung
-- **Ministral**: Unterstützt Vision- und Bildeingabe-Funktionen
-Diese Modelle unterstützen Standard-Textgenerierung, JSON-Ausgabeformatierung, Tool Calling und Streaming-Antworten. Die Ministral-Modelle unterstützen zusätzlich Bildverarbeitungsfunktionen zur Analyse und Beschreibung von Bildern.
+- **gpt-oss-120b**: Open-Source GPT-kompatibles Modell für allgemeine Content-Generierung und fortgeschrittenes Reasoning
+- **Qwen3.5-122B-A10B-FP8** und **Qwen3.6-35B-A3B-FP8**: Große Modelle mit Reasoning- und Vision-Funktionen
+- **Qwen3.5-0.8B**: Leichtgewichtiges Modell für kostensensitive Aufgaben
+- **Ministral-3-14B-Instruct-2512**: Chat-Modell mit Vision- und Bildeingabe-Funktionen
+- **Mistral-Medium-3.5-128B**: Frontier-Modell für komplexes Reasoning und Vision-Workloads
+
+Diese Modelle unterstützen Standard-Textgenerierung, JSON-Ausgabeformatierung, Tool Calling und Streaming-Antworten. Die Ministral-, Mistral-Medium- und Qwen-Modelle unterstützen zusätzlich Bildverarbeitungsfunktionen zur Analyse und Beschreibung von Bildern.
+
+Eine vollständige Liste der verfügbaren Modelle und deren Funktionen findest du in der [Modellübersicht](../../models/).
 
 ### Nutzungslimits {#usage-limits}
 


### PR DESCRIPTION
## Summary

- Update WordPress version requirement from 6.9 to 7.0
- Rename "AI Experiments" to "AI" (plugin was renamed in v0.6.0)
- Update plugin name to "AI Provider for mittwald" (correct WordPress plugin directory name)
- Change settings location from "Settings → AI Credentials" to "Settings → Connectors" (now part of WordPress 7.0 core)
- Clarify that AI plugin is optional (WordPress 7.0 includes AI Client and Connectors in core)
- Update supported models list to match current offerings (removed Devstral, added Qwen3.5/3.6 variants, Mistral-Medium-3.5-128B)
- Add new features: image generation, comment moderation
- Add alternative configuration methods (wp-config.php, environment variables)
- Update German translation accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)