### PR TITLE
Revert "bugfix: Observe darkmode setting and pass to flow"

### DIFF
--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -5,7 +5,6 @@ import {
   useMatomo,
 } from "@datapunt/matomo-tracker-react";
 import { useLocation } from "@docusaurus/router";
-import { setTheme } from "@mittwald/flow-react-components";
 import "@mittwald/flow-react-components/all.css";
 
 function PageViewTracker({ children }: PropsWithChildren<{}>) {
@@ -38,30 +37,6 @@ function PageViewTracker({ children }: PropsWithChildren<{}>) {
 }
 
 export default function Root({ children }: PropsWithChildren<{}>) {
-  useEffect(() => {
-    const html = document.documentElement;
-
-    const syncFlowTheme = () => {
-      const docusaurusTheme = html.getAttribute("data-theme");
-      setTheme(docusaurusTheme === "dark" ? "dark" : "light");
-    };
-
-    syncFlowTheme();
-
-    const observer = new MutationObserver(() => {
-      syncFlowTheme();
-    });
-
-    observer.observe(html, {
-      attributes: true,
-      attributeFilter: ["data-theme"],
-    });
-
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
-
   const matomoInstance = createInstance({
     urlBase: "https://developer.mittwald.de/stats/",
     siteId: 1,


### PR DESCRIPTION
Reverts mittwald/developer-portal#1137

Currently, changing the color scheme is broken, because it seems to trigger an infinite loop and freezes your browser window.

In any case, the changes from mittwald/developer-portal#1137 are not necessary any longer in recent flow versions.