### PR TITLE
docs(api): add guide on querying CPU and RAM usage metrics

### DIFF
--- a/docs/api/howtos/query-usage-metrics.mdx
+++ b/docs/api/howtos/query-usage-metrics.mdx
@@ -1,0 +1,317 @@
+---
+sidebar_label: Querying usage metrics
+sidebar_position: 30
+title: Querying CPU and RAM usage metrics over the API
+description: This article explains how to query CPU and memory usage statistics for projects and servers via the metrics API
+tags:
+  - Metrics
+  - Monitoring
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+The mStudio API exposes the CPU and memory usage statistics that you also see in
+the mStudio UI. Unlike the rest of the API, these are not served by regular REST
+operations: the `/v2/apps/metrics` route is a **transparent proxy to a Grafana
+instance**. Everything below that path is the Grafana HTTP API, so
+`POST /v2/apps/metrics/api/ds/query` is Grafana's data source query endpoint.
+
+The data source behind it is a Prometheus instance, which means the actual
+queries you send are [PromQL](https://prometheus.io/docs/prometheus/querying/basics/)
+expressions.
+
+## Authentication {#authentication}
+
+Authentication works exactly as for the rest of the API: pass your API token in
+the `Authorization` header.
+
+```http
+POST /v2/apps/metrics/api/ds/query HTTP/1.1
+Host: api.mittwald.de
+Authorization: Bearer <YOUR_API_TOKEN>
+Content-Type: application/json
+```
+
+See the [API introduction](/docs/v2/api/intro) for how to obtain an API token.
+
+## Authorization {#authorization}
+
+The metrics proxy does not just authenticate your token, it also inspects the
+**label selectors in your PromQL expression** and authorizes them individually.
+There are two separate rules to be aware of, and they fail with two different
+errors.
+
+### Every query must be scoped {#query-scoping}
+
+Each selector on a `cloudhosting_project_*` metric must carry at least one of
+the labels `project`, `project_group` or `placement_group`. An unscoped query
+such as `SUM(cloudhosting_project_usage_memory_bytes:5m:max)` is rejected
+outright, regardless of your permissions:
+
+```
+unauthorized: authorizer failed (one of the following authorizers must match:
+[when metric matches '^cloudhosting_project_.*$', must have labels map[project:{}]],
+[when metric matches '^cloudhosting_project_.*$', must have labels map[project_group:{}]],
+[when metric matches '^cloudhosting_project_.*$', must have labels map[placement_group:{}]]):
+none of the authorizers matched
+```
+
+### You must have access to the resource you select {#resource-access}
+
+Selecting a resource that your token cannot access does not return an empty
+result — it returns an error for that query:
+
+```
+unauthorized: authorizer failed (must be authorized to access the resources
+referenced in the query labels): user is not allowed to access project group s-kc6yrn
+```
+
+Crucially, **access to a project does not imply access to its server.** These
+are authorized separately, which has a practical consequence for the utilization
+examples below: they all divide by a `cloudhosting_projectgroup_limits_*` metric
+selected by `project_group`, so they require **server-level** access even when
+you only care about a single project.
+
+If you only hold project-level access, you can still query absolute usage
+values, since those select by `project` alone:
+
+```promql
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"})
+```
+
+Note also that the _returned series_ carry a `project_group` label even when you
+select by `project` only. Reading that label in a result is not the same as
+being allowed to select by it.
+
+## Available metrics {#available-metrics}
+
+All metrics are **recording rules**, not raw series. The `:5m` suffix denotes
+the downsampling interval: values are pre-aggregated into five-minute buckets.
+Consequently, there is no point in querying at a resolution finer than five
+minutes — you will simply get the same bucket value repeated.
+
+The suffix after the interval describes the aggregation function that was
+applied within each bucket (`:max` for peak usage). Metrics ending in `_rate`
+have already had `rate()` applied, so they must **not** be wrapped in `rate()`
+again.
+
+### Usage metrics {#usage-metrics}
+
+| Metric                                                           | Labels                     | Unit               | Meaning                                                                            |
+| ---------------------------------------------------------------- | -------------------------- | ------------------ | ---------------------------------------------------------------------------------- |
+| `cloudhosting_project_usage_memory_bytes:5m:max`                 | `project`, `project_group` | bytes              | Peak memory used by a project's workloads within each 5-minute bucket              |
+| `cloudhosting_project_usage_cpu_seconds_total_rate:5m`           | `project`, `project_group` | CPU seconds/second | Average CPU consumption of a project's workloads; `1` corresponds to one full core |
+| `cloudhosting_databasesetmember_usage_memory_bytes:5m:max`       | `project_group`            | bytes              | Peak memory used by the database instances (MySQL, Redis, …) of a server           |
+| `cloudhosting_databasesetmember_usage_cpu_seconds_total_rate:5m` | `project_group`            | CPU seconds/second | Average CPU consumption of the database instances of a server                      |
+
+Database usage is accounted for separately from project usage, because database
+instances are not part of a project's workloads. To get the **total** usage of a
+server, you therefore need to add both up (see the examples below).
+
+### Limit metrics {#limit-metrics}
+
+| Metric                                             | Labels          | Unit        | Meaning                           |
+| -------------------------------------------------- | --------------- | ----------- | --------------------------------- |
+| `cloudhosting_projectgroup_limits_memory_bytes:5m` | `project_group` | bytes       | Memory available to the server    |
+| `cloudhosting_projectgroup_limits_cpu_seconds:5m`  | `project_group` | CPU seconds | CPU cores available to the server |
+
+### Labels {#labels}
+
+- `project` contains the **short ID** of a project, formatted as `p-xxxxxx`.
+- `project_group` contains the **short ID** of a server, formatted as
+  `s-xxxxxx`. "Project group" is the internal name for what is called a server
+  in the mStudio.
+
+Note that these are the short IDs, **not** the UUID-formatted IDs that most REST
+operations of the API expect.
+
+A third label, `placement_group`, is also accepted as a valid scope by the
+authorizer. It is not needed for any of the queries in this guide.
+
+Result series additionally carry labels such as `project_environment`,
+`cluster` and `tier`. These are internal and should not be relied upon.
+
+## Example queries {#example-queries}
+
+The queries below all return a **ratio between 0 and 1**; multiply by 100 to get
+a percentage. This matches what the mStudio displays as utilization.
+
+### Memory utilization of a single project {#memory-utilization-project}
+
+```promql
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"}) /
+SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-kc6yrn"})
+```
+
+This relates a single project's memory usage to the limit of the server it runs
+on — in other words, "how much of my server's RAM does this project consume?".
+
+### CPU utilization of a single project {#cpu-utilization-project}
+
+```promql
+SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project="p-zrblbi"}) /
+SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-kc6yrn"})
+```
+
+### Memory utilization of an entire server {#memory-utilization-server}
+
+```promql
+(SUM (cloudhosting_databasesetmember_usage_memory_bytes:5m:max{project_group="s-kc6yrn"} or vector (0)) +
+ SUM (cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-kc6yrn"})) /
+SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-kc6yrn"})
+```
+
+Here, the `project_group` label is used on the usage metrics as well, so that
+_all_ projects on the server are summed up, and the database usage is added on
+top.
+
+The `or vector (0)` fallback is important: if a server has no databases at all,
+the `cloudhosting_databasesetmember_*` series does not exist, and without the
+fallback the entire addition would evaluate to an empty result rather than to
+the project usage alone.
+
+### CPU utilization of an entire server {#cpu-utilization-server}
+
+```promql
+(SUM (cloudhosting_databasesetmember_usage_cpu_seconds_total_rate:5m{project_group="s-kc6yrn"} or vector (0)) +
+ SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project_group="s-kc6yrn"})) /
+SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-kc6yrn"})
+```
+
+### Absolute values {#absolute-values}
+
+If you are interested in absolute numbers instead of utilization ratios, simply
+drop the division:
+
+```promql
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"})
+```
+
+Or omit the `SUM` to get one series per project on a server, which is useful for
+breaking down which project on a server consumes the most resources:
+
+```promql
+cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-kc6yrn"}
+```
+
+## Sending a query {#sending-a-query}
+
+Queries are sent to the Grafana query endpoint at
+`POST /v2/apps/metrics/api/ds/query`. The request body follows Grafana's
+[data source query API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/data_source/):
+
+```json
+{
+  "from": "now-24h",
+  "to": "now",
+  "queries": [
+    {
+      "refId": "A",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "MetricsAuthPrometheus"
+      },
+      "expr": "SUM (cloudhosting_project_usage_memory_bytes:5m:max{project=\"p-zrblbi\"}) / SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group=\"s-kc6yrn\"})",
+      "intervalMs": 300000,
+      "maxDataPoints": 288
+    }
+  ]
+}
+```
+
+The relevant fields are:
+
+- `from` and `to` define the time range. They accept either epoch milliseconds
+  or Grafana's relative time syntax (`now`, `now-24h`, `now-7d`).
+- `datasource.uid` must be `MetricsAuthPrometheus`. You can confirm this at
+  runtime by calling `GET /v2/apps/metrics/api/datasources`, which lists the
+  available data sources.
+- `refId` is an arbitrary identifier; the response is keyed by it. Send multiple
+  entries in `queries` with distinct `refId`s to evaluate several expressions in
+  a single round trip.
+- `expr` contains the PromQL expression.
+- `intervalMs` is the step size. Since the underlying data is downsampled to
+  five minutes, `300000` is the most sensible value.
+- `maxDataPoints` caps the number of returned samples. Grafana will increase the
+  step size if the requested range divided by `intervalMs` exceeds this value.
+
+### Interpreting the response {#interpreting-the-response}
+
+The response is a Grafana **data frame**, which stores values column-wise rather
+than as a list of timestamp/value pairs:
+
+```json
+{
+  "results": {
+    "A": {
+      "frames": [
+        {
+          "schema": {
+            "refId": "A",
+            "fields": [
+              { "name": "Time", "type": "time" },
+              { "name": "Value", "type": "number" }
+            ]
+          },
+          "data": {
+            "values": [
+              [1753048800000, 1753049100000, 1753049400000],
+              [0.4213, 0.4198, 0.4402]
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+`data.values` contains one array per field defined in `schema.fields`, in the
+same order. The first array holds the timestamps (epoch milliseconds), the
+second the values. To get the _n_-th sample, read index _n_ from each array.
+
+If a query fails, the corresponding `results` entry contains an `error` property
+instead of `frames`. Note that this may happen **per query** even when the HTTP
+status code is `200` — always check for `error` on each `refId` you sent.
+
+## Client libraries {#client-libraries}
+
+None of the mittwald SDKs cover this endpoint, since it is not part
+of the OpenAPI specification. You have two practical options:
+
+**Use a plain HTTP client.** The request and response shapes are small enough
+that this is often the least painful route. All you need is a POST with a JSON
+body and the two-array response decoding described above.
+
+**Use a Grafana client library** for the data frame decoding. Useful ones:
+
+<Tabs groupId="language">
+<TabItem value="typescript" label="TypeScript">
+
+[`@grafana/data`](https://www.npmjs.com/package/@grafana/data) provides
+`dataFrameFromJSON()`, which turns the raw response frames into typed
+`DataFrame` objects, plus helpers for iterating over fields. It is a large
+dependency, so this only pays off if you are working with the data extensively.
+
+</TabItem>
+<TabItem value="go" label="Go">
+
+[`github.com/grafana/grafana-plugin-sdk-go/data`](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/data)
+contains the canonical `data.Frame` type with `UnmarshalJSON` support, so you
+can decode the response frames directly into typed Go structs.
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+[`grafana-client`](https://github.com/grafana-toolbox/grafana-client) wraps the
+Grafana HTTP API including data source queries. Point it at
+`https://api.mittwald.de/v2/apps/metrics` and authenticate with your mittwald
+API token.
+
+</TabItem>
+</Tabs>
+
+Since the proxy exposes the Grafana HTTP API unchanged, any generic Grafana
+client will work as long as you can configure a custom base URL and a bearer
+token.

--- a/docs/api/howtos/query-usage-metrics.mdx
+++ b/docs/api/howtos/query-usage-metrics.mdx
@@ -33,7 +33,7 @@ Authorization: Bearer <YOUR_API_TOKEN>
 Content-Type: application/json
 ```
 
-See the [API introduction](/docs/v2/api/intro) for how to obtain an API token.
+See the [API introduction](../../intro) for how to obtain an API token.
 
 ## Authorization {#authorization}
 
@@ -64,7 +64,7 @@ result — it returns an error for that query:
 
 ```
 unauthorized: authorizer failed (must be authorized to access the resources
-referenced in the query labels): user is not allowed to access project group s-kc6yrn
+referenced in the query labels): user is not allowed to access project group s-XXXXXX
 ```
 
 Crucially, **access to a project does not imply access to its server.** These
@@ -77,7 +77,7 @@ If you only hold project-level access, you can still query absolute usage
 values, since those select by `project` alone:
 
 ```promql
-SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"})
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-XXXXXX"})
 ```
 
 Note also that the _returned series_ carry a `project_group` label even when you
@@ -118,9 +118,9 @@ server, you therefore need to add both up (see the examples below).
 
 ### Labels {#labels}
 
-- `project` contains the **short ID** of a project, formatted as `p-xxxxxx`.
+- `project` contains the **short ID** of a project, formatted as `p-XXXXXX`.
 - `project_group` contains the **short ID** of a server, formatted as
-  `s-xxxxxx`. "Project group" is the internal name for what is called a server
+  `s-XXXXXX`. "Project group" is the internal name for what is called a server
   in the mStudio.
 
 Note that these are the short IDs, **not** the UUID-formatted IDs that most REST
@@ -140,8 +140,8 @@ a percentage. This matches what the mStudio displays as utilization.
 ### Memory utilization of a single project {#memory-utilization-project}
 
 ```promql
-SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"}) /
-SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-kc6yrn"})
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-XXXXXX"}) /
+SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-XXXXXX"})
 ```
 
 This relates a single project's memory usage to the limit of the server it runs
@@ -150,16 +150,16 @@ on — in other words, "how much of my server's RAM does this project consume?".
 ### CPU utilization of a single project {#cpu-utilization-project}
 
 ```promql
-SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project="p-zrblbi"}) /
-SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-kc6yrn"})
+SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project="p-XXXXXX"}) /
+SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-XXXXXX"})
 ```
 
 ### Memory utilization of an entire server {#memory-utilization-server}
 
 ```promql
-(SUM (cloudhosting_databasesetmember_usage_memory_bytes:5m:max{project_group="s-kc6yrn"} or vector (0)) +
- SUM (cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-kc6yrn"})) /
-SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-kc6yrn"})
+(SUM (cloudhosting_databasesetmember_usage_memory_bytes:5m:max{project_group="s-XXXXXX"} or vector (0)) +
+ SUM (cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-XXXXXX"})) /
+SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-XXXXXX"})
 ```
 
 Here, the `project_group` label is used on the usage metrics as well, so that
@@ -174,9 +174,9 @@ the project usage alone.
 ### CPU utilization of an entire server {#cpu-utilization-server}
 
 ```promql
-(SUM (cloudhosting_databasesetmember_usage_cpu_seconds_total_rate:5m{project_group="s-kc6yrn"} or vector (0)) +
- SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project_group="s-kc6yrn"})) /
-SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-kc6yrn"})
+(SUM (cloudhosting_databasesetmember_usage_cpu_seconds_total_rate:5m{project_group="s-XXXXXX"} or vector (0)) +
+ SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project_group="s-XXXXXX"})) /
+SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-XXXXXX"})
 ```
 
 ### Absolute values {#absolute-values}
@@ -185,14 +185,14 @@ If you are interested in absolute numbers instead of utilization ratios, simply
 drop the division:
 
 ```promql
-SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"})
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-XXXXXX"})
 ```
 
 Or omit the `SUM` to get one series per project on a server, which is useful for
 breaking down which project on a server consumes the most resources:
 
 ```promql
-cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-kc6yrn"}
+cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-XXXXXX"}
 ```
 
 ## Sending a query {#sending-a-query}
@@ -212,7 +212,7 @@ Queries are sent to the Grafana query endpoint at
         "type": "prometheus",
         "uid": "MetricsAuthPrometheus"
       },
-      "expr": "SUM (cloudhosting_project_usage_memory_bytes:5m:max{project=\"p-zrblbi\"}) / SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group=\"s-kc6yrn\"})",
+      "expr": "SUM (cloudhosting_project_usage_memory_bytes:5m:max{project=\"p-XXXXXX\"}) / SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group=\"s-XXXXXX\"})",
       "intervalMs": 300000,
       "maxDataPoints": 288
     }
@@ -233,8 +233,11 @@ The relevant fields are:
 - `expr` contains the PromQL expression.
 - `intervalMs` is the step size. Since the underlying data is downsampled to
   five minutes, `300000` is the most sensible value.
-- `maxDataPoints` caps the number of returned samples. Grafana will increase the
-  step size if the requested range divided by `intervalMs` exceeds this value.
+- `maxDataPoints` caps the number of returned samples. If the requested range
+  divided by `intervalMs` exceeds this value, Grafana increases the step size
+  and you get coarser data than you asked for. To avoid that, set it to at least
+  the number of buckets in your range — for the 24 hours at five-minute
+  resolution used above, that is `24 × 60 / 5 = 288`.
 
 ### Interpreting the response {#interpreting-the-response}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/api/howtos/query-usage-metrics.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/api/howtos/query-usage-metrics.mdx
@@ -1,0 +1,337 @@
+---
+sidebar_label: Auslastungsmetriken abfragen
+sidebar_position: 30
+title: CPU- und RAM-Auslastung über die API abfragen
+description: Dieser Artikel erklärt, wie CPU- und Speicherauslastung von Projekten und Servern über die Metrics-API abgefragt werden können.
+tags:
+  - Metrics
+  - Monitoring
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+Die mStudio-API stellt die CPU- und Speicherauslastung bereit, die du auch im
+mStudio siehst. Anders als der Rest der API werden diese Daten nicht über
+reguläre REST-Operationen ausgeliefert: Die Route `/v2/apps/metrics` ist ein
+**transparenter Proxy auf eine Grafana-Instanz**. Alles unterhalb dieses Pfads
+ist die Grafana-HTTP-API, `POST /v2/apps/metrics/api/ds/query` ist also Grafanas
+Endpunkt zum Abfragen von Datenquellen.
+
+Die dahinterliegende Datenquelle ist eine Prometheus-Instanz. Die Abfragen, die
+du sendest, sind daher
+[PromQL](https://prometheus.io/docs/prometheus/querying/basics/)-Ausdrücke.
+
+## Authentifizierung {#authentication}
+
+Die Authentifizierung funktioniert genau wie beim Rest der API: Übergib deinen
+API-Token im `Authorization`-Header.
+
+```http
+POST /v2/apps/metrics/api/ds/query HTTP/1.1
+Host: api.mittwald.de
+Authorization: Bearer <YOUR_API_TOKEN>
+Content-Type: application/json
+```
+
+Wie du einen API-Token erhältst, erfährst du in der
+[Einführung zur API](/docs/v2/api/intro).
+
+## Autorisierung {#authorization}
+
+Der Metrics-Proxy authentifiziert nicht nur deinen Token, sondern prüft auch die
+**Label-Selektoren in deinem PromQL-Ausdruck** einzeln auf Berechtigungen. Dabei
+gibt es zwei voneinander unabhängige Regeln, die mit unterschiedlichen Fehlern
+fehlschlagen.
+
+### Jede Abfrage muss eingegrenzt sein {#query-scoping}
+
+Jeder Selektor auf einer `cloudhosting_project_*`-Metrik muss mindestens eines
+der Label `project`, `project_group` oder `placement_group` enthalten. Eine
+nicht eingegrenzte Abfrage wie
+`SUM(cloudhosting_project_usage_memory_bytes:5m:max)` wird unabhängig von deinen
+Berechtigungen direkt abgelehnt:
+
+```
+unauthorized: authorizer failed (one of the following authorizers must match:
+[when metric matches '^cloudhosting_project_.*$', must have labels map[project:{}]],
+[when metric matches '^cloudhosting_project_.*$', must have labels map[project_group:{}]],
+[when metric matches '^cloudhosting_project_.*$', must have labels map[placement_group:{}]]):
+none of the authorizers matched
+```
+
+### Du musst Zugriff auf die selektierte Ressource haben {#resource-access}
+
+Wählst du eine Ressource aus, auf die dein Token keinen Zugriff hat, erhältst du
+kein leeres Ergebnis, sondern einen Fehler für die betreffende Abfrage:
+
+```
+unauthorized: authorizer failed (must be authorized to access the resources
+referenced in the query labels): user is not allowed to access project group s-kc6yrn
+```
+
+Wichtig dabei: **Zugriff auf ein Projekt bedeutet nicht automatisch Zugriff auf
+dessen Server.** Beides wird getrennt autorisiert, was konkrete Auswirkungen auf
+die weiter unten stehenden Auslastungs-Beispiele hat: Sie teilen alle durch eine
+über `project_group` selektierte `cloudhosting_projectgroup_limits_*`-Metrik und
+benötigen deshalb Zugriff auf **Server-Ebene** – auch dann, wenn dich nur ein
+einzelnes Projekt interessiert.
+
+Wenn du nur Zugriff auf Projektebene hast, kannst du weiterhin absolute
+Verbrauchswerte abfragen, da diese nur über `project` selektieren:
+
+```promql
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"})
+```
+
+Beachte außerdem, dass die _zurückgelieferten_ Zeitreihen ein
+`project_group`-Label tragen, auch wenn du nur über `project` selektierst. Dieses
+Label im Ergebnis lesen zu können bedeutet nicht, dass du danach selektieren
+darfst.
+
+## Verfügbare Metriken {#available-metrics}
+
+Bei allen Metriken handelt es sich um **Recording Rules**, nicht um rohe
+Zeitreihen. Das Suffix `:5m` bezeichnet das Downsampling-Intervall: Die Werte
+sind in Fünf-Minuten-Buckets voraggregiert. Eine feinere Auflösung als fünf
+Minuten abzufragen bringt daher nichts – du erhältst schlicht denselben
+Bucket-Wert mehrfach.
+
+Das Suffix nach dem Intervall beschreibt die innerhalb eines Buckets angewendete
+Aggregationsfunktion (`:max` für Spitzenwerte). Metriken, die auf `_rate` enden,
+wurden bereits mit `rate()` verarbeitet und dürfen daher **nicht** erneut in
+`rate()` verpackt werden.
+
+### Verbrauchsmetriken {#usage-metrics}
+
+| Metrik                                                           | Label                      | Einheit              | Bedeutung                                                                                       |
+| ---------------------------------------------------------------- | -------------------------- | -------------------- | ----------------------------------------------------------------------------------------------- |
+| `cloudhosting_project_usage_memory_bytes:5m:max`                 | `project`, `project_group` | Bytes                | Maximal genutzter Speicher der Workloads eines Projekts innerhalb eines Fünf-Minuten-Buckets    |
+| `cloudhosting_project_usage_cpu_seconds_total_rate:5m`           | `project`, `project_group` | CPU-Sekunden/Sekunde | Durchschnittlicher CPU-Verbrauch der Workloads eines Projekts; `1` entspricht einem vollen Kern |
+| `cloudhosting_databasesetmember_usage_memory_bytes:5m:max`       | `project_group`            | Bytes                | Maximal genutzter Speicher der Datenbank-Instanzen (MySQL, Redis, …) eines Servers              |
+| `cloudhosting_databasesetmember_usage_cpu_seconds_total_rate:5m` | `project_group`            | CPU-Sekunden/Sekunde | Durchschnittlicher CPU-Verbrauch der Datenbank-Instanzen eines Servers                          |
+
+Der Datenbankverbrauch wird getrennt vom Projektverbrauch erfasst, da
+Datenbank-Instanzen nicht Teil der Workloads eines Projekts sind. Um den
+**Gesamtverbrauch** eines Servers zu erhalten, musst du daher beides addieren
+(siehe die Beispiele weiter unten).
+
+### Limit-Metriken {#limit-metrics}
+
+| Metrik                                             | Label           | Einheit      | Bedeutung                           |
+| -------------------------------------------------- | --------------- | ------------ | ----------------------------------- |
+| `cloudhosting_projectgroup_limits_memory_bytes:5m` | `project_group` | Bytes        | Für den Server verfügbarer Speicher |
+| `cloudhosting_projectgroup_limits_cpu_seconds:5m`  | `project_group` | CPU-Sekunden | Für den Server verfügbare CPU-Kerne |
+
+### Label {#labels}
+
+- `project` enthält die **Kurz-ID** eines Projekts im Format `p-xxxxxx`.
+- `project_group` enthält die **Kurz-ID** eines Servers im Format `s-xxxxxx`.
+  "Project Group" ist die interne Bezeichnung für das, was im mStudio Server
+  heißt.
+
+Beachte, dass es sich hierbei um die Kurz-IDs handelt und **nicht** um die
+IDs im UUID-Format, die die meisten REST-Operationen der API erwarten.
+
+Ein drittes Label, `placement_group`, wird vom Authorizer ebenfalls als gültige
+Eingrenzung akzeptiert. Für die Abfragen in diesem Artikel wird es nicht
+benötigt.
+
+Die zurückgelieferten Zeitreihen tragen zusätzlich Label wie
+`project_environment`, `cluster` und `tier`. Diese sind intern und sollten nicht
+verwendet werden.
+
+## Beispielabfragen {#example-queries}
+
+Die folgenden Abfragen liefern jeweils ein **Verhältnis zwischen 0 und 1**;
+multipliziere mit 100, um einen Prozentwert zu erhalten. Das entspricht der
+Auslastung, die auch im mStudio angezeigt wird.
+
+### Speicherauslastung eines einzelnen Projekts {#memory-utilization-project}
+
+```promql
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"}) /
+SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-kc6yrn"})
+```
+
+Diese Abfrage setzt den Speicherverbrauch eines einzelnen Projekts ins
+Verhältnis zum Limit des Servers, auf dem es läuft – beantwortet also die Frage
+"Wie viel vom RAM meines Servers verbraucht dieses Projekt?".
+
+### CPU-Auslastung eines einzelnen Projekts {#cpu-utilization-project}
+
+```promql
+SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project="p-zrblbi"}) /
+SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-kc6yrn"})
+```
+
+### Speicherauslastung eines gesamten Servers {#memory-utilization-server}
+
+```promql
+(SUM (cloudhosting_databasesetmember_usage_memory_bytes:5m:max{project_group="s-kc6yrn"} or vector (0)) +
+ SUM (cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-kc6yrn"})) /
+SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-kc6yrn"})
+```
+
+Hier wird das Label `project_group` auch auf den Verbrauchsmetriken verwendet,
+sodass _alle_ Projekte des Servers aufsummiert werden und der Datenbankverbrauch
+zusätzlich hinzukommt.
+
+Der Fallback `or vector (0)` ist dabei wichtig: Hat ein Server überhaupt keine
+Datenbanken, existiert die `cloudhosting_databasesetmember_*`-Zeitreihe nicht,
+und ohne den Fallback würde die gesamte Addition ein leeres Ergebnis liefern
+statt lediglich des Projektverbrauchs.
+
+### CPU-Auslastung eines gesamten Servers {#cpu-utilization-server}
+
+```promql
+(SUM (cloudhosting_databasesetmember_usage_cpu_seconds_total_rate:5m{project_group="s-kc6yrn"} or vector (0)) +
+ SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project_group="s-kc6yrn"})) /
+SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-kc6yrn"})
+```
+
+### Absolute Werte {#absolute-values}
+
+Wenn dich absolute Zahlen statt Auslastungsverhältnissen interessieren, lass
+einfach die Division weg:
+
+```promql
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"})
+```
+
+Oder lass das `SUM` weg, um eine Zeitreihe je Projekt auf dem Server zu
+erhalten. Das ist nützlich, um aufzuschlüsseln, welches Projekt eines Servers
+die meisten Ressourcen verbraucht:
+
+```promql
+cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-kc6yrn"}
+```
+
+## Eine Abfrage senden {#sending-a-query}
+
+Abfragen werden an den Grafana-Endpunkt
+`POST /v2/apps/metrics/api/ds/query` gesendet. Der Request-Body folgt Grafanas
+[Data-Source-Query-API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/data_source/):
+
+```json
+{
+  "from": "now-24h",
+  "to": "now",
+  "queries": [
+    {
+      "refId": "A",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "MetricsAuthPrometheus"
+      },
+      "expr": "SUM (cloudhosting_project_usage_memory_bytes:5m:max{project=\"p-zrblbi\"}) / SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group=\"s-kc6yrn\"})",
+      "intervalMs": 300000,
+      "maxDataPoints": 288
+    }
+  ]
+}
+```
+
+Die relevanten Felder sind:
+
+- `from` und `to` definieren den Zeitraum. Sie akzeptieren entweder
+  Epoch-Millisekunden oder Grafanas relative Zeitsyntax (`now`, `now-24h`,
+  `now-7d`).
+- `datasource.uid` muss `MetricsAuthPrometheus` lauten. Du kannst das zur
+  Laufzeit über `GET /v2/apps/metrics/api/datasources` bestätigen, was die
+  verfügbaren Datenquellen auflistet.
+- `refId` ist ein frei wählbarer Bezeichner, nach dem die Antwort geschlüsselt
+  ist. Sende mehrere Einträge in `queries` mit unterschiedlichen `refId`s, um
+  mehrere Ausdrücke in einem einzigen Request auszuwerten.
+- `expr` enthält den PromQL-Ausdruck.
+- `intervalMs` ist die Schrittweite. Da die zugrundeliegenden Daten auf fünf
+  Minuten heruntergerechnet sind, ist `300000` der sinnvollste Wert.
+- `maxDataPoints` begrenzt die Anzahl zurückgelieferter Datenpunkte. Grafana
+  erhöht die Schrittweite, wenn der angefragte Zeitraum geteilt durch
+  `intervalMs` diesen Wert überschreitet.
+
+### Die Antwort interpretieren {#interpreting-the-response}
+
+Die Antwort ist ein Grafana-**Data-Frame**, der Werte spaltenweise speichert und
+nicht als Liste von Zeitstempel-Wert-Paaren:
+
+```json
+{
+  "results": {
+    "A": {
+      "frames": [
+        {
+          "schema": {
+            "refId": "A",
+            "fields": [
+              { "name": "Time", "type": "time" },
+              { "name": "Value", "type": "number" }
+            ]
+          },
+          "data": {
+            "values": [
+              [1753048800000, 1753049100000, 1753049400000],
+              [0.4213, 0.4198, 0.4402]
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+`data.values` enthält je ein Array pro Feld aus `schema.fields`, in derselben
+Reihenfolge. Das erste Array enthält die Zeitstempel (Epoch-Millisekunden), das
+zweite die Werte. Für den _n_-ten Datenpunkt liest du also Index _n_ aus jedem
+Array.
+
+Schlägt eine Abfrage fehl, enthält der zugehörige `results`-Eintrag statt
+`frames` eine `error`-Eigenschaft. Beachte, dass dies **pro Abfrage** passieren
+kann, auch wenn der HTTP-Statuscode `200` lautet – prüfe daher immer jede
+gesendete `refId` auf `error`.
+
+## Client-Bibliotheken {#client-libraries}
+
+Keines der mittwald-SDKs deckt diesen Endpunkt ab, da er nicht Teil der
+OpenAPI-Spezifikation ist. Du hast zwei sinnvolle Möglichkeiten:
+
+**Einen einfachen HTTP-Client verwenden.** Request und Response sind
+überschaubar genug, dass das oft der unkomplizierteste Weg ist. Du brauchst
+lediglich einen POST mit JSON-Body und die oben beschriebene Dekodierung der
+beiden Arrays.
+
+**Eine Grafana-Client-Bibliothek verwenden**, um dir das Dekodieren der
+Data-Frames abzunehmen. Nützlich sind:
+
+<Tabs groupId="language">
+<TabItem value="typescript" label="TypeScript">
+
+[`@grafana/data`](https://www.npmjs.com/package/@grafana/data) stellt
+`dataFrameFromJSON()` bereit, das die rohen Frames der Antwort in typisierte
+`DataFrame`-Objekte umwandelt, sowie Hilfsfunktionen zum Iterieren über Felder.
+Es ist eine umfangreiche Abhängigkeit und lohnt sich daher nur, wenn du
+intensiver mit den Daten arbeitest.
+
+</TabItem>
+<TabItem value="go" label="Go">
+
+[`github.com/grafana/grafana-plugin-sdk-go/data`](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/data)
+enthält den kanonischen `data.Frame`-Typ inklusive `UnmarshalJSON`-Unterstützung.
+Damit kannst du die Frames der Antwort direkt in typisierte Go-Strukturen
+dekodieren.
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+[`grafana-client`](https://github.com/grafana-toolbox/grafana-client) kapselt die
+Grafana-HTTP-API inklusive Datenquellen-Abfragen. Richte den Client auf
+`https://api.mittwald.de/v2/apps/metrics` und authentifiziere dich mit deinem
+mittwald-API-Token.
+
+</TabItem>
+</Tabs>
+
+Da der Proxy die Grafana-HTTP-API unverändert bereitstellt, funktioniert jeder
+generische Grafana-Client, sofern du eine eigene Basis-URL und einen
+Bearer-Token konfigurieren kannst.

--- a/i18n/de/docusaurus-plugin-content-docs/current/api/howtos/query-usage-metrics.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/api/howtos/query-usage-metrics.mdx
@@ -35,7 +35,7 @@ Content-Type: application/json
 ```
 
 Wie du einen API-Token erhältst, erfährst du in der
-[Einführung zur API](/docs/v2/api/intro).
+[Einführung zur API](../../intro).
 
 ## Autorisierung {#authorization}
 
@@ -67,7 +67,7 @@ kein leeres Ergebnis, sondern einen Fehler für die betreffende Abfrage:
 
 ```
 unauthorized: authorizer failed (must be authorized to access the resources
-referenced in the query labels): user is not allowed to access project group s-kc6yrn
+referenced in the query labels): user is not allowed to access project group s-XXXXXX
 ```
 
 Wichtig dabei: **Zugriff auf ein Projekt bedeutet nicht automatisch Zugriff auf
@@ -81,7 +81,7 @@ Wenn du nur Zugriff auf Projektebene hast, kannst du weiterhin absolute
 Verbrauchswerte abfragen, da diese nur über `project` selektieren:
 
 ```promql
-SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"})
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-XXXXXX"})
 ```
 
 Beachte außerdem, dass die _zurückgelieferten_ Zeitreihen ein
@@ -125,8 +125,8 @@ Datenbank-Instanzen nicht Teil der Workloads eines Projekts sind. Um den
 
 ### Label {#labels}
 
-- `project` enthält die **Kurz-ID** eines Projekts im Format `p-xxxxxx`.
-- `project_group` enthält die **Kurz-ID** eines Servers im Format `s-xxxxxx`.
+- `project` enthält die **Kurz-ID** eines Projekts im Format `p-XXXXXX`.
+- `project_group` enthält die **Kurz-ID** eines Servers im Format `s-XXXXXX`.
   "Project Group" ist die interne Bezeichnung für das, was im mStudio Server
   heißt.
 
@@ -150,8 +150,8 @@ Auslastung, die auch im mStudio angezeigt wird.
 ### Speicherauslastung eines einzelnen Projekts {#memory-utilization-project}
 
 ```promql
-SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"}) /
-SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-kc6yrn"})
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-XXXXXX"}) /
+SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-XXXXXX"})
 ```
 
 Diese Abfrage setzt den Speicherverbrauch eines einzelnen Projekts ins
@@ -161,16 +161,16 @@ Verhältnis zum Limit des Servers, auf dem es läuft – beantwortet also die Fr
 ### CPU-Auslastung eines einzelnen Projekts {#cpu-utilization-project}
 
 ```promql
-SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project="p-zrblbi"}) /
-SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-kc6yrn"})
+SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project="p-XXXXXX"}) /
+SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-XXXXXX"})
 ```
 
 ### Speicherauslastung eines gesamten Servers {#memory-utilization-server}
 
 ```promql
-(SUM (cloudhosting_databasesetmember_usage_memory_bytes:5m:max{project_group="s-kc6yrn"} or vector (0)) +
- SUM (cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-kc6yrn"})) /
-SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-kc6yrn"})
+(SUM (cloudhosting_databasesetmember_usage_memory_bytes:5m:max{project_group="s-XXXXXX"} or vector (0)) +
+ SUM (cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-XXXXXX"})) /
+SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group="s-XXXXXX"})
 ```
 
 Hier wird das Label `project_group` auch auf den Verbrauchsmetriken verwendet,
@@ -185,9 +185,9 @@ statt lediglich des Projektverbrauchs.
 ### CPU-Auslastung eines gesamten Servers {#cpu-utilization-server}
 
 ```promql
-(SUM (cloudhosting_databasesetmember_usage_cpu_seconds_total_rate:5m{project_group="s-kc6yrn"} or vector (0)) +
- SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project_group="s-kc6yrn"})) /
-SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-kc6yrn"})
+(SUM (cloudhosting_databasesetmember_usage_cpu_seconds_total_rate:5m{project_group="s-XXXXXX"} or vector (0)) +
+ SUM (cloudhosting_project_usage_cpu_seconds_total_rate:5m{project_group="s-XXXXXX"})) /
+SUM (cloudhosting_projectgroup_limits_cpu_seconds:5m{project_group="s-XXXXXX"})
 ```
 
 ### Absolute Werte {#absolute-values}
@@ -196,7 +196,7 @@ Wenn dich absolute Zahlen statt Auslastungsverhältnissen interessieren, lass
 einfach die Division weg:
 
 ```promql
-SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-zrblbi"})
+SUM (cloudhosting_project_usage_memory_bytes:5m:max{project="p-XXXXXX"})
 ```
 
 Oder lass das `SUM` weg, um eine Zeitreihe je Projekt auf dem Server zu
@@ -204,7 +204,7 @@ erhalten. Das ist nützlich, um aufzuschlüsseln, welches Projekt eines Servers
 die meisten Ressourcen verbraucht:
 
 ```promql
-cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-kc6yrn"}
+cloudhosting_project_usage_memory_bytes:5m:max{project_group="s-XXXXXX"}
 ```
 
 ## Eine Abfrage senden {#sending-a-query}
@@ -224,7 +224,7 @@ Abfragen werden an den Grafana-Endpunkt
         "type": "prometheus",
         "uid": "MetricsAuthPrometheus"
       },
-      "expr": "SUM (cloudhosting_project_usage_memory_bytes:5m:max{project=\"p-zrblbi\"}) / SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group=\"s-kc6yrn\"})",
+      "expr": "SUM (cloudhosting_project_usage_memory_bytes:5m:max{project=\"p-XXXXXX\"}) / SUM (cloudhosting_projectgroup_limits_memory_bytes:5m{project_group=\"s-XXXXXX\"})",
       "intervalMs": 300000,
       "maxDataPoints": 288
     }
@@ -246,9 +246,12 @@ Die relevanten Felder sind:
 - `expr` enthält den PromQL-Ausdruck.
 - `intervalMs` ist die Schrittweite. Da die zugrundeliegenden Daten auf fünf
   Minuten heruntergerechnet sind, ist `300000` der sinnvollste Wert.
-- `maxDataPoints` begrenzt die Anzahl zurückgelieferter Datenpunkte. Grafana
-  erhöht die Schrittweite, wenn der angefragte Zeitraum geteilt durch
-  `intervalMs` diesen Wert überschreitet.
+- `maxDataPoints` begrenzt die Anzahl zurückgelieferter Datenpunkte.
+  Überschreitet der angefragte Zeitraum geteilt durch `intervalMs` diesen Wert,
+  erhöht Grafana die Schrittweite und du erhältst gröbere Daten als angefragt.
+  Setze den Wert daher mindestens auf die Anzahl der Buckets in deinem Zeitraum
+  – für die oben verwendeten 24 Stunden bei Fünf-Minuten-Auflösung sind das
+  `24 × 60 / 5 = 288`.
 
 ### Die Antwort interpretieren {#interpreting-the-response}
 


### PR DESCRIPTION
Adds a How-To guide covering the `/v2/apps/metrics` endpoint, which is not part of the OpenAPI specification and so far had no documentation.

## Contents

- **The proxy model** — `/v2/apps/metrics` is a transparent proxy to Grafana, so `POST /v2/apps/metrics/api/ds/query` is Grafana's data source query API, backed by Prometheus. Authentication is a regular API token.
- **Authorization** — the proxy authorizes the label selectors in the PromQL expression itself. Two distinct rules are documented: every `cloudhosting_project_*` selector must carry a `project`, `project_group` or `placement_group` label, and you must hold access to the resource you select. Notably, project access does not imply access to its server, which matters because every utilization query divides by a `project_group`-scoped limit metric.
- **Metric reference** — the four usage and two limit recording rules, with labels, units and meaning, plus the `:5m` / `:max` / `_rate` naming convention.
- **Example queries** — project- and server-level CPU/memory utilization, including why the `or vector(0)` fallback is needed.
- **Response handling** — reading Grafana's column-wise data frames, and the `200 OK` with per-query `error` case.
- **Client libraries** — recommends a plain HTTP client for most uses, with Grafana's TypeScript/Go/Python libraries as options for data frame decoding.

German translation included.

## Notes for review

The endpoint is undocumented, so the behavioural details were established empirically against the live API rather than from a spec. Two points worth a second pair of eyes:

- The **semantics of each metric** are inferred from the example queries, not from an authoritative source. In particular I describe `cloudhosting_project_usage_cpu_seconds_total_rate:5m` as "`1` equals one full core" — plausible for a rate of cpu-seconds per second, but unverified.
- `placement_group` is documented as an accepted scoping label because the authorizer names it in its error message. I do not know what it actually identifies, so the guide says only that it exists and is not needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VurtBFynjy9Yn1dtTrYxaF