### PR TITLE
Füge n8n Community Node Hinweise hinzu

### DIFF
--- a/docs/guides/apps/n8n.mdx
+++ b/docs/guides/apps/n8n.mdx
@@ -114,13 +114,13 @@ For secure production operation, further measures or clarifications are required
 - Access to n8n: Who is allowed to create, edit, trigger workflows, etc.?
 - Authentication for n8n, user and role management concepts
 - Configuration of n8n: Allowed nodes, system users, etc.
-- Persistence n8n data: For larger installations we recommend (a separate database for n8n data)[https://docs.n8n.io/hosting/configuration/supported-databases-settings/]
+- Persistence n8n data: For larger installations we recommend [a separate database for n8n data](https://docs.n8n.io/hosting/configuration/supported-databases-settings/)
 - Access to the vector database: read/write, schema changes
 - Access to documents: Who is allowed to read/write/delete?
 - Access to webhooks: Authorization and authentication, consumers or clients
 
 During development and testing, some of these aspects can be simplified, but for production use, all these aspects must be clearly regulated. Without clear resolution of these security issues, there is a risk of unintentionally disclosing too much information, potentially making internal documents publicly accessible or even triggering processes.
-n8n ships with a (security audit tool)[https://docs.n8n.io/hosting/securing/security-audit/], which is recommended for productive environment checks.
+n8n ships with a [security audit tool](https://docs.n8n.io/hosting/securing/security-audit/), which is recommended for productive environment checks.
 :::
 
 ## Reasoning models and thinking mode {#reasoning-models-and-thinking-mode}

--- a/docs/guides/apps/n8n.mdx
+++ b/docs/guides/apps/n8n.mdx
@@ -123,6 +123,22 @@ During development and testing, some of these aspects can be simplified, but for
 n8n ships with a (security audit tool)[https://docs.n8n.io/hosting/securing/security-audit/], which is recommended for productive environment checks.
 :::
 
+## Reasoning models and thinking mode {#reasoning-models-and-thinking-mode}
+
+Some mittwald AI Hosting models — for example [Qwen3.6-35B-A3B-FP8](../../../platform/aihosting/models/qwen3-6-35b-a3b-fp8) and [Qwen3.5-122B-A10B-FP8](../../../platform/aihosting/models/qwen3-5-122b-a10b-fp8) — ship with "thinking mode" enabled by default. Disabling (or, for other models, enabling) it requires sending `enable_thinking` nested inside `chat_template_kwargs` via the `extra_body` field of the chat completion request. See the respective model page for the exact request format.
+
+n8n's built-in **OpenAI Chat Model** node does not expose a way to set `extra_body` / `chat_template_kwargs`, so thinking mode cannot be toggled through that node.
+
+**Workaround:** use a community node that forwards arbitrary OpenAI-compatible parameters, such as [`@rlquilez/n8n-nodes-openai-litellm`](https://www.npmjs.com/package/@rlquilez/n8n-nodes-openai-litellm):
+
+1. In n8n, go to **Settings → Community Nodes** and install `@rlquilez/n8n-nodes-openai-litellm`.
+2. Configure the node with your mittwald AI Hosting credentials: base URL `https://llm.aihosting.mittwald.de/v1` and your API key.
+3. Set the node's extra body option to `{"chat_template_kwargs": {"enable_thinking": false}}` (or `true`, depending on the model and desired behavior).
+
+:::note
+This limitation is specific to n8n's built-in node, not to the mittwald AI Hosting API. If you call the API directly — for example with an HTTP Request node, or from your own backend — the standard `extra_body` approach shown on the model pages works without any community node.
+:::
+
 ## Use cases
 
 ### RAG with PostgreSQL and mittwald AI Hosting

--- a/docs/guides/apps/n8n.mdx
+++ b/docs/guides/apps/n8n.mdx
@@ -139,22 +139,6 @@ n8n's built-in **OpenAI Chat Model** node does not expose a way to set `extra_bo
 This limitation is specific to n8n's built-in node, not to the mittwald AI Hosting API. If you call the API directly — for example with an HTTP Request node, or from your own backend — the standard `extra_body` approach shown on the model pages works without any community node.
 :::
 
-## Reasoning models and thinking mode {#reasoning-models-and-thinking-mode}
-
-Some mittwald AI Hosting models — for example [Qwen3.6-35B-A3B-FP8](../../../platform/aihosting/models/qwen3-6-35b-a3b-fp8) and [Qwen3.5-122B-A10B-FP8](../../../platform/aihosting/models/qwen3-5-122b-a10b-fp8) — ship with "thinking mode" enabled by default. Disabling (or, for other models, enabling) it requires sending `enable_thinking` nested inside `chat_template_kwargs` via the `extra_body` field of the chat completion request. See the respective model page for the exact request format.
-
-n8n's built-in **OpenAI Chat Model** node does not expose a way to set `extra_body` / `chat_template_kwargs`, so thinking mode cannot be toggled through that node.
-
-**Workaround:** use a community node that forwards arbitrary OpenAI-compatible parameters, such as [`@rlquilez/n8n-nodes-openai-litellm`](https://www.npmjs.com/package/@rlquilez/n8n-nodes-openai-litellm):
-
-1. In n8n, go to **Settings → Community Nodes** and install `@rlquilez/n8n-nodes-openai-litellm`.
-2. Configure the node with your mittwald AI Hosting credentials: base URL `https://llm.aihosting.mittwald.de/v1` and your API key.
-3. Set the node's extra body option to `{"chat_template_kwargs": {"enable_thinking": false}}` (or `true`, depending on the model and desired behavior).
-
-:::note
-This limitation is specific to n8n's built-in node, not to the mittwald AI Hosting API. If you call the API directly — for example with an HTTP Request node, or from your own backend — the standard `extra_body` approach shown on the model pages works without any community node.
-:::
-
 ## Use cases
 
 ### RAG with PostgreSQL and mittwald AI Hosting

--- a/docs/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
+++ b/docs/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
@@ -33,6 +33,8 @@ Before every response the model generates an internal reasoning chain. For compl
 **Common mistake:** passing `enable_thinking: false` as a top-level field in the request body — the API silently ignores it and thinking stays on. It must be nested inside `chat_template_kwargs` as shown below.
 :::
 
+Using this model from n8n? The built-in OpenAI Chat Model node can't set `chat_template_kwargs` — see [Reasoning models and thinking mode](../../../../guides/apps/n8n#reasoning-models-and-thinking-mode) for a community-node workaround.
+
 ### Disabling thinking mode {#disable-thinking}
 
 <Tabs groupId="language">

--- a/docs/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
+++ b/docs/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
@@ -34,6 +34,8 @@ Before every response the model generates an internal reasoning chain. For compl
 **Common mistake:** passing `enable_thinking: false` as a top-level field in the request body — the API silently ignores it and thinking stays on. It must be nested inside `chat_template_kwargs` as shown below.
 :::
 
+Using this model from n8n? The built-in OpenAI Chat Model node can't set `chat_template_kwargs` — see [Reasoning models and thinking mode](../../../../guides/apps/n8n#reasoning-models-and-thinking-mode) for a community-node workaround.
+
 ### Disabling thinking mode {#disable-thinking}
 
 <Tabs groupId="language">

--- a/docs/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
+++ b/docs/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
@@ -31,6 +31,8 @@ The following limitations apply:
 
 Thinking mode is **off by default** on this model — the opposite of `Qwen3.5-122B-A10B-FP8`. Enable it selectively for tasks that benefit from chain-of-thought reasoning:
 
+Using this model from n8n? The built-in OpenAI Chat Model node can't set `chat_template_kwargs` — see [Reasoning models and thinking mode](../../../../guides/apps/n8n#reasoning-models-and-thinking-mode) for a community-node workaround.
+
 <Tabs groupId="language">
   <TabItem value="python" label="Python">
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/apps/n8n.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/apps/n8n.mdx
@@ -123,6 +123,22 @@ Im Entwicklungs- und Testbetrieb können einige dieser Aspekte vereinfacht werde
 n8n bietet auch ein (Werkzeug für Security Audits)[https://docs.n8n.io/hosting/securing/security-audit/], mit dem Produktivumgebungen geprüft werden können.
 :::
 
+## Reasoning-Modelle und Thinking-Modus {#reasoning-models-and-thinking-mode}
+
+Einige Modelle im mittwald AI Hosting – zum Beispiel [Qwen3.6-35B-A3B-FP8](../../../platform/aihosting/models/qwen3-6-35b-a3b-fp8) und [Qwen3.5-122B-A10B-FP8](../../../platform/aihosting/models/qwen3-5-122b-a10b-fp8) – haben den "Thinking-Modus" standardmäßig aktiviert. Um ihn zu deaktivieren (bzw. bei anderen Modellen zu aktivieren), muss `enable_thinking` verschachtelt in `chat_template_kwargs` über das `extra_body`-Feld der Chat-Completion-Anfrage gesendet werden. Das genaue Request-Format zeigt die jeweilige Modellseite.
+
+Der eingebaute **OpenAI Chat Model**-Node von n8n bietet keine Möglichkeit, `extra_body` / `chat_template_kwargs` zu setzen – der Thinking-Modus lässt sich darüber also nicht umschalten.
+
+**Workaround:** Verwende eine Community-Node, die beliebige OpenAI-kompatible Parameter durchreicht, z. B. [`@rlquilez/n8n-nodes-openai-litellm`](https://www.npmjs.com/package/@rlquilez/n8n-nodes-openai-litellm):
+
+1. Gehe in n8n zu **Settings → Community Nodes** und installiere `@rlquilez/n8n-nodes-openai-litellm`.
+2. Konfiguriere die Node mit deinen mittwald AI Hosting Zugangsdaten: Base-URL `https://llm.aihosting.mittwald.de/v1` und deinem API-Key.
+3. Setze die Extra-Body-Option der Node auf `{"chat_template_kwargs": {"enable_thinking": false}}` (bzw. `true`, je nach Modell und gewünschtem Verhalten).
+
+:::note
+Diese Einschränkung betrifft nur die eingebaute Node von n8n, nicht die mittwald AI Hosting API selbst. Wenn du die API direkt aufrufst – z. B. über eine HTTP-Request-Node oder aus deinem eigenen Backend – funktioniert der auf den Modellseiten gezeigte `extra_body`-Ansatz auch ohne Community-Node.
+:::
+
 ## Use cases
 
 ### RAG mit postgreSQL und mittwald AI-Hosting

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/apps/n8n.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/apps/n8n.mdx
@@ -114,13 +114,13 @@ Für einen sicheren Produktivbetrieb sind weitere Maßnahmen bzw. Klärungen erf
 - Zugriff auf n8n: Wer darf Workflows erstellen, bearbeiten, anstoßen, ...
 - Authentifizierung n8n, Benutzer- und Rollenkonzept
 - Konfiguration n8n: Erlaubte Knoten, Systembenutzer, ...
-- Persistenz n8n Daten: Für größere Installationen lohnt sich eine (Separate Datenbank für n8n Daten)[https://docs.n8n.io/hosting/configuration/supported-databases-settings/]
+- Persistenz n8n Daten: Für größere Installationen lohnt sich eine [Separate Datenbank für n8n Daten](https://docs.n8n.io/hosting/configuration/supported-databases-settings/)
 - Zugriff Vektordatenbank: lesen/schreiben, Schema-Veränderungen
 - Zugriff auf Dokumente: Wer darf lesen/schreiben/löschen?
 - Zugriff auf Webhooks: Authorisierung und Authentifizierung, Konsumenten bzw. Clients
 
 Im Entwicklungs- und Testbetrieb können einige dieser Aspekte vereinfacht werden, im produktiven Betrieb müssen alle diese Aspekte zweifelsfrei geklärt werden. Ohne genaue Klärung dieser Sicherheitsfragen besteht das Risiko, ungewollt zu viele Informationen preiszugeben und im schlimmsten Falle interne Dokumente öffentlich einsehbar zu machen oder gar Prozesse anzustoßen.
-n8n bietet auch ein (Werkzeug für Security Audits)[https://docs.n8n.io/hosting/securing/security-audit/], mit dem Produktivumgebungen geprüft werden können.
+n8n bietet auch ein [Werkzeug für Security Audits](https://docs.n8n.io/hosting/securing/security-audit/), mit dem Produktivumgebungen geprüft werden können.
 :::
 
 ## Reasoning-Modelle und Thinking-Modus {#reasoning-models-and-thinking-mode}

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/60-qwen3-5-122b-a10b-fp8.mdx
@@ -32,6 +32,8 @@ Das Modell generiert vor jeder Antwort eine interne Gedankenkette. Bei komplexen
 **Häufiger Fehler:** `enable_thinking: false` als Top-Level-Feld im Request-Body übergeben — die API ignoriert es stillschweigend und der Thinking-Modus bleibt aktiv. Es muss wie unten gezeigt in `chat_template_kwargs` verschachtelt werden.
 :::
 
+Nutzt du dieses Modell aus n8n heraus? Der eingebaute OpenAI Chat Model-Node kann `chat_template_kwargs` nicht setzen — siehe [Reasoning-Modelle und Thinking-Modus](../../../../guides/apps/n8n#reasoning-models-and-thinking-mode) für einen Workaround per Community-Node.
+
 ### Thinking-Modus deaktivieren {#thinking-modus-deaktivieren}
 
 <Tabs groupId="language">

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/70-qwen3-6-35b-a3b-fp8.mdx
@@ -33,6 +33,8 @@ Das Modell generiert vor jeder Antwort eine interne Gedankenkette. Bei komplexen
 **Häufiger Fehler:** `enable_thinking: false` als Top-Level-Feld im Request-Body übergeben — die API ignoriert es stillschweigend und der Thinking-Modus bleibt aktiv. Es muss wie unten gezeigt in `chat_template_kwargs` verschachtelt werden.
 :::
 
+Nutzt du dieses Modell aus n8n heraus? Der eingebaute OpenAI Chat Model-Node kann `chat_template_kwargs` nicht setzen — siehe [Reasoning-Modelle und Thinking-Modus](../../../../guides/apps/n8n#reasoning-models-and-thinking-mode) für einen Workaround per Community-Node.
+
 ### Thinking-Modus deaktivieren {#thinking-modus-deaktivieren}
 
 <Tabs groupId="language">

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
@@ -30,6 +30,8 @@ Folgende Einschränkungen gelten:
 
 Der Thinking-Modus ist bei diesem Modell **standardmäßig deaktiviert** – anders als bei `Qwen3.5-122B-A10B-FP8`. Aktiviere ihn gezielt für Aufgaben, die von Chain-of-Thought-Reasoning profitieren:
 
+Nutzt du dieses Modell aus n8n heraus? Der eingebaute OpenAI Chat Model-Node kann `chat_template_kwargs` nicht setzen — siehe [Reasoning-Modelle und Thinking-Modus](../../../../guides/apps/n8n#reasoning-models-and-thinking-mode) für einen Workaround per Community-Node.
+
 <Tabs groupId="language">
   <TabItem value="python" label="Python">
 


### PR DESCRIPTION
Die klassische n8n Node ermöglicht es nicht, Thinking bei LLMs auszustellen. Dieser PR füllt diese Lücke, indem er mehrere Hinweise zur Umgehung dieses Problems enthält (Community Node). Das Problem trat gehäuft via Tickets auf. 