### PR TITLE
docs(cli): add brew trust step to Homebrew install instructions

### DIFF
--- a/docs/cli/usage/install.md
+++ b/docs/cli/usage/install.md
@@ -11,6 +11,7 @@ On macOS, the recommended way of installing the CLI is using [Homebrew](https://
 
 ```
 $ brew tap mittwald/cli
+$ brew trust --formula mittwald/cli/mw
 $ brew install mw
 $ mw --help
 ```

--- a/i18n/de/docusaurus-plugin-content-docs/current/api/sdks/cli.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/api/sdks/cli.md
@@ -19,6 +19,7 @@ $ mw --help
 
 ```
 $ brew tap mittwald/cli
+$ brew trust --formula mittwald/cli/mw
 $ brew install mw
 $ mw --help
 ```

--- a/i18n/de/docusaurus-plugin-content-docs/current/cli/usage/install.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/cli/usage/install.md
@@ -11,6 +11,7 @@ Unter macOS ist die empfohlene Methode zur Installation der CLI die Verwendung v
 
 ```
 $ brew tap mittwald/cli
+$ brew trust --formula mittwald/cli/mw
 $ brew install mw
 $ mw --help
 ```


### PR DESCRIPTION
## Was

Ergänzt den fehlenden Schritt `brew trust --formula mittwald/cli/mw` in den Homebrew-Installationsanweisungen der mittwald CLI, zwischen `brew tap` und `brew install`.

## Betroffene Dateien

- `docs/cli/usage/install.md` (EN)
- `i18n/de/.../cli/usage/install.md` (DE)
- `i18n/de/.../api/sdks/cli.md` (DE)

EN und DE wurden konsistent angepasst.