### PR TITLE
Fix/local dev server

### DIFF
--- a/docs/contribution/40-how-to/5-local-development.mdx
+++ b/docs/contribution/40-how-to/5-local-development.mdx
@@ -85,22 +85,11 @@ If you want to test the authentication and execution of domain actions per OAuth
 This can either be the localhost or a domain with an entry to your local host configuration.
 You should ensure that no public domain is used as an entry to your local host configuration that is not in your control to mitigate security risk.
 
-## Testing Lifecycle Webhooks {#testing-lifecycle-webhooks}
+## Making Your Local Extension Reachable {#making-your-local-extension-reachable}
 
 Lifecycle webhooks are always sent by the mStudio backend to the webhook URL configured for your Extension.
 There is currently **no way to receive real lifecycle webhooks without making your locally running Extension publicly reachable**.
-Both methods described below therefore require a tunnel from the public internet to your machine.
-
-:::note Do you need to test the webhook handling itself?
-The technical side of lifecycle webhooks — accepting the call, verifying the signature, parsing the payload, and dispatching it to the right handler — is generic plumbing that you do not have to build yourself, and therefore do not have to test yourself.
-Libraries such as [`@weissaufschwarz/mitthooks`](https://www.npmjs.com/package/@weissaufschwarz/mitthooks), which is also used by the [Reference Extension](../../getting-started/reference-extension), cover all of it.
-
-What is left is your **domain logic**: what your Extension does when an Extension Instance is added, updated, or removed.
-That is ordinary application code, and you can test it locally in isolation — no tunnel and no mStudio required.
-Use the methods below to verify the integration as a whole.
-:::
-
-### Making Your Local Extension Reachable {#making-your-local-extension-reachable}
+A tunnel from the public internet to your machine is therefore part of every local setup that involves webhooks.
 
 In principle, **any tunneling technique** works.
 If you already use [ngrok](https://ngrok.com/) or [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/), keep using them.
@@ -121,6 +110,20 @@ You can do this in the "Webhooks" tab of your Extension in the mStudio, or progr
 :::info
 For a step-by-step walkthrough of this setup, and to see how it fits into a complete Extension,
 see [Expose Extension](../../getting-started/expose-extension) in the getting started guide.
+:::
+
+## Testing Lifecycle Webhooks {#testing-lifecycle-webhooks}
+
+Both methods described below deliver webhooks to the configured webhook URL of your Extension,
+so they require your local Extension to be reachable as described in [making your local Extension reachable](#making-your-local-extension-reachable).
+
+:::note Do you need to test the webhook handling itself?
+The technical side of lifecycle webhooks — accepting the call, verifying the signature, parsing the payload, and dispatching it to the right handler — is generic plumbing that you do not have to build yourself, and therefore do not have to test yourself.
+Libraries such as [`@weissaufschwarz/mitthooks`](https://www.npmjs.com/package/@weissaufschwarz/mitthooks), which is also used by the [Reference Extension](../../getting-started/reference-extension), cover all of it.
+
+What is left is your **domain logic**: what your Extension does when an Extension Instance is added, updated, or removed.
+That is ordinary application code, and you can test it locally in isolation — no tunnel and no mStudio required.
+Use the methods below to verify the integration as a whole.
 :::
 
 ### ...via Dry Run Webhooks (recommended) {#via-dry-run-webhooks}
@@ -156,7 +159,7 @@ Installing your Extension is the most realistic test, because it triggers webhoo
 by adding your Extension to a context, changing its state, and removing it again.
 Each of these actions produces a genuine, signed webhook call.
 
-1. Make your local Extension reachable and configure the webhook URL, as described above.
+1. Make your local Extension reachable and configure the webhook URL, as described in [making your local Extension reachable](#making-your-local-extension-reachable).
 2. Create an Extension Instance, as described in [Creating an Extension Instance](#creating-an-extension-instance).
    This triggers the `ExtensionAddedToContext` webhook.
 3. Activate or deactivate the Extension Instance to trigger `InstanceUpdated` webhooks.

--- a/docs/contribution/40-how-to/5-local-development.mdx
+++ b/docs/contribution/40-how-to/5-local-development.mdx
@@ -10,7 +10,7 @@ This makes the local development of Extensions challenging if the Extension heav
 However, there are ways to assist the local Extension development besides mocking the mStudio API, which might be difficult without deep knowledge of the API.
 We will explore these in the rest of this page.
 
-## Creating an Extension Instance
+## Creating an Extension Instance {#creating-an-extension-instance}
 
 :::note
 A [Context](../../glossary/#extension-context) must be defined in order to create an Extension Instance.
@@ -85,36 +85,60 @@ If you want to test the authentication and execution of domain actions per OAuth
 This can either be the localhost or a domain with an entry to your local host configuration.
 You should ensure that no public domain is used as an entry to your local host configuration that is not in your control to mitigate security risk.
 
-## Testing Lifecycle Webhooks
+## Testing Lifecycle Webhooks {#testing-lifecycle-webhooks}
 
-### ...via the Local Development Server
+Lifecycle webhooks are always sent by the mStudio backend to the webhook URL configured for your Extension.
+There is currently **no way to receive real lifecycle webhooks without making your locally running Extension publicly reachable**.
+Both methods described below therefore require a tunnel from the public internet to your machine.
 
-You can use the GitHub repository [marketplace-local-dev-server](https://github.com/mittwald/marketplace-local-dev-server) to locally test lifecycle webhooks, including the verification of the sender identity.
+:::note Do you need to test the webhook handling itself?
+The technical side of lifecycle webhooks — accepting the call, verifying the signature, parsing the payload, and dispatching it to the right handler — is generic plumbing that you do not have to build yourself, and therefore do not have to test yourself.
+Libraries such as [`@weissaufschwarz/mitthooks`](https://www.npmjs.com/package/@weissaufschwarz/mitthooks), which is also used by the [Reference Extension](../../getting-started/reference-extension), cover all of it.
 
-:::note
-
-Currently, the marketplace and contributions are not public.
-To get access to the repository, please reach out to your contact at mittwald.
-
+What is left is your **domain logic**: what your Extension does when an Extension Instance is added, updated, or removed.
+That is ordinary application code, and you can test it locally in isolation — no tunnel and no mStudio required.
+Use the methods below to verify the integration as a whole.
 :::
 
-The repository contains a `docker-compose` configuration that starts a local server.
-This server can send lifecycle webhooks.
-For this, it provides an API you can use to request lifecycle webhooks.
-You can freely choose the values transmitted by the webhooks.
-If you don't set some values, the server randomly generates those values.
+### Making Your Local Extension Reachable {#making-your-local-extension-reachable}
 
-If, for example, you set the Extension Instance IDs of the requested lifecycle webhooks and use a consistent ID, you can simulate complete lifecycles of Extension Instances.
+In principle, **any tunneling technique** works.
+If you already use [ngrok](https://ngrok.com/) or [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/), keep using them.
+We recommend [zrok](https://zrok.io/) as a free open-source option, which can be used self-hosted or as a free SaaS solution.
 
-### ...via Dry Run Webhooks
+We recommend reserving a **stable URL** that survives a restart of the tunnel, so you do not have to reconfigure the webhook URL of your Extension on every restart.
+With the zrok SaaS solution, this comes down to three commands:
+
+```bash
+zrok enable <your-token>          # once per machine, token from myzrok.io
+zrok reserve public 3000          # once, reserves a stable URL for your local port
+zrok share reserved <share-token> # starts the tunnel
+```
+
+Afterwards, configure the resulting public URL plus your webhook path as the webhook URL of your Extension.
+You can do this in the "Webhooks" tab of your Extension in the mStudio, or programmatically via the <OperationLink operation="extension-patch-extension" /> operation.
+
+:::info
+For a step-by-step walkthrough of this setup, and to see how it fits into a complete Extension,
+see [Expose Extension](../../getting-started/expose-extension) in the getting started guide.
+:::
+
+### ...via Dry Run Webhooks (recommended) {#via-dry-run-webhooks}
 
 You can use the mStudio backend to simulate lifecycle webhooks by using the <OperationLink operation="extension-dry-run-webhook" /> operation.
 The mStudio will send the requested lifecycle webhook to the URL configured for the Extension.
 You can only execute dry-run webhooks for Extension Instances belonging to you, the contributor.
-Similarly to the local development server, you can specify values for the content of the lifecycle webhooks or let the mStudio backend generate random values.
+You can specify values for the content of the lifecycle webhooks or let the mStudio backend generate random values.
 For an overview of the values you can statically specify, see the linked operation.
 
 The mStudio returns the result of the executed webhook containing the response body, headers, and status code as a response to the dry-run webhook request.
+
+Dry-run webhooks are the most practical way to iterate during development:
+
+- You do not have to install and remove your Extension again for every attempt.
+- The mStudio executes dry-run webhooks **synchronously**, so you get the response of your webhook handler back immediately instead of having to check your local logs.
+- Because of that, you can send the same webhook repeatedly and in an order you choose.
+  Real lifecycle webhooks are delivered asynchronously, which gives you far less control over timing and repetition.
 
 :::caution
 The mStudio adds the parameter `dry-run=true` to the webhook to make it identifiable as a dry-run.
@@ -125,6 +149,23 @@ Processing such webhooks could lead to data inconsistencies since they are simul
 You can additionally process the `executing-user-id` parameter for documentation purposes.
 This parameter is additionally added to every dry-run webhook automatically.
 It contains the user ID of the user who requested the dry-run webhook.
+
+### ...by Installing Your Extension {#by-installing-your-extension}
+
+Installing your Extension is the most realistic test, because it triggers webhooks exactly the way your users will:
+by adding your Extension to a context, changing its state, and removing it again.
+Each of these actions produces a genuine, signed webhook call.
+
+1. Make your local Extension reachable and configure the webhook URL, as described above.
+2. Create an Extension Instance, as described in [Creating an Extension Instance](#creating-an-extension-instance).
+   This triggers the `ExtensionAddedToContext` webhook.
+3. Activate or deactivate the Extension Instance to trigger `InstanceUpdated` webhooks.
+4. Remove the Extension from the context to trigger the `InstanceRemovedFromContext` webhook.
+
+For the semantics of the individual webhooks, see [lifecycle webhooks](../../overview/concepts/lifecycle-webhooks).
+
+Because all Extension Instances within your contributor are free of charge, you can repeat this cycle as often as you like.
+Since the mStudio delivers these webhooks asynchronously, use this method to confirm the integration as a whole rather than to iterate on details.
 
 ## Testing Frontend Fragments
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/contribution/40-how-to/5-local-development.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/contribution/40-how-to/5-local-development.mdx
@@ -11,7 +11,7 @@ Neben der Möglichkeit, die mStudio API zu mocken, was sich ohne Kenntnisse der 
 existieren dennoch Mittel und Wege, um die lokale Entwicklung von Extensions zu erleichtern.
 Diese werden im Folgenden vorgestellt.
 
-## Erstellen einer Extension Instance
+## Erstellen einer Extension Instance {#creating-an-extension-instance}
 
 :::note
 Es muss bereits ein [Context](../../glossary/#extension-context) zugewiesen sein, bevor du eine Extension Instance erstellen kannst.
@@ -94,37 +94,64 @@ Dies kann entweder localhost oder eine Domain sein, für die ein lokaler Host-Ei
 Es sollte darauf geachtet werden, dass bei Verwendung eines Host-Eintrags keine potenziell öffentlich auflösbare Domain verwendet wird,
 die nicht unter der Kontrolle des Entwicklers steht, um Sicherheitsrisiken zu vermeiden.
 
-## Testen der Lifecycle Webhooks
+## Deine lokale Extension erreichbar machen {#making-your-local-extension-reachable}
 
-### ...mittels lokalem Development Server
+Lifecycle Webhooks werden immer vom mStudio Backend an die an der Extension konfigurierte Webhook-URL gesendet.
+Es gibt derzeit **keine Möglichkeit, echte Lifecycle Webhooks zu empfangen, ohne die lokal laufende Extension öffentlich erreichbar zu machen**.
+Ein Tunnel aus dem öffentlichen Internet auf deinen Rechner gehört daher zu jedem lokalen Setup, in dem Webhooks eine Rolle spielen.
 
-Auf Github existiert das [marketplace-local-dev-server](https://github.com/mittwald/marketplace-local-dev-server)-Repository,
-welches dafür gedacht ist, lokal Lifecycle Webhooks samt Verifizierung der Sender-Identität zu testen.
+Grundsätzlich funktioniert **jede Tunneling-Technik**.
+Wenn du bereits [ngrok](https://ngrok.com/) oder [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/) verwendest, bleib dabei.
+Wir empfehlen [zrok](https://zrok.io/) als kostenlose Open-Source-Option, die sowohl self-hosted als auch als SaaS-Lösung genutzt werden kann.
 
-:::note
+Wir empfehlen, eine **stabile URL** zu reservieren, die einen Neustart des Tunnels übersteht,
+damit du die Webhook-URL deiner Extension nicht bei jedem Neustart neu konfigurieren musst.
+Mit der zrok SaaS-Lösung sind das drei Befehle:
 
-Zum aktuellen Zeitpunkt ist der Marktplatz und die Contribution noch nicht für die Allgemeinheit offen.
-Um Zugriff auf das Repository zu erhalten, kontaktiere bitte deinen Ansprechpartner bei mittwald.
+```bash
+zrok enable <dein-token>          # einmal pro Rechner, Token von myzrok.io
+zrok reserve public 3000          # einmalig, reserviert eine stabile URL für deinen lokalen Port
+zrok share reserved <share-token> # startet den Tunnel
+```
 
+Anschließend konfigurierst du die entstandene öffentliche URL samt deines Webhook-Pfads als Webhook-URL deiner Extension.
+Das geht im Tab "Webhooks" deiner Extension im mStudio oder programmatisch über die <OperationLink operation="extension-patch-extension" />-Operation.
+
+:::info
+Eine Schritt-für-Schritt-Anleitung für dieses Setup, und wie es sich in eine vollständige Extension einfügt,
+findest du unter [Expose Extension](../../getting-started/expose-extension) im Getting-Started-Guide.
 :::
 
-Es enthält eine Docker-Compose-Konfiguration, die einen lokalen Server startet, der Lifecycle Webhooks versenden kann.
-Dazu wird eine API angeboten, mit der Lifecycle Webhooks angefragt werden können.
-Die Werte, die in den Webhooks enthalten sind, können dabei frei gewählt werden.
-Falls Werte nicht gesetzt sind, werden sie zufällig generiert.
+## Testen der Lifecycle Webhooks {#testing-lifecycle-webhooks}
 
-Wenn bspw. die Extension Instance ID selbst vergeben wird, können so auch ganze Lebenszyklen von Extension Instances simuliert werden,
-indem für verschiedene Webhooks eine stabile Extension Instance ID verwendet wird.
+Beide im Folgenden beschriebenen Methoden senden Webhooks an die konfigurierte Webhook-URL deiner Extension.
+Sie setzen daher voraus, dass deine lokale Extension erreichbar ist, wie unter [deine lokale Extension erreichbar machen](#making-your-local-extension-reachable) beschrieben.
 
-### ...mittels Dry Run Webhooks
+:::note Musst du das Webhook-Handling überhaupt testen?
+Die technische Seite von Lifecycle Webhooks — den Call annehmen, die Signatur verifizieren, den Payload parsen und ihn an den richtigen Handler weiterreichen — ist generische Infrastruktur, die du nicht selbst bauen und deshalb auch nicht selbst testen musst.
+Bibliotheken wie [`@weissaufschwarz/mitthooks`](https://www.npmjs.com/package/@weissaufschwarz/mitthooks), die auch die [Reference Extension](../../getting-started/reference-extension) verwendet, decken das vollständig ab.
+
+Übrig bleibt deine **Domänenlogik**: was deine Extension tut, wenn eine Extension Instance hinzugefügt, aktualisiert oder entfernt wird.
+Das ist gewöhnlicher Anwendungscode, den du lokal isoliert testen kannst — ganz ohne Tunnel und ohne mStudio.
+Nutze die folgenden Methoden, um die Integration als Ganzes zu verifizieren.
+:::
+
+### ...mittels Dry Run Webhooks (empfohlen) {#via-dry-run-webhooks}
 
 Mithilfe der <OperationLink operation="extension-dry-run-webhook" />-Operation können Lifecycle Webhooks auch über das mStudio Backend simuliert werden.
 Dabei wird der angefragte Lifecycle Webhook an die an der Extension konfigurierten URL gesendet.
 Dry Run Webhooks können nur für Extension Instances des Contributors ausgeführt werden.
-Sie können genau wie beim lokalen Development Server mit beliebigen Werten gefüllt werden oder zufällige Werte enthalten.
+Die Werte der Lifecycle Webhooks können frei gewählt werden oder vom mStudio Backend zufällig generiert werden.
 Für eine Übersicht, welche Werte statisch gesetzt werden können, siehe in der verlinkten Operation.
 
 Das Ergebnis samt Response Body, Headern und Status Code wird dabei als Antwort auf die Operation zurückgegeben.
+
+Dry Run Webhooks sind der praktischste Weg, um während der Entwicklung zu iterieren:
+
+- Du musst deine Extension nicht für jeden Versuch neu installieren und wieder entfernen.
+- Das mStudio führt Dry Run Webhooks **synchron** aus. Du bekommst die Antwort deines Webhook-Handlers also unmittelbar zurück, statt in deinen lokalen Logs nachsehen zu müssen.
+- Dadurch kannst du denselben Webhook beliebig oft und in einer selbst gewählten Reihenfolge senden.
+  Echte Lifecycle Webhooks werden asynchron zugestellt, wodurch du deutlich weniger Kontrolle über Zeitpunkt und Wiederholung hast.
 
 :::caution
 Um den Webhook als Dry Run erkennbar zu machen, wird dem Webhook der Query-Parameter `dry-run=true` hinzugefügt.
@@ -135,6 +162,23 @@ da es sich um eine Simulation handelt und so die Daten inkonsistent werden könn
 Zu Dokumentationszwecken kann zusätzlich der `executing-user-id` Query-Parameter ausgewertet werden.
 Dieser wird ebenfalls automatisch jedem Dry Run Webhook beigefügt.
 Er enthält die ID des Benutzers, der den Dry Run Webhook ausgelöst hat.
+
+### ...durch Installation deiner Extension {#by-installing-your-extension}
+
+Die Installation deiner Extension ist der realistischste Test, denn sie löst Webhooks genauso aus, wie es später deine Nutzer tun:
+indem die Extension zu einem Context hinzugefügt, ihr Zustand verändert und sie wieder entfernt wird.
+Jede dieser Aktionen erzeugt einen echten, signierten Webhook-Call.
+
+1. Mache deine lokale Extension erreichbar und konfiguriere die Webhook-URL, wie unter [deine lokale Extension erreichbar machen](#making-your-local-extension-reachable) beschrieben.
+2. Erstelle eine Extension Instance, wie unter [Erstellen einer Extension Instance](#creating-an-extension-instance) beschrieben.
+   Das löst den `ExtensionAddedToContext`-Webhook aus.
+3. Aktiviere oder deaktiviere die Extension Instance, um `InstanceUpdated`-Webhooks auszulösen.
+4. Entferne die Extension aus dem Context, um den `InstanceRemovedFromContext`-Webhook auszulösen.
+
+Die Bedeutung der einzelnen Webhooks ist unter [Lifecycle Webhooks](../../overview/concepts/lifecycle-webhooks) beschrieben.
+
+Da alle Extension Instances innerhalb deines Contributors kostenlos sind, kannst du diesen Zyklus beliebig oft wiederholen.
+Da das mStudio diese Webhooks asynchron zustellt, eignet sich diese Methode eher dazu, die Integration als Ganzes zu bestätigen, als im Detail zu iterieren.
 
 ## Frontend Fragments testen {#testing-frontend-fragments}
 


### PR DESCRIPTION
the local dev server is no longer supported - we also promote different ways of testing the webhooks in the getting-started-guide.