### PR TITLE
docs(guides): add guide on profiling PHP applications with Tideways

### DIFF
--- a/docs/guides/operations/tideways-profiling.md
+++ b/docs/guides/operations/tideways-profiling.md
@@ -8,7 +8,7 @@ description: |
   Learn how to profile and monitor your PHP applications with Tideways, using the bundled PHP extension and a containerized Tideways daemon.
 ---
 
-[Tideways](https://tideways.com/) is a commercial application performance monitoring (APM) and profiling service for PHP. It continuously records how long your requests take, where that time is spent, and which errors occur — down to individual function calls and database queries.
+[Tideways](https://tideways.com/) is a commercial application performance monitoring (APM) and profiling service for PHP. It continuously records how long your requests take, where that time is spent, and which errors occur, down to individual function calls and database queries.
 
 Tideways consists of three parts:
 

--- a/docs/guides/operations/tideways-profiling.md
+++ b/docs/guides/operations/tideways-profiling.md
@@ -230,14 +230,14 @@ After installing it and logging in with your Tideways account, click the Tideway
 
 - Verify that the daemon container is running and that port `9135` is published. Without a published port, the container is not reachable from your app.
 - Check that `tideways.connection` uses the container's internal DNS name, not its display name or container ID. You can look up the DNS name in the mStudio UI or with `mw container list`.
-- Inspect the daemon logs with `mw container logs tideways-daemon` for connection or authentication errors.
+- Inspect the PHP error logs at `/var/log/php_errors.log` and the daemon logs with `mw container logs tideways-daemon` for connection or authentication errors.
 - Make sure the API key belongs to the Tideways project you are looking at.
 
 ### The extension is not loaded {#troubleshooting-extension}
 
 - Confirm that your app runs a PHP version that includes the extension (see [Prerequisites](#prerequisites)).
 - Make sure the configuration file is located in `~/.config/php/php.d/` and has an `.ini` extension. `extension=tideways.so` has no effect in a per-directory `.user.ini` file.
-- Check the PHP error log of your app for messages about a failed extension load.
+- Check the PHP error log of your app at `/var/log/php_errors.log` for messages about a failed extension load.
 
 ### Traces are missing for CLI scripts and cron jobs {#troubleshooting-cli}
 

--- a/docs/guides/operations/tideways-profiling.md
+++ b/docs/guides/operations/tideways-profiling.md
@@ -192,7 +192,9 @@ Your API key is a credential. Anyone with filesystem access to your project can 
 
 Changes to files in `~/.config/php/php.d` are detected automatically, and the PHP-FPM service is restarted for you. There is no need to restart anything manually.
 
-The configuration applies to the whole project, so all PHP apps in it will report to Tideways. Loading a PHP extension is a system-level setting and therefore cannot be done in a per-directory `.user.ini` file.
+The configuration applies to the whole project, so all PHP apps in it will report to Tideways. This includes PHP running on the command line, which means cron jobs, queue workers and console commands are profiled as well, without any additional configuration.
+
+Loading a PHP extension is a system-level setting and therefore cannot be done in a per-directory `.user.ini` file.
 
 :::
 
@@ -238,10 +240,6 @@ After installing it and logging in with your Tideways account, click the Tideway
 - Confirm that your app runs a PHP version that includes the extension (see [Prerequisites](#prerequisites)).
 - Make sure the configuration file is located in `~/.config/php/php.d/` and has an `.ini` extension. `extension=tideways.so` has no effect in a per-directory `.user.ini` file.
 - Check the PHP error log of your app at `/var/log/php_errors.log` for messages about a failed extension load.
-
-### Traces are missing for CLI scripts and cron jobs {#troubleshooting-cli}
-
-The extension's default behavior differs between web requests and CLI scripts. If you want to monitor cron jobs, queue workers or console commands, refer to the [Tideways documentation on background jobs and CLI monitoring](https://support.tideways.com/documentation/).
 
 ### Profiling a containerized PHP application {#troubleshooting-containers}
 

--- a/docs/guides/operations/tideways-profiling.md
+++ b/docs/guides/operations/tideways-profiling.md
@@ -1,0 +1,257 @@
+---
+title: Profiling PHP applications with Tideways
+sidebar_label: Tideways profiling
+tags:
+  - PHP
+  - Containers
+description: |
+  Learn how to profile and monitor your PHP applications with Tideways, using the bundled PHP extension and a containerized Tideways daemon.
+---
+
+[Tideways](https://tideways.com/) is a commercial application performance monitoring (APM) and profiling service for PHP. It continuously records how long your requests take, where that time is spent, and which errors occur — down to individual function calls and database queries.
+
+Tideways consists of three parts:
+
+1. A **PHP extension** that instruments your application and collects traces. This extension is already bundled with mittwald's PHP builds, so you only need to enable it.
+2. The **Tideways daemon**, a small background service that buffers the collected traces and forwards them to the Tideways backend. You run it yourself, as a container in your project.
+3. The **Tideways backend** at [app.tideways.io](https://app.tideways.io/), where you analyze the collected data.
+
+This guide walks you through enabling the extension and running the daemon on the mittwald platform.
+
+## Prerequisites {#prerequisites}
+
+To follow this guide, you will need:
+
+- Access to a mittwald mStudio project with a [PHP app](/docs/v2/platform/workloads/php) (or [PHP worker](/docs/v2/platform/workloads/php-worker))
+- A hosting plan that supports [containerized workloads](/docs/v2/platform/workloads/containers), because the Tideways daemon runs as a container
+- A [Tideways account](https://tideways.com/) and the API key of a Tideways project (you will find it in the Tideways UI under the project's settings)
+- One of the following PHP versions, which are the first mittwald builds to ship the Tideways extension:
+  - PHP 8.3.33 or newer
+  - PHP 8.4.24 or newer
+  - PHP 8.5.9 or newer
+
+You can look up the PHP version of your app in the mStudio UI, or from the CLI:
+
+```shellsession title="Local shell session"
+user@local $ mw app get <app-id>
+```
+
+If your app runs an older PHP version, update it before you continue:
+
+```shellsession title="Local shell session"
+user@local $ mw app dependency update <app-id> --set php=~8.4
+```
+
+See [Managing and deploying PHP applications](/docs/v2/platform/workloads/php#auto-updates) for more details on PHP version management.
+
+## Step 1: Running the Tideways daemon {#daemon}
+
+The PHP extension does not talk to the Tideways backend directly. Instead, it sends its data to the Tideways daemon over a TCP connection, and the daemon takes care of buffering and transmitting it. This means you need exactly one daemon container per project, which all of your PHP apps can share.
+
+We use the `ghcr.io/tideways/daemon:latest` image from the [GitHub Container Registry](https://github.com/tideways/daemon/pkgs/container/daemon) for this container. The daemon listens on TCP port `9135` and needs no persistent storage, so no volumes are required.
+
+:::note
+
+The daemon does **not** need your API key. The key is configured on the PHP side and passed along with every trace, which is why a single daemon can serve multiple Tideways projects.
+
+:::
+
+### Using the mStudio UI {#daemon-ui}
+
+In mStudio, go to your project, select **"Containers"** and click **"Create container"**. A guided dialog will open to assist you with the container setup.
+
+First, enter a description — this is a free text field used to identify the container. For example, enter **"Tideways daemon"** and click **"Next"**.
+
+Next, you'll be asked for the image name. Enter `ghcr.io/tideways/daemon:latest` and confirm with **"Next"**.
+
+#### Entrypoint and Command {#daemon-ui-command}
+
+- **Entrypoint:** No changes required
+- **Command:** No changes required for a default setup. To control how the daemon registers itself in the Tideways UI, you can pass `--env=production --hostname=tideways-daemon` (see [Daemon options](#daemon-options) below).
+
+#### Volumes {#daemon-ui-volumes}
+
+No volumes are required. The daemon only buffers data in memory and forwards it.
+
+#### Environment Variables {#daemon-ui-env}
+
+No environment variables are required.
+
+Once you're through the dialog, you'll be asked for the **port**. Enter `9135` so that the daemon becomes reachable for the other workloads in your project. Click **"Create container"** to create and start the container.
+
+:::note
+
+Take note of the container's internal DNS name, which is displayed in mStudio after creation. It is derived from the container name — a container named `Tideways daemon` gets the DNS name `tideways-daemon`. You will need this name in [step 2](#php-config).
+
+:::
+
+### Alternative: Using the `mw container run` command {#daemon-cli-run}
+
+You can also create and start the daemon container directly from the command line:
+
+```shellsession title="Local shell session"
+user@local $ mw container run \
+  --name tideways-daemon \
+  --description "Tideways daemon" \
+  --publish 9135:9135 \
+  ghcr.io/tideways/daemon:latest
+```
+
+The `--name` flag determines the internal DNS name under which the daemon will be reachable from your apps.
+
+To pass options to the daemon itself, add them after the image name. Because these options look like CLI flags, separate them from the `mw` flags with a `--`:
+
+```shellsession title="Local shell session"
+user@local $ mw container run \
+  --name tideways-daemon \
+  --description "Tideways daemon" \
+  --publish 9135:9135 \
+  -- ghcr.io/tideways/daemon:latest --env=production --hostname=tideways-daemon
+```
+
+### Alternative: Using the `mw stack deploy` command {#daemon-cli-stack}
+
+Alternatively, you can use the `mw stack deploy` command, which is compatible with Docker Compose. Create a `docker-compose.yml` file with the following content:
+
+```yaml
+services:
+  tideways-daemon:
+    image: ghcr.io/tideways/daemon:latest
+    command: "--env=production --hostname=tideways-daemon"
+    ports:
+      - "9135:9135/tcp"
+```
+
+Then deploy it:
+
+```shellsession title="Local shell session"
+user@local $ mw stack deploy
+```
+
+This command will read the `docker-compose.yml` file from the current directory and deploy it to your default stack.
+
+### Daemon options {#daemon-options}
+
+The daemon runs fine with its defaults, but two options are worth setting explicitly:
+
+- `--env=<name>` sets the environment name that traces are reported under, for example `production` or `staging`. It defaults to `production`.
+- `--hostname=<name>` sets the server name that the daemon registers itself with in the Tideways UI. Inside containers, the daemon appends the container ID to the detected hostname by default, which means that every recreation of the container shows up as a new server. Setting a fixed hostname avoids this.
+
+The [daemon configuration reference](https://support.tideways.com/documentation/reference/daemon/configuration-reference.html) documents all available options.
+
+:::note
+
+Publishing port `9135` only makes the daemon reachable from _within_ your hosting environment, meaning from other containers and managed apps in the same project. It is not exposed to the internet, and the platform's network policies prevent access from other projects.
+
+:::
+
+## Step 2: Configuring the PHP extension {#php-config}
+
+The Tideways extension is part of your app's PHP installation, but it is disabled by default. To enable and configure it, add a new configuration file to your project's PHP configuration directory. Connect to your app via SSH:
+
+```shellsession title="Local shell session"
+user@local $ mw app ssh <app-id>
+```
+
+Then create the file `~/.config/php/php.d/20-tideways.ini` with the following content:
+
+```ini title="~/.config/php/php.d/20-tideways.ini"
+extension=tideways.so
+
+; The API key of your Tideways project
+tideways.api_key=YOUR_API_KEY
+
+; The internal DNS name and port of your daemon container
+tideways.connection=tcp://tideways-daemon:9135
+
+; Groups the collected data within your Tideways project
+tideways.service=web
+
+; Percentage of requests that are recorded with the timeline profiler
+tideways.trace_sample_rate=25
+```
+
+Replace `YOUR_API_KEY` with the API key of your Tideways project, and `tideways-daemon` with the internal DNS name of the container you created in [step 1](#daemon).
+
+The settings have the following meaning:
+
+- `tideways.api_key` (**required**) authenticates your traces against your Tideways project.
+- `tideways.connection` (**required** in this setup) points the extension at your daemon. Without it, the extension looks for a daemon on a local Unix socket, which does not exist on the mittwald platform.
+- `tideways.service` groups monitoring data into independent units within a project, each with its own performance and error statistics. Use it to tell your web frontend, your API and your background workers apart. It defaults to `app`.
+- `tideways.trace_sample_rate` controls the percentage of requests that are recorded with the full timeline profiler. It defaults to `25`. All other requests are still covered by performance and error monitoring.
+
+See the [Tideways configuration documentation](https://support.tideways.com/documentation/setup/configuration/configure-tideways-globally-via-php-ini.html) for the complete list of settings.
+
+:::caution
+
+Your API key is a credential. Anyone with filesystem access to your project can read it from this file, so do not commit `20-tideways.ini` to version control or copy it into publicly readable directories.
+
+:::
+
+:::note
+
+Changes to files in `~/.config/php/php.d` are detected automatically, and the PHP-FPM service is restarted for you. There is no need to restart anything manually.
+
+The configuration applies to the whole project, so all PHP apps in it will report to Tideways. Loading a PHP extension is a system-level setting and therefore cannot be done in a per-directory `.user.ini` file.
+
+:::
+
+## Step 3: Verifying the setup {#verification}
+
+First, check that the extension is loaded. In an SSH session on your app, run:
+
+```shellsession title="SSH shell session"
+user@ssh $ php -m | grep -i tideways
+```
+
+The output should contain `tideways`. To also confirm that your settings were picked up, run:
+
+```shellsession title="SSH shell session"
+user@ssh $ php -i | grep tideways
+```
+
+Next, check that the daemon is running and accepting connections:
+
+```shellsession title="Local shell session"
+user@local $ mw container logs tideways-daemon
+```
+
+Finally, send some traffic to your application and open your project in [app.tideways.io](https://app.tideways.io/). The first data points usually appear within a few minutes.
+
+## Profiling on demand with the browser extension {#browser-extension}
+
+Sampling covers your average traffic, but sometimes you want a full trace of one specific page load. The [Tideways browser extension](https://support.tideways.com/documentation/reference/browser-extension/chrome-extension.html) lets you trigger this from your browser: it sets a signed `TIDEWAYS_SESSION` cookie that instructs the PHP extension to record a complete timeline and callgraph trace for your own requests.
+
+After installing it and logging in with your Tideways account, click the Tideways icon and select **"Take Profile"** to reload the current page with profiling enabled, or **"Profile for 15 seconds"** to capture a sequence of interactions such as a form submission or a series of AJAX calls.
+
+## Troubleshooting {#troubleshooting}
+
+### No data appears in Tideways {#troubleshooting-no-data}
+
+- Verify that the daemon container is running and that port `9135` is published. Without a published port, the container is not reachable from your app.
+- Check that `tideways.connection` uses the container's internal DNS name, not its display name or container ID. You can look up the DNS name in the mStudio UI or with `mw container list`.
+- Inspect the daemon logs with `mw container logs tideways-daemon` for connection or authentication errors.
+- Make sure the API key belongs to the Tideways project you are looking at.
+
+### The extension is not loaded {#troubleshooting-extension}
+
+- Confirm that your app runs a PHP version that includes the extension (see [Prerequisites](#prerequisites)).
+- Make sure the configuration file is located in `~/.config/php/php.d/` and has an `.ini` extension. `extension=tideways.so` has no effect in a per-directory `.user.ini` file.
+- Check the PHP error log of your app for messages about a failed extension load.
+
+### Traces are missing for CLI scripts and cron jobs {#troubleshooting-cli}
+
+The extension's default behavior differs between web requests and CLI scripts. If you want to monitor cron jobs, queue workers or console commands, refer to the [Tideways documentation on background jobs and CLI monitoring](https://support.tideways.com/documentation/).
+
+### Profiling a containerized PHP application {#troubleshooting-containers}
+
+This guide covers managed PHP apps, where mittwald provides the PHP build including the Tideways extension. If you run PHP in your own container instead, you need to install the extension into your image yourself, following the [Tideways Docker installation instructions](https://support.tideways.com/documentation/setup/installation/docker-with-compose.html). The daemon setup described in [step 1](#daemon) stays the same.
+
+## Further resources {#further-resources}
+
+- [Tideways documentation](https://support.tideways.com/documentation/)
+- [Configuring Tideways via php.ini](https://support.tideways.com/documentation/setup/configuration/configure-tideways-globally-via-php-ini.html)
+- [Tideways daemon configuration reference](https://support.tideways.com/documentation/reference/daemon/configuration-reference.html)
+- [Tideways browser extension](https://support.tideways.com/documentation/reference/browser-extension/chrome-extension.html)
+- [Managing and deploying PHP applications](/docs/v2/platform/workloads/php)
+- [Managing and deploying containerized applications](/docs/v2/platform/workloads/containers)

--- a/docs/guides/operations/tideways-profiling.md
+++ b/docs/guides/operations/tideways-profiling.md
@@ -164,8 +164,10 @@ tideways.api_key=YOUR_API_KEY
 ; The internal DNS name and port of your daemon container
 tideways.connection=tcp://tideways-daemon:9135
 
-; Groups the collected data within your Tideways project
-tideways.service=web
+; Optional: Override the default service name for this app. Use this
+; with caution, as some apps will automatically set the service name
+; depending in which interface you're using (e.g. storefront/backend/API)
+; tideways.service=...
 
 ; Percentage of requests that are recorded with the timeline profiler
 tideways.trace_sample_rate=25
@@ -177,7 +179,7 @@ The settings have the following meaning:
 
 - `tideways.api_key` (**required**) authenticates your traces against your Tideways project.
 - `tideways.connection` (**required** in this setup) points the extension at your daemon. Without it, the extension looks for a daemon on a local Unix socket, which does not exist on the mittwald platform.
-- `tideways.service` groups monitoring data into independent units within a project, each with its own performance and error statistics. Use it to tell your web frontend, your API and your background workers apart. It defaults to `app`.
+- `tideways.service` lets you override the default service name that Tideways assigns to your app. See [the docs on Configuring Services](https://support.tideways.com/documentation/setup/configuration/services.html) for more information.
 - `tideways.trace_sample_rate` controls the percentage of requests that are recorded with the full timeline profiler. It defaults to `25`. All other requests are still covered by performance and error monitoring.
 
 See the [Tideways configuration documentation](https://support.tideways.com/documentation/setup/configuration/configure-tideways-globally-via-php-ini.html) for the complete list of settings.
@@ -210,6 +212,12 @@ The output should contain `tideways`. To also confirm that your settings were pi
 
 ```shellsession title="SSH shell session"
 user@ssh $ php -i | grep tideways
+```
+
+The output of this command should contain a section like this:
+
+```
+Can connect to tideways-daemon? => Yes, version 1.15.2
 ```
 
 Next, check that the daemon is running and accepting connections:

--- a/docs/guides/operations/tideways-profiling.md
+++ b/docs/guides/operations/tideways-profiling.md
@@ -48,7 +48,7 @@ See [Managing and deploying PHP applications](/docs/v2/platform/workloads/php#au
 
 The PHP extension does not talk to the Tideways backend directly. Instead, it sends its data to the Tideways daemon over a TCP connection, and the daemon takes care of buffering and transmitting it. This means you need exactly one daemon container per project, which all of your PHP apps can share.
 
-We use the `ghcr.io/tideways/daemon:latest` image from the [GitHub Container Registry](https://github.com/tideways/daemon/pkgs/container/daemon) for this container. The daemon listens on TCP port `9135` and needs no persistent storage, so no volumes are required.
+We will run this daemon as a [container in your project](/docs/v2/platform/workloads/containers/), using the `ghcr.io/tideways/daemon:latest` image from the [GitHub Container Registry](https://github.com/tideways/daemon/pkgs/container/daemon). The daemon listens on TCP port `9135` and needs no persistent storage, so no volumes are required.
 
 :::note
 
@@ -111,7 +111,7 @@ user@local $ mw container run \
 
 ### Alternative: Using the `mw stack deploy` command {#daemon-cli-stack}
 
-Alternatively, you can use the `mw stack deploy` command, which is compatible with Docker Compose. Create a `docker-compose.yml` file with the following content:
+Alternatively, you can use the [`mw stack deploy` command](/docs/v2/cli/reference/stack/), which is compatible with Docker Compose. Create a `docker-compose.yml` file with the following content:
 
 ```yaml
 services:

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
@@ -48,7 +48,7 @@ Weitere Informationen zur Verwaltung der PHP-Version findest du unter [PHP-Anwen
 
 Die PHP-Extension kommuniziert nicht direkt mit dem Tideways-Backend. Stattdessen schickt sie ihre Daten über eine TCP-Verbindung an den Tideways-Daemon, der sich um Pufferung und Übertragung kümmert. Du benötigst daher genau einen Daemon-Container pro Projekt, den sich alle deine PHP-Apps teilen können.
 
-Für diesen Container verwenden wir das Image `ghcr.io/tideways/daemon:latest` aus der [GitHub Container Registry](https://github.com/tideways/daemon/pkgs/container/daemon). Der Daemon lauscht auf dem TCP-Port `9135` und benötigt keinen persistenten Speicher, es sind also keine Volumes erforderlich.
+Wir betreiben diesen Daemon als [Container in deinem Projekt](/docs/v2/platform/workloads/containers/) und verwenden dafür das Image `ghcr.io/tideways/daemon:latest` aus der [GitHub Container Registry](https://github.com/tideways/daemon/pkgs/container/daemon). Der Daemon lauscht auf dem TCP-Port `9135` und benötigt keinen persistenten Speicher, es sind also keine Volumes erforderlich.
 
 :::note
 
@@ -111,7 +111,7 @@ user@local $ mw container run \
 
 ### Alternative: Verwendung des `mw stack deploy`-Befehls {#daemon-cli-stack}
 
-Alternativ kannst du den Befehl `mw stack deploy` verwenden, der mit Docker Compose kompatibel ist. Erstelle dazu eine `docker-compose.yml`-Datei mit folgendem Inhalt:
+Alternativ kannst du den [Befehl `mw stack deploy`](/docs/v2/cli/reference/stack/) verwenden, der mit Docker Compose kompatibel ist. Erstelle dazu eine `docker-compose.yml`-Datei mit folgendem Inhalt:
 
 ```yaml
 services:

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
@@ -5,7 +5,7 @@ tags:
   - PHP
   - Containers
 description: |
-  Erfahre, wie du deine PHP-Anwendungen mit Tideways profilst und überwachst – mit der mitgelieferten PHP-Extension und einem containerisierten Tideways-Daemon.
+  Erfahre, wie du Profiling und Überwachung mit Tideways für deine PHP-Anwendungen nutzt – mit der mitgelieferten PHP-Extension und einem containerisierten Tideways-Daemon.
 ---
 
 [Tideways](https://tideways.com/) ist ein kommerzieller Dienst für Application Performance Monitoring (APM) und Profiling von PHP-Anwendungen. Tideways zeichnet kontinuierlich auf, wie lange deine Requests dauern, wo diese Zeit verbraucht wird und welche Fehler auftreten — bis hinunter zu einzelnen Funktionsaufrufen und Datenbankabfragen.

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
@@ -164,8 +164,11 @@ tideways.api_key=YOUR_API_KEY
 ; Interner DNS-Name und Port deines Daemon-Containers
 tideways.connection=tcp://tideways-daemon:9135
 
-; Gruppiert die gesammelten Daten innerhalb deines Tideways-Projekts
-tideways.service=web
+; Optional: Überschreibt den Standard-Servicenamen für diese App. Nutze
+; das mit Bedacht, da manche Anwendungen den Servicenamen automatisch
+; setzen, je nachdem, welche Oberfläche gerade genutzt wird (z. B.
+; Storefront/Backend/API)
+; tideways.service=...
 
 ; Prozentsatz der Requests, die mit dem Timeline-Profiler aufgezeichnet werden
 tideways.trace_sample_rate=25
@@ -177,7 +180,7 @@ Die Einstellungen haben folgende Bedeutung:
 
 - `tideways.api_key` (**erforderlich**) authentifiziert deine Traces gegenüber deinem Tideways-Projekt.
 - `tideways.connection` (in diesem Setup **erforderlich**) verweist die Extension auf deinen Daemon. Ohne diese Einstellung sucht die Extension einen Daemon auf einem lokalen Unix-Socket, den es auf der mittwald-Plattform nicht gibt.
-- `tideways.service` gruppiert die Monitoring-Daten in voneinander unabhängige Einheiten innerhalb eines Projekts, jeweils mit eigenen Performance- und Fehlerstatistiken. Damit kannst du zum Beispiel Webfrontend, API und Hintergrund-Worker voneinander trennen. Der Standardwert ist `app`.
+- `tideways.service` erlaubt dir, den Standard-Servicenamen zu überschreiben, den Tideways deiner App zuweist. Weitere Informationen findest du in der [Dokumentation zur Konfiguration von Services](https://support.tideways.com/documentation/setup/configuration/services.html).
 - `tideways.trace_sample_rate` steuert, wie viel Prozent der Requests mit dem vollständigen Timeline-Profiler aufgezeichnet werden. Der Standardwert ist `25`. Alle übrigen Requests werden weiterhin vom Performance- und Fehler-Monitoring erfasst.
 
 Die vollständige Liste der Einstellungen findest du in der [Tideways-Konfigurationsdokumentation](https://support.tideways.com/documentation/setup/configuration/configure-tideways-globally-via-php-ini.html).
@@ -210,6 +213,12 @@ Die Ausgabe sollte `tideways` enthalten. Um zusätzlich zu prüfen, ob deine Ein
 
 ```shellsession title="SSH-Sitzung"
 user@ssh $ php -i | grep tideways
+```
+
+Die Ausgabe dieses Befehls sollte einen Abschnitt wie diesen enthalten:
+
+```
+Can connect to tideways-daemon? => Yes, version 1.15.2
 ```
 
 Prüfe als Nächstes, ob der Daemon läuft und Verbindungen annimmt:

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
@@ -192,7 +192,9 @@ Dein API-Key ist ein Zugangsschlüssel. Jede Person mit Dateisystemzugriff auf d
 
 Änderungen an Dateien in `~/.config/php/php.d` werden automatisch erkannt, und der PHP-FPM-Dienst wird für dich neu gestartet. Du musst nichts manuell neu starten.
 
-Die Konfiguration gilt für das gesamte Projekt, es melden also alle darin enthaltenen PHP-Apps an Tideways. Das Laden einer PHP-Extension ist eine systemweite Einstellung und kann deshalb nicht in einer verzeichnisbezogenen `.user.ini`-Datei erfolgen.
+Die Konfiguration gilt für das gesamte Projekt, es melden also alle darin enthaltenen PHP-Apps an Tideways. Das schließt PHP auf der Kommandozeile mit ein: Cronjobs, Queue-Worker und Console-Commands werden ohne zusätzliche Konfiguration ebenfalls profiliert.
+
+Das Laden einer PHP-Extension ist eine systemweite Einstellung und kann deshalb nicht in einer verzeichnisbezogenen `.user.ini`-Datei erfolgen.
 
 :::
 
@@ -238,10 +240,6 @@ Nachdem du sie installiert und dich mit deinem Tideways-Account angemeldet hast,
 - Vergewissere dich, dass deine App eine PHP-Version verwendet, die die Extension enthält (siehe [Voraussetzungen](#prerequisites)).
 - Stelle sicher, dass die Konfigurationsdatei in `~/.config/php/php.d/` liegt und die Endung `.ini` hat. `extension=tideways.so` hat in einer verzeichnisbezogenen `.user.ini`-Datei keine Wirkung.
 - Prüfe das PHP-Error-Log deiner App unter `/var/log/php_errors.log` auf Meldungen über eine fehlgeschlagene Extension-Ladung.
-
-### Für CLI-Skripte und Cronjobs fehlen Traces {#troubleshooting-cli}
-
-Das Standardverhalten der Extension unterscheidet sich zwischen Web-Requests und CLI-Skripten. Wenn du Cronjobs, Queue-Worker oder Console-Commands überwachen möchtest, wirf einen Blick in die [Tideways-Dokumentation zu Background-Jobs und CLI-Monitoring](https://support.tideways.com/documentation/).
 
 ### Profiling einer containerisierten PHP-Anwendung {#troubleshooting-containers}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
@@ -230,14 +230,14 @@ Nachdem du sie installiert und dich mit deinem Tideways-Account angemeldet hast,
 
 - Prüfe, ob der Daemon-Container läuft und Port `9135` veröffentlicht ist. Ohne veröffentlichten Port ist der Container aus deiner App nicht erreichbar.
 - Prüfe, ob `tideways.connection` den internen DNS-Namen des Containers verwendet und nicht dessen Anzeigenamen oder Container-ID. Den DNS-Namen findest du im mStudio UI oder über `mw container list`.
-- Sieh dir die Daemon-Logs mit `mw container logs tideways-daemon` auf Verbindungs- oder Authentifizierungsfehler an.
+- Sieh dir das PHP-Error-Log unter `/var/log/php_errors.log` und die Daemon-Logs mit `mw container logs tideways-daemon` auf Verbindungs- oder Authentifizierungsfehler an.
 - Stelle sicher, dass der API-Key zu dem Tideways-Projekt gehört, das du dir gerade ansiehst.
 
 ### Die Extension wird nicht geladen {#troubleshooting-extension}
 
 - Vergewissere dich, dass deine App eine PHP-Version verwendet, die die Extension enthält (siehe [Voraussetzungen](#prerequisites)).
 - Stelle sicher, dass die Konfigurationsdatei in `~/.config/php/php.d/` liegt und die Endung `.ini` hat. `extension=tideways.so` hat in einer verzeichnisbezogenen `.user.ini`-Datei keine Wirkung.
-- Prüfe das PHP-Error-Log deiner App auf Meldungen über eine fehlgeschlagene Extension-Ladung.
+- Prüfe das PHP-Error-Log deiner App unter `/var/log/php_errors.log` auf Meldungen über eine fehlgeschlagene Extension-Ladung.
 
 ### Für CLI-Skripte und Cronjobs fehlen Traces {#troubleshooting-cli}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/operations/tideways-profiling.md
@@ -1,0 +1,257 @@
+---
+title: PHP-Anwendungen mit Tideways profilen
+sidebar_label: Tideways-Profiling
+tags:
+  - PHP
+  - Containers
+description: |
+  Erfahre, wie du deine PHP-Anwendungen mit Tideways profilst und überwachst – mit der mitgelieferten PHP-Extension und einem containerisierten Tideways-Daemon.
+---
+
+[Tideways](https://tideways.com/) ist ein kommerzieller Dienst für Application Performance Monitoring (APM) und Profiling von PHP-Anwendungen. Tideways zeichnet kontinuierlich auf, wie lange deine Requests dauern, wo diese Zeit verbraucht wird und welche Fehler auftreten — bis hinunter zu einzelnen Funktionsaufrufen und Datenbankabfragen.
+
+Tideways besteht aus drei Bestandteilen:
+
+1. Einer **PHP-Extension**, die deine Anwendung instrumentiert und Traces sammelt. Diese Extension ist in den PHP-Builds von mittwald bereits enthalten und muss nur noch aktiviert werden.
+2. Dem **Tideways-Daemon**, einem kleinen Hintergrunddienst, der die gesammelten Traces puffert und an das Tideways-Backend weiterleitet. Diesen betreibst du selbst, als Container in deinem Projekt.
+3. Dem **Tideways-Backend** unter [app.tideways.io](https://app.tideways.io/), in dem du die gesammelten Daten auswertest.
+
+Diese Anleitung zeigt dir, wie du die Extension aktivierst und den Daemon auf der mittwald-Plattform betreibst.
+
+## Voraussetzungen {#prerequisites}
+
+Für diese Anleitung benötigst du:
+
+- Zugriff auf ein mittwald mStudio-Projekt mit einer [PHP-App](/docs/v2/platform/workloads/php) (oder einem [PHP-Worker](/docs/v2/platform/workloads/php-worker))
+- Ein Hosting-Produkt, das [Container-Workloads](/docs/v2/platform/workloads/containers) unterstützt, da der Tideways-Daemon als Container läuft
+- Einen [Tideways-Account](https://tideways.com/) und den API-Key eines Tideways-Projekts (diesen findest du in der Tideways-Oberfläche in den Projekteinstellungen)
+- Eine der folgenden PHP-Versionen — das sind die ersten mittwald-Builds, die die Tideways-Extension mitbringen:
+  - PHP 8.3.33 oder neuer
+  - PHP 8.4.24 oder neuer
+  - PHP 8.5.9 oder neuer
+
+Die PHP-Version deiner App kannst du im mStudio UI nachsehen oder über die CLI:
+
+```shellsession title="Lokale Shell-Sitzung"
+user@local $ mw app get <app-id>
+```
+
+Falls deine App noch eine ältere PHP-Version verwendet, aktualisiere sie, bevor du fortfährst:
+
+```shellsession title="Lokale Shell-Sitzung"
+user@local $ mw app dependency update <app-id> --set php=~8.4
+```
+
+Weitere Informationen zur Verwaltung der PHP-Version findest du unter [PHP-Anwendungen verwalten und deployen](/docs/v2/platform/workloads/php#auto-updates).
+
+## Schritt 1: Den Tideways-Daemon betreiben {#daemon}
+
+Die PHP-Extension kommuniziert nicht direkt mit dem Tideways-Backend. Stattdessen schickt sie ihre Daten über eine TCP-Verbindung an den Tideways-Daemon, der sich um Pufferung und Übertragung kümmert. Du benötigst daher genau einen Daemon-Container pro Projekt, den sich alle deine PHP-Apps teilen können.
+
+Für diesen Container verwenden wir das Image `ghcr.io/tideways/daemon:latest` aus der [GitHub Container Registry](https://github.com/tideways/daemon/pkgs/container/daemon). Der Daemon lauscht auf dem TCP-Port `9135` und benötigt keinen persistenten Speicher, es sind also keine Volumes erforderlich.
+
+:::note
+
+Der Daemon benötigt deinen API-Key **nicht**. Der Key wird auf PHP-Seite konfiguriert und mit jedem Trace mitgeschickt — deshalb kann ein einzelner Daemon auch mehrere Tideways-Projekte bedienen.
+
+:::
+
+### Über das mStudio UI {#daemon-ui}
+
+Gehe in mStudio zu deinem Projekt, wähle **„Container"** und klicke auf **„Container erstellen"**. Ein geführter Dialog öffnet sich, um dir beim Container-Setup zu helfen.
+
+Gib zunächst eine Beschreibung ein — dies ist ein Freitextfeld zur Identifizierung des Containers. Gib zum Beispiel **„Tideways-Daemon"** ein und klicke auf **„Weiter"**.
+
+Als Nächstes wirst du nach dem Image-Namen gefragt. Gib `ghcr.io/tideways/daemon:latest` ein und bestätige mit **„Weiter"**.
+
+#### Entrypoint und Command {#daemon-ui-command}
+
+- **Entrypoint:** Keine Änderungen erforderlich
+- **Command:** Für ein Standard-Setup keine Änderungen erforderlich. Um zu steuern, wie sich der Daemon in der Tideways-Oberfläche registriert, kannst du `--env=production --hostname=tideways-daemon` angeben (siehe [Daemon-Optionen](#daemon-options) weiter unten).
+
+#### Volumes {#daemon-ui-volumes}
+
+Es sind keine Volumes erforderlich. Der Daemon puffert die Daten nur im Arbeitsspeicher und leitet sie weiter.
+
+#### Umgebungsvariablen {#daemon-ui-env}
+
+Es sind keine Umgebungsvariablen erforderlich.
+
+Am Ende des Dialogs wirst du nach dem **Port** gefragt. Gib `9135` ein, damit der Daemon für die übrigen Workloads in deinem Projekt erreichbar wird. Klicke auf **„Container erstellen"**, um den Container zu erstellen und zu starten.
+
+:::note
+
+Merke dir den internen DNS-Namen des Containers, der nach der Erstellung in mStudio angezeigt wird. Er leitet sich vom Container-Namen ab — ein Container namens `Tideways-Daemon` erhält den DNS-Namen `tideways-daemon`. Du benötigst diesen Namen in [Schritt 2](#php-config).
+
+:::
+
+### Alternative: Verwendung des `mw container run`-Befehls {#daemon-cli-run}
+
+Du kannst den Daemon-Container auch direkt über die Kommandozeile erstellen und starten:
+
+```shellsession title="Lokale Shell-Sitzung"
+user@local $ mw container run \
+  --name tideways-daemon \
+  --description "Tideways-Daemon" \
+  --publish 9135:9135 \
+  ghcr.io/tideways/daemon:latest
+```
+
+Das `--name`-Flag bestimmt den internen DNS-Namen, unter dem der Daemon aus deinen Apps erreichbar ist.
+
+Um Optionen an den Daemon selbst zu übergeben, hängst du sie hinter dem Image-Namen an. Da diese Optionen wie CLI-Flags aussehen, trennst du sie mit einem `--` von den `mw`-Flags:
+
+```shellsession title="Lokale Shell-Sitzung"
+user@local $ mw container run \
+  --name tideways-daemon \
+  --description "Tideways-Daemon" \
+  --publish 9135:9135 \
+  -- ghcr.io/tideways/daemon:latest --env=production --hostname=tideways-daemon
+```
+
+### Alternative: Verwendung des `mw stack deploy`-Befehls {#daemon-cli-stack}
+
+Alternativ kannst du den Befehl `mw stack deploy` verwenden, der mit Docker Compose kompatibel ist. Erstelle dazu eine `docker-compose.yml`-Datei mit folgendem Inhalt:
+
+```yaml
+services:
+  tideways-daemon:
+    image: ghcr.io/tideways/daemon:latest
+    command: "--env=production --hostname=tideways-daemon"
+    ports:
+      - "9135:9135/tcp"
+```
+
+Deploye sie anschließend:
+
+```shellsession title="Lokale Shell-Sitzung"
+user@local $ mw stack deploy
+```
+
+Dieser Befehl liest die `docker-compose.yml`-Datei aus dem aktuellen Verzeichnis und deployt sie in deinen Standard-Stack.
+
+### Daemon-Optionen {#daemon-options}
+
+Der Daemon läuft mit seinen Standardeinstellungen problemlos, zwei Optionen solltest du aber explizit setzen:
+
+- `--env=<name>` legt den Namen der Umgebung fest, unter der Traces gemeldet werden, zum Beispiel `production` oder `staging`. Der Standardwert ist `production`.
+- `--hostname=<name>` legt den Servernamen fest, unter dem sich der Daemon in der Tideways-Oberfläche registriert. In Containern hängt der Daemon standardmäßig die Container-ID an den ermittelten Hostnamen an — dadurch erscheint jede Neuerstellung des Containers als neuer Server. Ein fester Hostname vermeidet das.
+
+Alle verfügbaren Optionen sind in der [Konfigurationsreferenz des Daemons](https://support.tideways.com/documentation/reference/daemon/configuration-reference.html) dokumentiert.
+
+:::note
+
+Das Veröffentlichen von Port `9135` macht den Daemon ausschließlich _innerhalb_ deiner Hosting-Umgebung erreichbar, also für andere Container und Managed Apps im selben Projekt. Er ist nicht aus dem Internet erreichbar, und die Netzwerk-Policies der Plattform verhindern Zugriffe aus anderen Projekten.
+
+:::
+
+## Schritt 2: Die PHP-Extension konfigurieren {#php-config}
+
+Die Tideways-Extension ist Bestandteil der PHP-Installation deiner App, ist aber standardmäßig deaktiviert. Um sie zu aktivieren und zu konfigurieren, legst du eine neue Konfigurationsdatei im PHP-Konfigurationsverzeichnis deines Projekts an. Verbinde dich dazu per SSH mit deiner App:
+
+```shellsession title="Lokale Shell-Sitzung"
+user@local $ mw app ssh <app-id>
+```
+
+Erstelle dann die Datei `~/.config/php/php.d/20-tideways.ini` mit folgendem Inhalt:
+
+```ini title="~/.config/php/php.d/20-tideways.ini"
+extension=tideways.so
+
+; Der API-Key deines Tideways-Projekts
+tideways.api_key=YOUR_API_KEY
+
+; Interner DNS-Name und Port deines Daemon-Containers
+tideways.connection=tcp://tideways-daemon:9135
+
+; Gruppiert die gesammelten Daten innerhalb deines Tideways-Projekts
+tideways.service=web
+
+; Prozentsatz der Requests, die mit dem Timeline-Profiler aufgezeichnet werden
+tideways.trace_sample_rate=25
+```
+
+Ersetze `YOUR_API_KEY` durch den API-Key deines Tideways-Projekts und `tideways-daemon` durch den internen DNS-Namen des Containers aus [Schritt 1](#daemon).
+
+Die Einstellungen haben folgende Bedeutung:
+
+- `tideways.api_key` (**erforderlich**) authentifiziert deine Traces gegenüber deinem Tideways-Projekt.
+- `tideways.connection` (in diesem Setup **erforderlich**) verweist die Extension auf deinen Daemon. Ohne diese Einstellung sucht die Extension einen Daemon auf einem lokalen Unix-Socket, den es auf der mittwald-Plattform nicht gibt.
+- `tideways.service` gruppiert die Monitoring-Daten in voneinander unabhängige Einheiten innerhalb eines Projekts, jeweils mit eigenen Performance- und Fehlerstatistiken. Damit kannst du zum Beispiel Webfrontend, API und Hintergrund-Worker voneinander trennen. Der Standardwert ist `app`.
+- `tideways.trace_sample_rate` steuert, wie viel Prozent der Requests mit dem vollständigen Timeline-Profiler aufgezeichnet werden. Der Standardwert ist `25`. Alle übrigen Requests werden weiterhin vom Performance- und Fehler-Monitoring erfasst.
+
+Die vollständige Liste der Einstellungen findest du in der [Tideways-Konfigurationsdokumentation](https://support.tideways.com/documentation/setup/configuration/configure-tideways-globally-via-php-ini.html).
+
+:::caution
+
+Dein API-Key ist ein Zugangsschlüssel. Jede Person mit Dateisystemzugriff auf dein Projekt kann ihn aus dieser Datei auslesen. Checke `20-tideways.ini` daher nicht in die Versionsverwaltung ein und kopiere die Datei nicht in öffentlich lesbare Verzeichnisse.
+
+:::
+
+:::note
+
+Änderungen an Dateien in `~/.config/php/php.d` werden automatisch erkannt, und der PHP-FPM-Dienst wird für dich neu gestartet. Du musst nichts manuell neu starten.
+
+Die Konfiguration gilt für das gesamte Projekt, es melden also alle darin enthaltenen PHP-Apps an Tideways. Das Laden einer PHP-Extension ist eine systemweite Einstellung und kann deshalb nicht in einer verzeichnisbezogenen `.user.ini`-Datei erfolgen.
+
+:::
+
+## Schritt 3: Das Setup überprüfen {#verification}
+
+Prüfe zunächst, ob die Extension geladen ist. Führe dazu in einer SSH-Sitzung auf deiner App aus:
+
+```shellsession title="SSH-Sitzung"
+user@ssh $ php -m | grep -i tideways
+```
+
+Die Ausgabe sollte `tideways` enthalten. Um zusätzlich zu prüfen, ob deine Einstellungen übernommen wurden, führe aus:
+
+```shellsession title="SSH-Sitzung"
+user@ssh $ php -i | grep tideways
+```
+
+Prüfe als Nächstes, ob der Daemon läuft und Verbindungen annimmt:
+
+```shellsession title="Lokale Shell-Sitzung"
+user@local $ mw container logs tideways-daemon
+```
+
+Schicke abschließend etwas Traffic auf deine Anwendung und öffne dein Projekt unter [app.tideways.io](https://app.tideways.io/). Die ersten Datenpunkte erscheinen üblicherweise innerhalb weniger Minuten.
+
+## Gezieltes Profiling mit der Browser-Extension {#browser-extension}
+
+Sampling deckt deinen durchschnittlichen Traffic ab, manchmal möchtest du aber einen vollständigen Trace eines bestimmten Seitenaufrufs. Mit der [Tideways-Browser-Extension](https://support.tideways.com/documentation/reference/browser-extension/chrome-extension.html) kannst du das direkt aus dem Browser auslösen: Sie setzt ein signiertes `TIDEWAYS_SESSION`-Cookie, das die PHP-Extension anweist, für deine eigenen Requests einen vollständigen Timeline- und Callgraph-Trace aufzuzeichnen.
+
+Nachdem du sie installiert und dich mit deinem Tideways-Account angemeldet hast, klickst du auf das Tideways-Icon und wählst **„Take Profile"**, um die aktuelle Seite mit aktiviertem Profiling neu zu laden, oder **„Profile for 15 seconds"**, um eine Abfolge von Interaktionen wie ein Formular-Submit oder mehrere AJAX-Calls aufzuzeichnen.
+
+## Fehlerbehebung {#troubleshooting}
+
+### In Tideways erscheinen keine Daten {#troubleshooting-no-data}
+
+- Prüfe, ob der Daemon-Container läuft und Port `9135` veröffentlicht ist. Ohne veröffentlichten Port ist der Container aus deiner App nicht erreichbar.
+- Prüfe, ob `tideways.connection` den internen DNS-Namen des Containers verwendet und nicht dessen Anzeigenamen oder Container-ID. Den DNS-Namen findest du im mStudio UI oder über `mw container list`.
+- Sieh dir die Daemon-Logs mit `mw container logs tideways-daemon` auf Verbindungs- oder Authentifizierungsfehler an.
+- Stelle sicher, dass der API-Key zu dem Tideways-Projekt gehört, das du dir gerade ansiehst.
+
+### Die Extension wird nicht geladen {#troubleshooting-extension}
+
+- Vergewissere dich, dass deine App eine PHP-Version verwendet, die die Extension enthält (siehe [Voraussetzungen](#prerequisites)).
+- Stelle sicher, dass die Konfigurationsdatei in `~/.config/php/php.d/` liegt und die Endung `.ini` hat. `extension=tideways.so` hat in einer verzeichnisbezogenen `.user.ini`-Datei keine Wirkung.
+- Prüfe das PHP-Error-Log deiner App auf Meldungen über eine fehlgeschlagene Extension-Ladung.
+
+### Für CLI-Skripte und Cronjobs fehlen Traces {#troubleshooting-cli}
+
+Das Standardverhalten der Extension unterscheidet sich zwischen Web-Requests und CLI-Skripten. Wenn du Cronjobs, Queue-Worker oder Console-Commands überwachen möchtest, wirf einen Blick in die [Tideways-Dokumentation zu Background-Jobs und CLI-Monitoring](https://support.tideways.com/documentation/).
+
+### Profiling einer containerisierten PHP-Anwendung {#troubleshooting-containers}
+
+Diese Anleitung behandelt Managed PHP-Apps, bei denen mittwald den PHP-Build inklusive Tideways-Extension bereitstellt. Wenn du PHP stattdessen in einem eigenen Container betreibst, musst du die Extension selbst in dein Image installieren — folge dazu der [Docker-Installationsanleitung von Tideways](https://support.tideways.com/documentation/setup/installation/docker-with-compose.html). Das Daemon-Setup aus [Schritt 1](#daemon) bleibt unverändert.
+
+## Weiterführende Ressourcen {#further-resources}
+
+- [Tideways-Dokumentation](https://support.tideways.com/documentation/)
+- [Tideways über die php.ini konfigurieren](https://support.tideways.com/documentation/setup/configuration/configure-tideways-globally-via-php-ini.html)
+- [Konfigurationsreferenz des Tideways-Daemons](https://support.tideways.com/documentation/reference/daemon/configuration-reference.html)
+- [Tideways-Browser-Extension](https://support.tideways.com/documentation/reference/browser-extension/chrome-extension.html)
+- [PHP-Anwendungen verwalten und deployen](/docs/v2/platform/workloads/php)
+- [Containerisierte Anwendungen verwalten und deployen](/docs/v2/platform/workloads/containers)


### PR DESCRIPTION
Adds a guide on setting up [Tideways](https://tideways.com/) profiling for PHP applications on the mittwald platform, in English and German.

The guide covers:

- **Prerequisites** — including the PHP versions that are the first mittwald builds to ship the Tideways extension (8.3.33, 8.4.24, 8.5.9), and how to check/update an app's PHP version.
- **Running the Tideways daemon** as a container, documented via the mStudio UI, `mw container run` and `mw stack deploy`. Includes the `--env` / `--hostname` daemon options and why a fixed hostname matters in containers, plus a note that publishing port 9135 keeps the daemon reachable only within the hosting environment.
- **Configuring the PHP extension** via `~/.config/php/php.d/20-tideways.ini`, with an explanation of `tideways.api_key`, `tideways.connection`, `tideways.service` and `tideways.trace_sample_rate`, and a caution about the API key being a credential.
- **Verifying the setup** and profiling on demand with the Tideways browser extension.
- **Troubleshooting**, including the case of running PHP in your own container rather than as a managed app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBg695xrs4TeqDqvRYeHZZ