### PR TITLE
feat: Add darkmode test and wire it plus a smoke test as pre-merge job

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -40,6 +40,12 @@ jobs:
         run: npm run generate
       - name: Build
         run: npm run build
+      - name: Install Playwright Browsers Dependencies
+        run: npx playwright install-deps
+      - name: Install Playwright Browsers
+        run: npx playwright install
+      - name: Run smoke and dark mode regression tests
+        run: npx playwright test tests/smoke.test.ts tests/dark-mode-flow.test.ts --project=chromium
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
         with:

--- a/tests/dark-mode-flow.test.ts
+++ b/tests/dark-mode-flow.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Dark mode regression - Flow theme sync', () => {
+  test('theme switch updates Flow component rendering', async ({ page }) => {
+    await page.goto('/docs/v2/reference/file/file-create-file');
+    await page.waitForLoadState('networkidle');
+
+    // This page should contain Flow components rendered from API reference blocks.
+    const flowElements = page.locator('[class*="flow--"]');
+    await expect(flowElements.first()).toBeVisible();
+
+    const themeToggle = page
+      .locator(
+        'button[title*="dark and light mode"], button[aria-label*="color mode"], button[class*="colorModeToggle"], button[class*="toggleButton"]',
+      )
+      .first();
+
+    await expect(themeToggle).toBeVisible();
+
+    const before = await page.evaluate(() => {
+      const theme = document.documentElement.getAttribute('data-theme') ?? '';
+      const signatures = Array.from(
+        document.querySelectorAll('[class*="flow--"]'),
+      )
+        .slice(0, 20)
+        .map((element) => {
+          const styles = window.getComputedStyle(element);
+
+          return [
+            styles.color,
+            styles.backgroundColor,
+            styles.borderTopColor,
+            styles.outlineColor,
+          ].join('|');
+        });
+
+      return { theme, signatures };
+    });
+
+    await themeToggle.click();
+
+    await page.waitForFunction(
+      (initialTheme) =>
+        document.documentElement.getAttribute('data-theme') !== initialTheme,
+      before.theme,
+    );
+
+    const after = await page.evaluate(() => {
+      const theme = document.documentElement.getAttribute('data-theme') ?? '';
+      const signatures = Array.from(
+        document.querySelectorAll('[class*="flow--"]'),
+      )
+        .slice(0, 20)
+        .map((element) => {
+          const styles = window.getComputedStyle(element);
+
+          return [
+            styles.color,
+            styles.backgroundColor,
+            styles.borderTopColor,
+            styles.outlineColor,
+          ].join('|');
+        });
+
+      return { theme, signatures };
+    });
+
+    expect(after.theme).not.toEqual(before.theme);
+
+    const anyFlowStyleChanged = after.signatures.some(
+      (signature, index) => signature !== before.signatures[index],
+    );
+
+    expect(anyFlowStyleChanged).toBe(true);
+  });
+});


### PR DESCRIPTION
Only auto merge dependabot PRs when at least some simple tests keep working. Currently dark mode plus simple smoke test, later we might add more interactions to be tested and kept alive.

Tested against faulty state reverted via `92acccb74786d5003f5cd2948ef30d02f34b93f1`