### PR TITLE
docs(aihosting): document 10-minute Whisper audio duration limit

### DIFF
--- a/docs/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
+++ b/docs/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
@@ -14,11 +14,25 @@ The [Speech-to-text guide](../../examples/whisper/) has runnable examples for ba
 The following limitations apply to this model on our platform:
 
 - Maximum file size: 25 MB per upload
-- No explicit context length limit – depends on audio duration and file size
+- Maximum audio duration: 10 minutes (600 seconds) per request
 - Translation is currently not supported (`to_language`)
 - Supported output formats: **`json`**, **`verbose_json`**
   - `response_format="text"` is accepted but returns a JSON body regardless — use `"json"` instead
   - `srt` and `vtt` are not supported (HTTP 400)
+
+### Audio duration and file size {#duration-limit}
+
+:::warning Both limits apply independently
+A file well below 25 MB can still be rejected for being too long. At typical speech bitrates the duration limit is the one you hit first: 25 MB holds roughly 52 minutes of 64 kbps mono audio, but everything beyond 10 minutes is rejected.
+
+Exceeding the duration returns HTTP 400:
+
+```text
+Audio exceeds maximum allowed duration of 600s (file contains 1500.6s at 44100Hz).
+```
+
+Split longer recordings before uploading. The [speech-to-text guide](../../examples/whisper/#large-files) contains a ready-to-use `pydub` example that cuts at silence points and keeps every chunk under both limits.
+:::
 
 ### Supported Input Formats
 

--- a/docs/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
+++ b/docs/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
@@ -228,7 +228,7 @@ curl -X POST https://llm.aihosting.mittwald.de/v1/audio/transcriptions \
     -F "model=whisper-large-v3-turbo"
 ```
 
-The `file` parameter should contain the audio file to be transcribed. Supported formats include MP3, OGG, WAV, and FLAC. Maximum file size is 25 MB. The `model` parameter specifies which Whisper model to use for transcription.
+The `file` parameter should contain the audio file to be transcribed. Supported formats include MP3, OGG, WAV, and FLAC. Maximum file size is 25 MB and maximum audio duration is 10 minutes (600 seconds); both limits apply independently. The `model` parameter specifies which Whisper model to use for transcription.
 
 Additional optional parameters can be provided:
 
@@ -250,4 +250,4 @@ curl -X POST https://llm.aihosting.mittwald.de/v1/audio/transcriptions \
 
 - Translation functionality (`to_language` parameter) is not supported
 - For best results, always specify the `language` parameter explicitly
-- Segment large audio files into chunks smaller than 25 MB if needed
+- Segment audio files into chunks smaller than 25 MB and shorter than 10 minutes if needed. Exceeding the duration returns HTTP 400 with `Audio exceeds maximum allowed duration of 600s`. See the [speech-to-text guide](../../examples/whisper/#large-files) for a chunking example

--- a/docs/platform/aihosting/50-examples/10-openwebui.mdx
+++ b/docs/platform/aihosting/50-examples/10-openwebui.mdx
@@ -100,7 +100,7 @@ To test the speech-to-text functionality:
 
 1. Click the microphone icon in a chat interface
 2. Speak in the configured language
-3. The transcription will use our `/v1/audio/transcriptions` endpoint with support for MP3, OGG, WAV, and FLAC formats (maximum 25 MB file size)
+3. The transcription will use our `/v1/audio/transcriptions` endpoint with support for MP3, OGG, WAV, and FLAC formats (maximum 25 MB file size and maximum 10 minutes audio duration)
 
 :::note
 Always set the language parameter explicitly for best accuracy, especially for non-German audio inputs.

--- a/docs/platform/aihosting/50-examples/90-whisper.mdx
+++ b/docs/platform/aihosting/50-examples/90-whisper.mdx
@@ -13,7 +13,7 @@ user@local $ pip install openai
 user@local $ export OPENAI_API_KEY="sk-…"
 ```
 
-For large-file chunking (files over 25 MB):
+For chunking long or large files (over 10 minutes or over 25 MB):
 
 ```shellsession
 user@local $ pip install pydub
@@ -68,18 +68,20 @@ for filename, lang in files_and_languages:
     print(f"[{lang}] {result.text[:120]}")
 ```
 
-## Large files (> 25 MB) {#large-files}
+## Long or large files (> 10 minutes or > 25 MB) {#large-files}
 
-The API accepts files up to 25 MB. Split larger recordings at silence points using `pydub` so that each chunk is well under the limit and no words are cut mid-utterance:
+The API accepts files up to 25 MB and up to 10 minutes of audio. Both limits apply independently, and for speech recordings the duration limit is usually the binding one. Split longer recordings at silence points using `pydub` so that each chunk stays below both limits and no words are cut mid-utterance:
 
 ```python
 from pydub import AudioSegment
 from pydub.silence import split_on_silence
 from io import BytesIO
 
+MAX_CHUNK_MS = 9 * 60 * 1000   # Stay below the 10-minute duration limit
+
 
 def transcribe_large_file(path: str, language: str = "en") -> str:
-    """Transcribe a file of any size by splitting at silence points."""
+    """Transcribe a file of any size or length by splitting at silence points."""
     audio = AudioSegment.from_file(path)
 
     # Split at pauses longer than 700 ms with silence below -40 dBFS
@@ -95,8 +97,18 @@ def transcribe_large_file(path: str, language: str = "en") -> str:
         chunk_ms = 60_000
         chunks = [audio[i: i + chunk_ms] for i in range(0, len(audio), chunk_ms)]
 
-    transcripts: list[str] = []
+    # Guard: a passage without pauses can still exceed the 10-minute limit
+    bounded: list[AudioSegment] = []
     for chunk in chunks:
+        if len(chunk) <= MAX_CHUNK_MS:
+            bounded.append(chunk)
+        else:
+            bounded.extend(
+                chunk[i: i + MAX_CHUNK_MS] for i in range(0, len(chunk), MAX_CHUNK_MS)
+            )
+
+    transcripts: list[str] = []
+    for chunk in bounded:
         buf = BytesIO()
         chunk.export(buf, format="mp3")
         buf.seek(0)

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/50-whisper-large-v3-turbo.mdx
@@ -13,11 +13,25 @@ Der [Spracherkennungs-Guide](../../examples/whisper/) enthält lauffähige Beisp
 Die folgenden Einschränkungen gelten für dieses Modell bei unserer Plattform:
 
 - Maximale Dateigröße: 25 MB pro Upload
-- Keine explizite Kontextlängenbegrenzung – abhängig von Audiodauer und Dateigröße
+- Maximale Audiolänge: 10 Minuten (600 Sekunden) pro Anfrage
 - Es ist derzeit keine Übersetzung möglich (`to_language`)
 - Unterstützte Ausgabeformate: **`json`**, **`verbose_json`**
   - `response_format="text"` wird akzeptiert, gibt aber immer einen JSON-Body zurück – stattdessen `"json"` verwenden
   - `srt` und `vtt` werden nicht unterstützt (HTTP 400)
+
+### Audiolänge und Dateigröße {#duration-limit}
+
+:::warning Beide Limits gelten unabhängig voneinander
+Eine Datei kann deutlich unter 25 MB liegen und trotzdem wegen ihrer Länge abgelehnt werden. Bei üblichen Sprach-Bitraten greift das Längenlimit zuerst: In 25 MB passen rund 52 Minuten Audio bei 64 kbps mono, akzeptiert wird davon aber nur, was 10 Minuten nicht überschreitet.
+
+Wird die Länge überschritten, kommt HTTP 400 zurück:
+
+```text
+Audio exceeds maximum allowed duration of 600s (file contains 1500.6s at 44100Hz).
+```
+
+Längere Aufnahmen vor dem Upload aufteilen. Der [Spracherkennungs-Guide](../../examples/whisper/#grosse-dateien) enthält ein fertiges `pydub`-Beispiel, das an Stille-Stellen schneidet und jeden Abschnitt unter beiden Limits hält.
+:::
 
 ### Unterstützte Eingabeformate
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
@@ -228,7 +228,7 @@ curl -X POST https://llm.aihosting.mittwald.de/v1/audio/transcriptions \
     -F "model=whisper-large-v3-turbo"
 ```
 
-Der `file`-Parameter sollte die zu transkribierende Audiodatei enthalten. Unterstützte Formate sind MP3, OGG, WAV und FLAC. Die maximale Dateigröße beträgt 25 MB. Der `model`-Parameter gibt an, welches Whisper-Modell für die Transkription verwendet werden soll.
+Der `file`-Parameter sollte die zu transkribierende Audiodatei enthalten. Unterstützte Formate sind MP3, OGG, WAV und FLAC. Die maximale Dateigröße beträgt 25 MB, die maximale Audiolänge 10 Minuten (600 Sekunden). Beide Limits gelten unabhängig voneinander. Der `model`-Parameter gibt an, welches Whisper-Modell für die Transkription verwendet werden soll.
 
 Zusätzlich können folgende optionale Parameter übermittelt werden:
 
@@ -250,4 +250,4 @@ curl -X POST https://llm.aihosting.mittwald.de/v1/audio/transcriptions \
 
 - Übersetzungsfunktion (`to_language`-Parameter) wird nicht unterstützt
 - Für beste Ergebnisse sollte der `language`-Parameter immer explizit angegeben werden
-- Segmentiere große Audiodateien bei Bedarf in Teile kleiner als 25 MB
+- Segmentiere Audiodateien bei Bedarf in Teile kleiner als 25 MB und kürzer als 10 Minuten. Wird die Länge überschritten, kommt HTTP 400 mit `Audio exceeds maximum allowed duration of 600s` zurück. Ein Beispiel dazu im [Spracherkennungs-Guide](../../examples/whisper/#grosse-dateien)

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/10-openwebui.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/10-openwebui.mdx
@@ -100,7 +100,7 @@ Um die Speech-to-Text-Funktionalität zu testen:
 
 1. Klicke auf das Mikrofon-Symbol in einer Chat-Oberfläche
 2. Sprich in der konfigurierten Sprache
-3. Die Transkription verwendet unseren `/v1/audio/transcriptions`-Endpunkt mit Unterstützung für MP3-, OGG-, WAV- und FLAC-Formate (maximale Dateigröße 25 MB)
+3. Die Transkription verwendet unseren `/v1/audio/transcriptions`-Endpunkt mit Unterstützung für MP3-, OGG-, WAV- und FLAC-Formate (maximale Dateigröße 25 MB, maximale Audiolänge 10 Minuten)
 
 :::note
 Setze den Sprachparameter immer explizit für beste Genauigkeit, insbesondere für nicht-deutsche Audioeingaben.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/90-whisper.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/90-whisper.mdx
@@ -13,7 +13,7 @@ user@local $ pip install openai
 user@local $ export OPENAI_API_KEY="sk-…"
 ```
 
-Für das Aufteilen großer Dateien (über 25 MB):
+Für das Aufteilen langer oder großer Dateien (über 10 Minuten oder über 25 MB):
 
 ```shellsession
 user@local $ pip install pydub
@@ -68,18 +68,20 @@ for dateiname, sprache in dateien_und_sprachen:
     print(f"[{sprache}] {result.text[:120]}")
 ```
 
-## Große Dateien (> 25 MB) {#grosse-dateien}
+## Lange oder große Dateien (> 10 Minuten oder > 25 MB) {#grosse-dateien}
 
-Die API akzeptiert Dateien bis zu 25 MB. Größere Aufnahmen mit `pydub` an Stille-Stellen aufteilen, damit jeder Abschnitt sicher unter dem Limit bleibt und keine Wörter mittendrin geschnitten werden:
+Die API akzeptiert Dateien bis zu 25 MB und bis zu 10 Minuten Audio. Beide Limits gelten unabhängig voneinander, bei Sprachaufnahmen greift üblicherweise das Längenlimit zuerst. Längere Aufnahmen mit `pydub` an Stille-Stellen aufteilen, damit jeder Abschnitt unter beiden Limits bleibt und keine Wörter mittendrin geschnitten werden:
 
 ```python
 from pydub import AudioSegment
 from pydub.silence import split_on_silence
 from io import BytesIO
 
+MAX_CHUNK_MS = 9 * 60 * 1000   # Unter dem 10-Minuten-Limit bleiben
+
 
 def grosse_datei_transkribieren(path: str, language: str = "de") -> str:
-    """Datei beliebiger Größe transkribieren durch Aufteilen an Stille-Stellen."""
+    """Datei beliebiger Größe und Länge transkribieren durch Aufteilen an Stille-Stellen."""
     audio = AudioSegment.from_file(path)
 
     # An Pausen von mehr als 700 ms mit Stille unter -40 dBFS aufteilen
@@ -95,8 +97,18 @@ def grosse_datei_transkribieren(path: str, language: str = "de") -> str:
         chunk_ms = 60_000
         chunks = [audio[i: i + chunk_ms] for i in range(0, len(audio), chunk_ms)]
 
-    transkripte: list[str] = []
+    # Fallback: eine Passage ohne Pausen kann das 10-Minuten-Limit weiterhin überschreiten
+    begrenzt: list[AudioSegment] = []
     for chunk in chunks:
+        if len(chunk) <= MAX_CHUNK_MS:
+            begrenzt.append(chunk)
+        else:
+            begrenzt.extend(
+                chunk[i: i + MAX_CHUNK_MS] for i in range(0, len(chunk), MAX_CHUNK_MS)
+            )
+
+    transkripte: list[str] = []
+    for chunk in begrenzt:
         buf = BytesIO()
         chunk.export(buf, format="mp3")
         buf.seek(0)


### PR DESCRIPTION
Only the 25 MB file size limit was documented for `whisper-large-v3-turbo`. Audio longer than 600s is rejected with HTTP 400, and at typical speech bitrates that limit binds first (25 MB holds ~52 minutes of 64 kbps mono).

Documents both limits as independent in EN and DE, and bounds the chunking example so a pause-free passage cannot exceed 600s.