### PR TITLE
docs: Responses-API-Support pro Modell dokumentiert

### DIFF
--- a/docs/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
+++ b/docs/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
@@ -152,6 +152,21 @@ curl -i -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
 This endpoint provides access to the **Responses API**, following the structure of the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses).
 As the route is still **experimental**, not all features are fully supported. Some extended parameters may behave differently compared to the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses).
 
+Supported on all models: single-turn and multi-turn (full history passed in `input`) text generation, streaming.
+
+Function/tool calling and `reasoning.effort` are supported on gpt-oss-120b, Qwen3.5-122B-A10B-FP8, Qwen3.6-35B-A3B-FP8, and Qwen3.5-0.8B. Ministral-3-14B-Instruct-2512 and Mistral-Medium-3.5-128B don't support tool calling on this endpoint (Mistral-Medium-3.5-128B also doesn't support `reasoning.effort`); use `/v1/chat/completions` for these two models instead. See the full per-model table in [Responses API support](../../dedicated/openai-compatibility#responses-api).
+
+Not supported on any model:
+
+- Stateful conversations — `previous_response_id` and retrieving a stored response (`GET /v1/responses/{id}`) are rejected. Pass the full conversation history in `input` on every call instead.
+- `background: true` (background/async responses).
+- Multimodal input (`input_image` content parts) — use `/v1/chat/completions` for [vision](#vision-image--text) instead.
+- Built-in tools such as `web_search`, `file_search`, or `code_interpreter`. Only custom function tools are supported.
+
+:::caution
+Sending an image to a model without vision support doesn't return an error. Only send images to vision-capable models.
+:::
+
 Structured output such as schema-based JSON **cannot currently be enforced** with this endpoint.
 If structured output is required, the `/v1/chat/completions` endpoint should be used instead.
 

--- a/docs/platform/aihosting/70-dedicated/50-openai-compatibility.mdx
+++ b/docs/platform/aihosting/70-dedicated/50-openai-compatibility.mdx
@@ -26,40 +26,40 @@ The model name also changes. Use the ID returned by `/v1/models` instead of an O
 
 ## Supported endpoints {#endpoints}
 
-| Endpoint | Supported |
-|----------|-----------|
-| `GET /v1/models` | ✅ |
-| `POST /v1/chat/completions` | ✅ |
-| `POST /v1/completions` | ✅ (legacy text completions) |
-| `POST /v1/responses` | ✅ |
-| `POST /v1/embeddings` | ❌ — this endpoint serves a generative model, not an embedding model |
-| Assistants API (`/v1/assistants`, `/v1/threads`, …) | ❌ |
-| Batch API (`/v1/batches`) | ❌ |
-| Fine-tuning API (`/v1/fine_tuning`) | ❌ |
-| Files API (`/v1/files`) | ❌ |
-| Moderations API (`/v1/moderations`) | ❌ |
-| Audio / image endpoints | ❌ |
+| Endpoint                                            | Supported                                                            |
+| --------------------------------------------------- | -------------------------------------------------------------------- |
+| `GET /v1/models`                                    | ✅                                                                   |
+| `POST /v1/chat/completions`                         | ✅                                                                   |
+| `POST /v1/completions`                              | ✅ (legacy text completions)                                         |
+| `POST /v1/responses`                                | ⚠️ — subset only, see [Responses API support](#responses-api)        |
+| `POST /v1/embeddings`                               | ❌ — this endpoint serves a generative model, not an embedding model |
+| Assistants API (`/v1/assistants`, `/v1/threads`, …) | ❌                                                                   |
+| Batch API (`/v1/batches`)                           | ❌                                                                   |
+| Fine-tuning API (`/v1/fine_tuning`)                 | ❌                                                                   |
+| Files API (`/v1/files`)                             | ❌                                                                   |
+| Moderations API (`/v1/moderations`)                 | ❌                                                                   |
+| Audio / image endpoints                             | ❌                                                                   |
 
 ## /v1/chat/completions parameter support {#parameters}
 
-| Parameter | Support | Notes |
-|-----------|---------|-------|
-| `model` | ✅ | Use the model ID from `/v1/models` |
-| `messages` | ✅ | |
-| `stream` | ✅ | See [Streaming](../getting-started#streaming) |
-| `temperature`, `top_p` | ✅ | |
-| `max_tokens` / `max_completion_tokens` | ✅ | |
-| `stop` | ✅ | |
-| `n` | ✅ | Multiple completions per request |
-| `presence_penalty`, `frequency_penalty` | ✅ | |
-| `logprobs`, `top_logprobs` | ✅ | |
-| `tools`, `tool_choice` | ✅ | See [Tool calling](#tool-calling) |
-| `parallel_tool_calls` | ✅ | `false` limits to one tool call; `true` (default) allows multiple |
-| `response_format` | ✅ | See [Structured outputs](#structured-outputs) |
-| `seed` | ⚠️ | Accepted and passed through — reproducibility is best-effort due to GPU non-determinism |
-| `user` | ⚠️ | Accepted but ignored |
-| `logit_bias` | ✅ | Supported; token IDs outside the model vocabulary return a validation error |
-| `stream_options` | ✅ | Supported when `stream: true`; passing it without streaming returns a validation error. `include_usage: true` appends a usage chunk at the end of the stream |
+| Parameter                               | Support | Notes                                                                                                                                                        |
+| --------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `model`                                 | ✅      | Use the model ID from `/v1/models`                                                                                                                           |
+| `messages`                              | ✅      |                                                                                                                                                              |
+| `stream`                                | ✅      | See [Streaming](../getting-started#streaming)                                                                                                                |
+| `temperature`, `top_p`                  | ✅      |                                                                                                                                                              |
+| `max_tokens` / `max_completion_tokens`  | ✅      |                                                                                                                                                              |
+| `stop`                                  | ✅      |                                                                                                                                                              |
+| `n`                                     | ✅      | Multiple completions per request                                                                                                                             |
+| `presence_penalty`, `frequency_penalty` | ✅      |                                                                                                                                                              |
+| `logprobs`, `top_logprobs`              | ✅      |                                                                                                                                                              |
+| `tools`, `tool_choice`                  | ✅      | See [Tool calling](#tool-calling)                                                                                                                            |
+| `parallel_tool_calls`                   | ✅      | `false` limits to one tool call; `true` (default) allows multiple                                                                                            |
+| `response_format`                       | ✅      | See [Structured outputs](#structured-outputs)                                                                                                                |
+| `seed`                                  | ⚠️      | Accepted and passed through — reproducibility is best-effort due to GPU non-determinism                                                                      |
+| `user`                                  | ⚠️      | Accepted but ignored                                                                                                                                         |
+| `logit_bias`                            | ✅      | Supported; token IDs outside the model vocabulary return a validation error                                                                                  |
+| `stream_options`                        | ✅      | Supported when `stream: true`; passing it without streaming returns a validation error. `include_usage: true` appends a usage chunk at the end of the stream |
 
 ## Structured outputs {#structured-outputs}
 
@@ -70,8 +70,13 @@ Both JSON mode and JSON schema mode are supported.
 ```json
 {
   "model": "YOUR_MODEL_ID",
-  "messages": [{"role": "user", "content": "Return a JSON object with keys name and age."}],
-  "response_format": {"type": "json_object"}
+  "messages": [
+    {
+      "role": "user",
+      "content": "Return a JSON object with keys name and age."
+    }
+  ],
+  "response_format": { "type": "json_object" }
 }
 ```
 
@@ -80,7 +85,9 @@ Both JSON mode and JSON schema mode are supported.
 ```json
 {
   "model": "YOUR_MODEL_ID",
-  "messages": [{"role": "user", "content": "Extract the person's name and age."}],
+  "messages": [
+    { "role": "user", "content": "Extract the person's name and age." }
+  ],
   "response_format": {
     "type": "json_schema",
     "json_schema": {
@@ -89,8 +96,8 @@ Both JSON mode and JSON schema mode are supported.
       "schema": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "age": {"type": "integer"}
+          "name": { "type": "string" },
+          "age": { "type": "integer" }
         },
         "required": ["name", "age"],
         "additionalProperties": false
@@ -144,6 +151,40 @@ tool_calls = response.choices[0].message.tool_calls
 ```
 
 `parallel_tool_calls=False` restricts the model to at most one tool call per turn, which simplifies handling in multi-step agent loops.
+
+## Responses API support {#responses-api}
+
+`POST /v1/responses` is reachable and follows the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses) shape, but only a subset of it works, and support varies **per model**.
+
+| Capability                                                                 | Support | Notes                                                                                                                           |
+| -------------------------------------------------------------------------- | :-----: | ------------------------------------------------------------------------------------------------------------------------------- |
+| Single-turn text input (`input` as string)                                 |   ✅    |                                                                                                                                 |
+| Multi-turn via full conversation history (`input` as message array)        |   ✅    |                                                                                                                                 |
+| Streaming (`stream: true`)                                                 |   ✅    |                                                                                                                                 |
+| `text.format` (structured output / JSON schema)                            |   ⚠️    | Accepted, not enforced with guided decoding — use `/v1/chat/completions` `response_format` for enforced schemas                 |
+| Stateful conversations (`previous_response_id`, `store: true` + retrieval) |   ❌    | `previous_response_id` returns `400`, `GET /v1/responses/{id}` returns `500`; pass full conversation history in `input` instead |
+| `background: true`                                                         |   ❌    | Returns `400`                                                                                                                   |
+| Multimodal input (`input_image` content parts)                             |   ❌    | Returns `400` — use `/v1/chat/completions` for [vision](../../api-endpoints/supported-endpoints#vision-image--text)             |
+| Built-in tools (`web_search`, `file_search`, `code_interpreter`, …)        |   ❌    | Use custom function tools instead                                                                                               |
+
+Tool and `reasoning.effort` support also varies by model:
+
+| Model                         | Tool calling | `reasoning.effort` |
+| ----------------------------- | :----------: | :----------------: |
+| gpt-oss-120b                  |      ✅      |         ✅         |
+| Qwen3.5-122B-A10B-FP8         |      ✅      |         ✅         |
+| Qwen3.6-35B-A3B-FP8           |      ✅      |         ✅         |
+| Qwen3.5-0.8B                  |      ✅      |         ✅         |
+| Ministral-3-14B-Instruct-2512 |      ❌      |         ✅         |
+| Mistral-Medium-3.5-128B       |      ❌      |         ❌         |
+
+Both Mistral-family models support tool calling on `/v1/chat/completions` — use that endpoint instead if you need tool calling with them.
+
+:::caution
+Sending image content to a model without vision support doesn't return an error on either endpoint. Only send images to models documented as vision-capable (Ministral-3-14B-Instruct-2512, Qwen3.5-122B-A10B-FP8, Qwen3.6-35B-A3B-FP8, Mistral-Medium-3.5-128B, GLM-OCR).
+:::
+
+Prefer `/v1/chat/completions` for production workloads. Use `/v1/responses` where you specifically need its output format, on a model that supports the features you need on this endpoint.
 
 ## Configuring client timeouts {#timeouts}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
@@ -152,6 +152,21 @@ curl -i -X POST https://llm.aihosting.mittwald.de/v1/chat/completions \
 Dieser Endpunkt bietet Zugriff auf die **Responses API**, welcher auf der Struktur von der [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses) basiert.
 Da die Route noch **experimentell** ist, sind nicht alle Funktionen vollständig verfügbar. Einige erweiterte Parameter können sich anders verhalten als in der [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses).
 
+Bei allen Modellen unterstützt: Single-Turn- und Multi-Turn-Texterzeugung (vollständiger Verlauf in `input`), Streaming.
+
+Function/Tool Calling und `reasoning.effort` sind bei gpt-oss-120b, Qwen3.5-122B-A10B-FP8, Qwen3.6-35B-A3B-FP8 und Qwen3.5-0.8B unterstützt. Ministral-3-14B-Instruct-2512 und Mistral-Medium-3.5-128B unterstützen kein Tool Calling auf diesem Endpunkt (Mistral-Medium-3.5-128B zusätzlich kein `reasoning.effort`); für diese beiden Modelle stattdessen `/v1/chat/completions` verwenden. Die vollständige Modell-Tabelle steht unter [Responses-API-Support](../../dedicated/openai-compatibility#responses-api).
+
+Bei keinem Modell unterstützt:
+
+- Serverseitig gespeicherte Konversationen — `previous_response_id` und der Abruf einer gespeicherten Response (`GET /v1/responses/{id}`) werden abgelehnt. Stattdessen bei jedem Aufruf den vollständigen Gesprächsverlauf in `input` übergeben.
+- `background: true` (Background-/Async-Responses).
+- Multimodale Eingabe (`input_image`-Content-Parts) — für [Vision](#vision-bild--text) stattdessen `/v1/chat/completions` verwenden.
+- Eingebaute Tools wie `web_search`, `file_search` oder `code_interpreter`. Nur Custom-Function-Tools werden unterstützt.
+
+:::caution
+Ein Bild an ein Modell ohne Vision-Support zu senden, führt nicht zu einem Fehler. Bilder nur an vision-fähige Modelle senden.
+:::
+
 Strukturierte Ausgaben wie schema-basiertes JSON können über diesen Endpunkt derzeit nicht erzwungen werden.
 Falls ein festes Ausgabeformat benötigt wird, sollte stattdessen der Endpunkt /v1/chat/completions verwendet werden
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/70-dedicated/50-openai-compatibility.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/70-dedicated/50-openai-compatibility.mdx
@@ -26,40 +26,40 @@ Der Modellname ändert sich ebenfalls. Verwende die ID aus `/v1/models` statt ei
 
 ## Unterstützte Endpunkte {#endpoints}
 
-| Endpunkt | Unterstützt |
-|----------|-------------|
-| `GET /v1/models` | ✅ |
-| `POST /v1/chat/completions` | ✅ |
-| `POST /v1/completions` | ✅ (Legacy-Text-Completions) |
-| `POST /v1/responses` | ✅ |
-| `POST /v1/embeddings` | ❌ — dieser Endpunkt betreibt ein generatives Modell, kein Embedding-Modell |
-| Assistants API (`/v1/assistants`, `/v1/threads`, …) | ❌ |
-| Batch API (`/v1/batches`) | ❌ |
-| Fine-tuning API (`/v1/fine_tuning`) | ❌ |
-| Files API (`/v1/files`) | ❌ |
-| Moderations API (`/v1/moderations`) | ❌ |
-| Audio-/Bild-Endpunkte | ❌ |
+| Endpunkt                                            | Unterstützt                                                                 |
+| --------------------------------------------------- | --------------------------------------------------------------------------- |
+| `GET /v1/models`                                    | ✅                                                                          |
+| `POST /v1/chat/completions`                         | ✅                                                                          |
+| `POST /v1/completions`                              | ✅ (Legacy-Text-Completions)                                                |
+| `POST /v1/responses`                                | ⚠️ — nur Teilmenge, siehe [Responses-API-Support](#responses-api)           |
+| `POST /v1/embeddings`                               | ❌ — dieser Endpunkt betreibt ein generatives Modell, kein Embedding-Modell |
+| Assistants API (`/v1/assistants`, `/v1/threads`, …) | ❌                                                                          |
+| Batch API (`/v1/batches`)                           | ❌                                                                          |
+| Fine-tuning API (`/v1/fine_tuning`)                 | ❌                                                                          |
+| Files API (`/v1/files`)                             | ❌                                                                          |
+| Moderations API (`/v1/moderations`)                 | ❌                                                                          |
+| Audio-/Bild-Endpunkte                               | ❌                                                                          |
 
 ## Parameter-Unterstützung für /v1/chat/completions {#parameters}
 
-| Parameter | Support | Hinweise |
-|-----------|---------|----------|
-| `model` | ✅ | Modell-ID aus `/v1/models` verwenden |
-| `messages` | ✅ | |
-| `stream` | ✅ | Siehe [Streaming](../getting-started#streaming) |
-| `temperature`, `top_p` | ✅ | |
-| `max_tokens` / `max_completion_tokens` | ✅ | |
-| `stop` | ✅ | |
-| `n` | ✅ | Mehrere Completions pro Anfrage |
-| `presence_penalty`, `frequency_penalty` | ✅ | |
-| `logprobs`, `top_logprobs` | ✅ | |
-| `tools`, `tool_choice` | ✅ | Siehe [Tool Calling](#tool-calling) |
-| `parallel_tool_calls` | ✅ | `false` begrenzt auf einen Tool-Call; `true` (Standard) erlaubt mehrere |
-| `response_format` | ✅ | Siehe [Strukturierte Ausgaben](#structured-outputs) |
-| `seed` | ⚠️ | Wird akzeptiert und weitergeleitet — Reproduzierbarkeit ist Best-Effort aufgrund von GPU-Nicht-Determinismus |
-| `user` | ⚠️ | Wird akzeptiert, aber ignoriert |
-| `logit_bias` | ✅ | Unterstützt; Token-IDs außerhalb des Modell-Vokabulars geben einen Validierungsfehler zurück |
-| `stream_options` | ✅ | Unterstützt bei `stream: true`; ohne Streaming gibt es einen Validierungsfehler. `include_usage: true` hängt am Ende des Streams einen Usage-Chunk an |
+| Parameter                               | Support | Hinweise                                                                                                                                              |
+| --------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`                                 | ✅      | Modell-ID aus `/v1/models` verwenden                                                                                                                  |
+| `messages`                              | ✅      |                                                                                                                                                       |
+| `stream`                                | ✅      | Siehe [Streaming](../getting-started#streaming)                                                                                                       |
+| `temperature`, `top_p`                  | ✅      |                                                                                                                                                       |
+| `max_tokens` / `max_completion_tokens`  | ✅      |                                                                                                                                                       |
+| `stop`                                  | ✅      |                                                                                                                                                       |
+| `n`                                     | ✅      | Mehrere Completions pro Anfrage                                                                                                                       |
+| `presence_penalty`, `frequency_penalty` | ✅      |                                                                                                                                                       |
+| `logprobs`, `top_logprobs`              | ✅      |                                                                                                                                                       |
+| `tools`, `tool_choice`                  | ✅      | Siehe [Tool Calling](#tool-calling)                                                                                                                   |
+| `parallel_tool_calls`                   | ✅      | `false` begrenzt auf einen Tool-Call; `true` (Standard) erlaubt mehrere                                                                               |
+| `response_format`                       | ✅      | Siehe [Strukturierte Ausgaben](#structured-outputs)                                                                                                   |
+| `seed`                                  | ⚠️      | Wird akzeptiert und weitergeleitet — Reproduzierbarkeit ist Best-Effort aufgrund von GPU-Nicht-Determinismus                                          |
+| `user`                                  | ⚠️      | Wird akzeptiert, aber ignoriert                                                                                                                       |
+| `logit_bias`                            | ✅      | Unterstützt; Token-IDs außerhalb des Modell-Vokabulars geben einen Validierungsfehler zurück                                                          |
+| `stream_options`                        | ✅      | Unterstützt bei `stream: true`; ohne Streaming gibt es einen Validierungsfehler. `include_usage: true` hängt am Ende des Streams einen Usage-Chunk an |
 
 ## Strukturierte Ausgaben {#structured-outputs}
 
@@ -70,8 +70,13 @@ Sowohl JSON-Object-Modus als auch JSON-Schema-Modus werden unterstützt.
 ```json
 {
   "model": "YOUR_MODEL_ID",
-  "messages": [{"role": "user", "content": "Gib ein JSON-Objekt mit den Feldern name und age zurück."}],
-  "response_format": {"type": "json_object"}
+  "messages": [
+    {
+      "role": "user",
+      "content": "Gib ein JSON-Objekt mit den Feldern name und age zurück."
+    }
+  ],
+  "response_format": { "type": "json_object" }
 }
 ```
 
@@ -80,7 +85,9 @@ Sowohl JSON-Object-Modus als auch JSON-Schema-Modus werden unterstützt.
 ```json
 {
   "model": "YOUR_MODEL_ID",
-  "messages": [{"role": "user", "content": "Extrahiere Name und Alter der Person."}],
+  "messages": [
+    { "role": "user", "content": "Extrahiere Name und Alter der Person." }
+  ],
   "response_format": {
     "type": "json_schema",
     "json_schema": {
@@ -89,8 +96,8 @@ Sowohl JSON-Object-Modus als auch JSON-Schema-Modus werden unterstützt.
       "schema": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "age": {"type": "integer"}
+          "name": { "type": "string" },
+          "age": { "type": "integer" }
         },
         "required": ["name", "age"],
         "additionalProperties": false
@@ -144,6 +151,40 @@ tool_calls = response.choices[0].message.tool_calls
 ```
 
 `parallel_tool_calls=False` begrenzt das Modell auf maximal einen Tool-Call pro Turn, was die Verarbeitung in mehrstufigen Agent-Loops vereinfacht.
+
+## Responses-API-Support {#responses-api}
+
+`POST /v1/responses` ist erreichbar und folgt der Struktur der [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses), aber nur ein Teil davon funktioniert, und die Unterstützung unterscheidet sich **pro Modell**.
+
+| Fähigkeit                                                                                | Support | Hinweise                                                                                                                                          |
+| ---------------------------------------------------------------------------------------- | :-----: | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Single-Turn-Texteingabe (`input` als String)                                             |   ✅    |                                                                                                                                                   |
+| Multi-Turn über vollständigen Gesprächsverlauf (`input` als Message-Array)               |   ✅    |                                                                                                                                                   |
+| Streaming (`stream: true`)                                                               |   ✅    |                                                                                                                                                   |
+| `text.format` (strukturierte Ausgabe / JSON-Schema)                                      |   ⚠️    | Wird akzeptiert, aber nicht per Guided Decoding erzwungen — für erzwungene Schemata `/v1/chat/completions` mit `response_format` verwenden        |
+| Serverseitig gespeicherte Konversationen (`previous_response_id`, `store: true` + Abruf) |   ❌    | `previous_response_id` liefert `400`, `GET /v1/responses/{id}` liefert `500`; stattdessen den vollständigen Gesprächsverlauf in `input` übergeben |
+| `background: true`                                                                       |   ❌    | Liefert `400`                                                                                                                                     |
+| Multimodale Eingabe (`input_image`-Content-Parts)                                        |   ❌    | Liefert `400` — für [Vision](../../api-endpoints/supported-endpoints#vision-bild--text) `/v1/chat/completions` verwenden                          |
+| Eingebaute Tools (`web_search`, `file_search`, `code_interpreter`, …)                    |   ❌    | Stattdessen Custom-Function-Tools verwenden                                                                                                       |
+
+Tool Calling und `reasoning.effort` unterscheiden sich zusätzlich pro Modell:
+
+| Modell                        | Tool Calling | `reasoning.effort` |
+| ----------------------------- | :----------: | :----------------: |
+| gpt-oss-120b                  |      ✅      |         ✅         |
+| Qwen3.5-122B-A10B-FP8         |      ✅      |         ✅         |
+| Qwen3.6-35B-A3B-FP8           |      ✅      |         ✅         |
+| Qwen3.5-0.8B                  |      ✅      |         ✅         |
+| Ministral-3-14B-Instruct-2512 |      ❌      |         ✅         |
+| Mistral-Medium-3.5-128B       |      ❌      |         ❌         |
+
+Beide Mistral-Modelle unterstützen Tool Calling über `/v1/chat/completions` — für Tool Calling mit diesen Modellen diesen Endpunkt verwenden.
+
+:::caution
+Ein Bild an ein Modell ohne Vision-Support zu senden, führt auf keinem der beiden Endpunkte zu einem Fehler. Bilder nur an Modelle senden, die als vision-fähig dokumentiert sind (Ministral-3-14B-Instruct-2512, Qwen3.5-122B-A10B-FP8, Qwen3.6-35B-A3B-FP8, Mistral-Medium-3.5-128B, GLM-OCR).
+:::
+
+Für Produktivworkloads `/v1/chat/completions` bevorzugen. `/v1/responses` dort einsetzen, wo das spezifische Ausgabeformat benötigt wird und das Modell die dafür nötigen Fähigkeiten auf diesem Endpunkt unterstützt.
 
 ## Client-Timeouts konfigurieren {#timeouts}
 


### PR DESCRIPTION
Neue Hinweise auf die Responses API, die wir schon länger anbieten. Ein paar Kunden nutzen diese, bis jetzt haben wir in den Dokus kaum davon gesprochen. 