### PR TITLE
docs(qwen): clarify presence_penalty guidance for precise coding tasks

### DIFF
--- a/docs/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
+++ b/docs/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
@@ -122,10 +122,10 @@ echo $response->choices[0]->message->content;
 
 When thinking mode is **enabled** (default), the model returns two separate fields:
 
-| Field | Contents |
-| ----- | -------- |
+| Field                                  | Contents                                     |
+| -------------------------------------- | -------------------------------------------- |
 | `choices[0].message.reasoning_content` | Internal chain-of-thought (may be very long) |
-| `choices[0].message.content` | Final answer |
+| `choices[0].message.content`           | Final answer                                 |
 
 If `content` is empty, the model placed its answer inside the reasoning block — disable thinking mode to ensure `content` is always populated.
 
@@ -151,12 +151,13 @@ The model has different recommended settings depending on the use case. Do not u
 
 **Precise coding / web development:**
 
-| Parameter          | Value |
-| ------------------ | ----- |
-| `temperature`      | 0.6   |
-| `top_p`            | 0.95  |
-| `top_k`            | 20    |
-| `presence_penalty` | 0.0   |
+| Parameter     | Value |
+| ------------- | ----- |
+| `temperature` | 0.6   |
+| `top_p`       | 0.95  |
+| `top_k`       | 20    |
+
+Qwen recommends `presence_penalty=0.0` for precise coding tasks. If this produces empty `content` responses or reasoning-only loops, `presence_penalty=1.0` can be tested as a more stable operating value; values up to 2.0 are permitted by Qwen depending on the framework, but may likewise cause errors.
 
 ### Non-thinking mode (`enable_thinking: false`)
 
@@ -182,10 +183,10 @@ The model has different recommended settings depending on the use case. Do not u
 
 Set `max_tokens` according to task complexity to control cost and latency:
 
-| Task type                                      | Recommended `max_tokens` |
-| ---------------------------------------------- | ------------------------ |
-| Standard queries                               | 32,768                   |
-| Complex problems (math, programming contests)  | 81,920                   |
+| Task type                                     | Recommended `max_tokens` |
+| --------------------------------------------- | ------------------------ |
+| Standard queries                              | 32,768                   |
+| Complex problems (math, programming contests) | 81,920                   |
 
 ## Tips for specific tasks
 
@@ -203,11 +204,11 @@ For a ready-to-run example using Qwen3.5-122B-A10B-FP8 as the answering model in
 
 Recommended parameters for vision:
 
-| Parameter     | Value |
-| ------------- | ----- |
-| `temperature` | 0.7   |
-| `top_p`       | 0.8   |
-| `top_k`       | 20    |
+| Parameter     | Value                      |
+| ------------- | -------------------------- |
+| `temperature` | 0.7                        |
+| `top_p`       | 0.8                        |
+| `top_k`       | 20                         |
 | `max_tokens`  | 512–2048 depending on task |
 
 For accurate text extraction (OCR) or data reading, use `temperature=0.1` instead.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
@@ -121,10 +121,10 @@ echo $response->choices[0]->message->content;
 
 Wenn der Thinking-Modus **aktiviert** ist (Standard), liefert das Modell zwei separate Felder:
 
-| Feld | Inhalt |
-| ---- | ------ |
+| Feld                                   | Inhalt                                      |
+| -------------------------------------- | ------------------------------------------- |
 | `choices[0].message.reasoning_content` | Interne Gedankenkette (kann sehr lang sein) |
-| `choices[0].message.content` | Endgültige Antwort |
+| `choices[0].message.content`           | Endgültige Antwort                          |
 
 Wenn `content` leer ist, hat das Modell seine Antwort in den Reasoning-Block geschrieben — deaktiviere den Thinking-Modus, damit `content` immer befüllt wird.
 
@@ -150,12 +150,13 @@ Das Modell hat je nach Anwendungsfall unterschiedliche empfohlene Einstellungen.
 
 **Präzise Coding-Aufgaben / Webentwicklung:**
 
-| Parameter          | Wert |
-| ------------------ | ---- |
-| `temperature`      | 0.6  |
-| `top_p`            | 0.95 |
-| `top_k`            | 20   |
-| `presence_penalty` | 0.0  |
+| Parameter     | Wert |
+| ------------- | ---- |
+| `temperature` | 0.6  |
+| `top_p`       | 0.95 |
+| `top_k`       | 20   |
+
+Für präzise Coding-Aufgaben empfiehlt Qwen `presence_penalty=0.0`. Falls dabei leere `content`-Antworten bzw. Reasoning-only-Loops auftreten, kann `presence_penalty=1.0` als stabilerer Betriebswert getestet werden; Werte bis 2.0 sind laut Qwen je nach Framework zulässig, können aber ebenso zu Fehlern führen.
 
 ### Non-Thinking-Modus (`enable_thinking: false`)
 
@@ -202,11 +203,11 @@ Ein fertiges Beispiel, das Qwen3.5-122B-A10B-FP8 als Antwortmodell in einer Doku
 
 Empfohlene Parameter für Vision:
 
-| Parameter     | Wert |
-| ------------- | ---- |
-| `temperature` | 0.7  |
-| `top_p`       | 0.8  |
-| `top_k`       | 20   |
+| Parameter     | Wert                     |
+| ------------- | ------------------------ |
+| `temperature` | 0.7                      |
+| `top_p`       | 0.8                      |
+| `top_k`       | 20                       |
 | `max_tokens`  | 512–2048 je nach Aufgabe |
 
 Für präzise Texterkennung (OCR) oder das Auslesen von Daten empfiehlt sich stattdessen `temperature=0.1`.


### PR DESCRIPTION
## Summary
- Qwen3.5-122B-A10B-FP8 docs (EN + DE) now note that `presence_penalty=1.0` can be tested if `presence_penalty=0.0` causes empty-content/reasoning-only responses for precise coding tasks.
- Prettier formatting pass across touched docs and a few src files.