### PR TITLE
docs(aihosting): Qwen3-TTS-CustomVoice model page and text-to-speech guide

### DIFF
--- a/docs/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
+++ b/docs/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
@@ -1,0 +1,302 @@
+---
+sidebar_label: Qwen3-TTS-CustomVoice
+description: Detailed information about Qwen3-TTS-12Hz-1.7B-CustomVoice
+title: Qwen3-TTS-12Hz-1.7B-CustomVoice
+slug: /platform/aihosting/models/qwen3-tts-customvoice
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+The [Text-to-speech guide](../../examples/text-to-speech/) has runnable examples for the nine voices, the output formats, speaking rate, and splitting long texts.
+
+## Description
+
+"Qwen3-TTS-12Hz-1.7B-CustomVoice" is a text-to-speech model by Alibaba with 1.7 billion parameters. You send text, you get back an audio file. It is the counterpart to [Whisper-Large-V3-Turbo](./whisper-large-v3-turbo), which goes the other way and turns audio into text.
+
+The model serves the `/v1/audio/speech` endpoint and ships nine built-in voices across thirteen languages and dialects. Speech is generated faster than real time: producing one second of audio takes roughly an eighth of a second on our hardware.
+
+It supports and is suitable for:
+
+- Turning text into speech in thirteen languages and dialects
+- Nine distinct built-in voices, selected per request
+- Five output formats, including compressed ones for direct delivery to a browser
+- Adjusting the speaking rate between 0.25 and 4.0
+- Streaming, so playback can start about 25 times sooner than waiting for the whole file
+
+The following limitations apply:
+
+- Voice cloning from your own reference audio is not available on this endpoint
+- `response_format="aac"` is not supported, although the OpenAI API defines it
+- The `language` parameter takes capitalised language names, not the ISO-639-1 codes that [Whisper](./whisper-large-v3-turbo) uses
+- The model has no chat endpoint. `/v1/chat/completions` is not available for it
+
+:::warning[`language` does not take ISO codes here]
+Whisper accepts `de`, `en`, `fr`. This model rejects them and returns HTTP 400:
+
+```text
+Invalid language 'De'. Supported: Auto, Beijing_Dialect, Chinese, English, French, German, Italian, Japanese, Korean, Portuguese, Russian, Sichuan_Dialect, Spanish
+```
+
+Write `German` instead of `de`. If you build one wrapper around both audio models, this is the parameter that will bite you, because the same value is valid on one route and rejected on the other.
+
+You can also leave `language` out entirely. The default is `Auto` and it detects German and English reliably in our testing.
+:::
+
+## Supported voices
+
+All nine work on this endpoint. There is no separate "custom voice" list to request.
+
+`aiden`, `dylan`, `eric`, `ono_anna`, `ryan`, `serena`, `sohee`, `uncle_fu`, `vivian`
+
+`voice` is optional. Leaving it out gives you the model default. An unknown value returns HTTP 400 and lists the valid ones:
+
+```text
+Invalid voice 'bob'. Supported: aiden, dylan, eric, ono_anna, ryan, serena, sohee, uncle_fu, vivian
+```
+
+## Supported values for parameter `language`
+
+`Auto`, `Beijing_Dialect`, `Chinese`, `English`, `French`, `German`, `Italian`, `Japanese`, `Korean`, `Portuguese`, `Russian`, `Sichuan_Dialect`, `Spanish`
+
+## Supported output formats
+
+| `response_format` | Content type | Size for the same 4.5 s of speech |
+| ----------------- | ------------ | --------------------------------- |
+| `wav`             | `audio/wav`  | 73 kB                             |
+| `pcm`             | `audio/pcm`  | 92 kB                             |
+| `flac`            | `audio/flac` | 50 kB                             |
+| `mp3`             | `audio/mpeg` | 15 kB                             |
+| `opus`            | `audio/ogg`  | 8.6 kB                            |
+
+`wav` is the default and the right choice when you process the audio further. For delivery to a browser or a phone, `opus` is roughly a tenth of the size at speech quality.
+
+`aac` returns HTTP 400:
+
+```text
+Input should be 'wav', 'pcm', 'flac', 'mp3' or 'opus'
+```
+
+## Getting started
+
+<Tabs groupId="language">
+<TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+response = client.audio.speech.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="ryan",
+    input="Hallo und herzlich willkommen bei mittwald.",
+    response_format="mp3",
+)
+
+response.write_to_file("willkommen.mp3")
+```
+
+</TabItem>
+<TabItem value="javascript" label="JavaScript">
+
+```javascript
+import OpenAI from "openai";
+import { writeFile } from "node:fs/promises";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const response = await client.audio.speech.create({
+  model: "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+  voice: "ryan",
+  input: "Hallo und herzlich willkommen bei mittwald.",
+  response_format: "mp3",
+});
+
+await writeFile("willkommen.mp3", Buffer.from(await response.arrayBuffer()));
+```
+
+</TabItem>
+<TabItem value="php" label="PHP">
+
+```php
+<?php
+
+$payload = [
+    "model" => "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    "voice" => "ryan",
+    "input" => "Hallo und herzlich willkommen bei mittwald.",
+    "response_format" => "mp3",
+];
+
+$ch = curl_init("https://llm.aihosting.mittwald.de/v1/audio/speech");
+curl_setopt_array($ch, [
+    CURLOPT_POST => true,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER => [
+        "Authorization: Bearer sk-your-api-key-here",
+        "Content-Type: application/json",
+    ],
+    CURLOPT_POSTFIELDS => json_encode($payload),
+]);
+
+file_put_contents("willkommen.mp3", curl_exec($ch));
+curl_close($ch);
+```
+
+</TabItem>
+</Tabs>
+
+## Recommended inference parameters
+
+| Parameter         | Value                 | Effect                                                    |
+| ----------------- | --------------------- | --------------------------------------------------------- |
+| `voice`           | one of the nine names | Optional. Model default if omitted                        |
+| `language`        | `Auto`                | Optional. Set it explicitly when the text mixes languages |
+| `response_format` | `wav` or `opus`       | `wav` to process further, `opus` to deliver               |
+| `speed`           | `1.0`                 | Between 0.25 and 4.0, see [Speaking rate](#speaking-rate) |
+
+### Speaking rate {#speaking-rate}
+
+`speed` scales the duration close to inversely. The same German sentence, three runs per setting:
+
+| `speed` | Measured duration |
+| ------- | ----------------- |
+| `0.5`   | 9.28 s            |
+| `1.0`   | 4.85 s            |
+| `2.0`   | 2.23 s            |
+
+Output length varies a little between runs even with identical input, because the model samples. Treat the numbers as the shape of the curve, not as exact values.
+
+## Latency
+
+Measured on our hardware, German and English, one request at a time:
+
+| Input length   | Time to first byte | Audio produced |
+| -------------- | ------------------ | -------------- |
+| 51 characters  | 443 ms             | 3.5 s          |
+| 177 characters | 1497 ms            | 12.2 s         |
+| 366 characters | 3206 ms            | 26.6 s         |
+
+The ratio of generation time to audio length stays flat at roughly 0.12 across that range, so you can estimate the wait from the length of your text: expect about an eighth of the playback time you are asking for, plus a small constant.
+
+Those numbers are for a buffered request, where the whole file arrives at once. If a user is waiting for the audio, stream it instead.
+
+## Streaming {#streaming}
+
+Set `stream` to `true` and the first audio arrives in well under a second, no matter how long the text is. Measured on the same sentence as the table above:
+
+| Mode                       | Content type        | First chunk |
+| -------------------------- | ------------------- | ----------- |
+| buffered (default)         | `audio/wav`         | 1497 ms     |
+| `"stream": true`           | `text/event-stream` | 175 ms      |
+| `"stream_format": "sse"`   | `text/event-stream` | 57 ms       |
+| `"stream_format": "audio"` | `audio/wav`         | 61 ms       |
+
+The two SSE modes emit OpenAI `speech.audio.delta` and `speech.audio.done` events with Base64 audio in each delta. `"stream_format": "audio"` skips the event framing and sends raw audio chunks in the format you asked for, which is the simpler option when you are piping straight into a player.
+
+<Tabs groupId="language">
+<TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+with client.audio.speech.with_streaming_response.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="ryan",
+    input="Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+    response_format="wav",
+    extra_body={"stream_format": "audio"},
+) as response:
+    response.stream_to_file("ausgabe.wav")
+```
+
+</TabItem>
+<TabItem value="javascript" label="JavaScript">
+
+```javascript
+import OpenAI from "openai";
+import { createWriteStream } from "node:fs";
+import { Readable } from "node:stream";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const response = await client.audio.speech.create({
+  model: "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+  voice: "ryan",
+  input: "Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+  response_format: "wav",
+  // @ts-expect-error stream_format is not in the OpenAI types yet
+  stream_format: "audio",
+});
+
+Readable.fromWeb(response.body).pipe(createWriteStream("ausgabe.wav"));
+```
+
+</TabItem>
+<TabItem value="php" label="PHP">
+
+```php
+<?php
+
+$payload = [
+    "model" => "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    "voice" => "ryan",
+    "input" => "Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+    "response_format" => "wav",
+    "stream_format" => "audio",
+];
+
+$out = fopen("ausgabe.wav", "w");
+
+$ch = curl_init("https://llm.aihosting.mittwald.de/v1/audio/speech");
+curl_setopt_array($ch, [
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => [
+        "Authorization: Bearer sk-your-api-key-here",
+        "Content-Type: application/json",
+    ],
+    CURLOPT_POSTFIELDS => json_encode($payload),
+    CURLOPT_WRITEFUNCTION => function ($ch, $chunk) use ($out) {
+        fwrite($out, $chunk);
+        return strlen($chunk);
+    },
+]);
+
+curl_exec($ch);
+curl_close($ch);
+fclose($out);
+```
+
+</TabItem>
+</Tabs>
+
+For very long texts, splitting still helps even with streaming, because it lets you start the next request while the current one plays. The [Text-to-speech guide](../../examples/text-to-speech/#long-texts) has a worked example.
+
+## Error responses
+
+| Situation                  | Status | Message                                                 |
+| -------------------------- | ------ | ------------------------------------------------------- |
+| `input` is an empty string | 400    | `Input text cannot be empty`                            |
+| Unknown `voice`            | 400    | `Invalid voice '…'. Supported: …`                       |
+| Unknown `language`         | 400    | `Invalid language '…'. Supported: …`                    |
+| `response_format="aac"`    | 400    | `Input should be 'wav', 'pcm', 'flac', 'mp3' or 'opus'` |
+| Unknown model name         | 404    | `The model '…' does not exist.`                         |
+
+## Licence and terms of use
+
+The model is published by Alibaba under the Apache 2.0 licence. Before you can use it, accept its terms of use in mStudio. See [Terms of use](../access-and-usage/terms-of-use/).

--- a/docs/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
+++ b/docs/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
@@ -30,6 +30,9 @@ The following limitations apply:
 - `response_format="aac"` is not supported, although the OpenAI API defines it
 - The `language` parameter takes capitalised language names, not the ISO-639-1 codes that [Whisper](/docs/v2/platform/aihosting/models/whisper-large-v3-turbo) uses
 - The model has no chat endpoint. `/v1/chat/completions` is not available for it
+- There is no markup language. `[angry]`, `<laugh>`, and SSML tags are read out loud or dropped, see [Controlling delivery with instructions](#instructions)
+- German text needs preparation before you send it, and short German lines are unreliable, see [Writing text for German](#german-text)
+- `seed` is accepted but does not reproduce a previous result, see [Reproducibility](#reproducibility)
 
 :::warning[`language` does not take ISO codes here]
 Whisper accepts `de`, `en`, `fr`. This model rejects them and returns HTTP 400:
@@ -41,6 +44,15 @@ Invalid language 'De'. Supported: Auto, Beijing_Dialect, Chinese, English, Frenc
 Write `German` instead of `de`. If you build one wrapper around both audio models, this is the parameter that will bite you, because the same value is valid on one route and rejected on the other.
 
 You can also leave `language` out entirely. The default is `Auto` and it detects German and English reliably in our testing.
+
+A wrong but _valid_ value is worse than an invalid one, because it still returns HTTP 200. German text sent with `language: "English"` comes back as English-sounding nonsense:
+
+```text
+Input:  Die Lieferung kommt am Dienstagmorgen an, und die Rechnung wurde bereits an Ihre Adresse geschickt.
+Spoken: Deliver on camped on beanstalk market and keongty you were the brights and your addres
+```
+
+`German`, `Auto`, and omitting the parameter all produce correct German. So pass the right value or none at all, and don't hard-code `English` as a default in a wrapper that also handles German copy.
 :::
 
 ## Supported voices
@@ -48,6 +60,22 @@ You can also leave `language` out entirely. The default is `Auto` and it detects
 All nine work on this endpoint. There is no separate "custom voice" list to request.
 
 `aiden`, `dylan`, `eric`, `ono_anna`, `ryan`, `serena`, `sohee`, `uncle_fu`, `vivian`
+
+Every voice speaks every supported language, and all nine transcribe back cleanly in German and English in our tests, so pick by how the voice sounds rather than by its native language. Measured average pitch on English text:
+
+| Voice      | Native language   | Pitch  |
+| ---------- | ----------------- | ------ |
+| `aiden`    | English           | 147 Hz |
+| `dylan`    | Chinese (Beijing) | 164 Hz |
+| `ryan`     | English           | 171 Hz |
+| `eric`     | Chinese (Sichuan) | 177 Hz |
+| `uncle_fu` | Chinese           | 218 Hz |
+| `sohee`    | Korean            | 220 Hz |
+| `serena`   | Chinese           | 246 Hz |
+| `vivian`   | Chinese           | 250 Hz |
+| `ono_anna` | Japanese          | 264 Hz |
+
+Two things to know before you pick one for German. The voices whose native language is not German carry an audible accent, which is a matter of taste rather than a defect. And `instructions` only shapes the delivery of voices with an English-native voice on English text, see [Controlling delivery with instructions](#instructions), so on German the voice itself is the only lever you have over the character of the output.
 
 `voice` is optional in the API itself, but the OpenAI Python SDK requires it as a keyword argument, so pass it explicitly. An unknown value returns HTTP 400 and lists the valid ones:
 
@@ -76,6 +104,8 @@ Invalid voice 'bob'. Supported: aiden, dylan, eric, ono_anna, ryan, serena, sohe
 ```text
 Input should be 'wav', 'pcm', 'flac', 'mp3' or 'opus'
 ```
+
+Audio is 24 kHz, 16-bit, mono in every format. The loudness is not normalised: across our test set the peak level ranged from 0.23 to 0.89 of full scale, about 11 dB between the quietest and the loudest clip. If you play several clips one after another, run them through a loudness normaliser first.
 
 ## Getting started
 
@@ -155,12 +185,14 @@ curl_close($ch);
 
 ## Recommended inference parameters
 
-| Parameter         | Value                 | Effect                                                    |
-| ----------------- | --------------------- | --------------------------------------------------------- |
-| `voice`           | one of the nine names | Optional. Model default if omitted                        |
-| `language`        | `Auto`                | Optional. Set it explicitly when the text mixes languages |
-| `response_format` | `wav` or `opus`       | `wav` to process further, `opus` to deliver               |
-| `speed`           | `1.0`                 | Between 0.25 and 4.0, see [Speaking rate](#speaking-rate) |
+| Parameter         | Value                       | Effect                                                                      |
+| ----------------- | --------------------------- | --------------------------------------------------------------------------- |
+| `voice`           | one of the nine names       | Optional. Model default if omitted                                          |
+| `language`        | `Auto`                      | Optional. Set it explicitly when the text mixes languages                   |
+| `response_format` | `wav` or `opus`             | `wav` to process further, `opus` to deliver                                 |
+| `speed`           | `1.0`                       | Between 0.25 and 4.0, see [Speaking rate](#speaking-rate)                   |
+| `instructions`    | free text, ≤ 500 characters | Optional. Describes how to speak, see [Controlling delivery](#instructions) |
+| `seed`            | any integer                 | Accepted, but does not reproduce, see [Reproducibility](#reproducibility)   |
 
 ### Speaking rate {#speaking-rate}
 
@@ -173,6 +205,257 @@ curl_close($ch);
 | `2.0`   | 2.23 s            |
 
 Output length varies a little between runs even with identical input, because the model samples. Treat the numbers as the shape of the curve, not as exact values.
+
+`speed` has no effect while you stream. If you need a slower or faster reading of streamed audio, change the playback rate on your side.
+
+## Controlling delivery with instructions {#instructions}
+
+There is no markup language on this endpoint. Square-bracket tags, angle-bracket tags, and SSML are not parsed. They are either read out loud or dropped, and which one you get is not predictable:
+
+| You send                                               | The model says                                          |
+| ------------------------------------------------------ | ------------------------------------------------------- |
+| `[angry] The delivery arrives on Tuesday morning.`     | "**Hey,** the delivery arrives on Tuesday morning."     |
+| `<laugh> The delivery arrives on Tuesday morning.`     | "The delivery arrives on Tuesday morning." (no laugh)   |
+| `(excited) The delivery arrives on Tuesday morning!`   | "The delivery arrives on Tuesday morning." (no emotion) |
+| `The delivery arrives … <break time="1s"/> Thank you.` | "The delivery arrives … **They** thank you."            |
+| `<speak><prosody rate="slow">…</prosody></speak>`      | "**Speaks to rate slow pitch,** the delivery arrives …" |
+
+Strip any markup from your text and put the intent into the `instructions` parameter instead. It takes a plain sentence describing how the line should be delivered, up to 500 characters. Longer values return HTTP 400.
+
+:::warning[`instructions` works on English, barely on German]
+Measured on our hardware, five runs per setting, English text on the `ryan` voice: pitch moves between 156 Hz without instructions and 222 Hz for "shout", and the speaking rate between 10.6 characters per second for "whisper" and 18.6 for "speak very fast and excitedly". Both move in the direction you asked for.
+
+On German text the same instructions barely register. The pitch range across all emotions collapses to 17 Hz and the rate range to 1.1 characters per second, which is inside the run-to-run noise. Writing the instruction in German instead of English does not change that.
+
+For German, choose a different `voice` and adjust `speed` instead of describing an emotion.
+:::
+
+### Example: section-by-section voiceover for a client site
+
+A web agency builds a landing page for a client and wants a spoken version of each section: a calm product intro, a friendlier feature paragraph, and a call to action with some drive. One voice throughout keeps it recognisable as the same narrator, `instructions` change the delivery, and `opus` keeps the files small enough to ship with the page.
+
+Note that `language` and `instructions` are sent differently: `instructions` is a first-class parameter in the OpenAI SDKs, `language` is specific to this model and goes into `extra_body`.
+
+<Tabs groupId="language">
+<TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+sections = [
+    (
+        "01-intro",
+        "Your hosting, fully managed. No servers to patch and no pager at three in the morning.",
+        "Speak calmly and clearly, like a product narrator.",
+    ),
+    (
+        "02-feature",
+        "Every deploy ships in seconds, and any change is one click away from a rollback.",
+        "Speak in a cheerful, upbeat tone.",
+    ),
+    (
+        "03-cta",
+        "Start your free trial today and put your first site online in ten minutes.",
+        "Speak fast and excitedly, like a short radio advert.",
+    ),
+]
+
+for name, text, instructions in sections:
+    response = client.audio.speech.create(
+        model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        voice="ryan",
+        input=text,
+        instructions=instructions,
+        response_format="opus",
+        extra_body={"language": "English"},
+    )
+    response.write_to_file(f"{name}.opus")
+```
+
+</TabItem>
+<TabItem value="javascript" label="JavaScript">
+
+```javascript
+import OpenAI from "openai";
+import { writeFile } from "node:fs/promises";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const sections = [
+  [
+    "01-intro",
+    "Your hosting, fully managed. No servers to patch and no pager at three in the morning.",
+    "Speak calmly and clearly, like a product narrator.",
+  ],
+  [
+    "02-feature",
+    "Every deploy ships in seconds, and any change is one click away from a rollback.",
+    "Speak in a cheerful, upbeat tone.",
+  ],
+  [
+    "03-cta",
+    "Start your free trial today and put your first site online in ten minutes.",
+    "Speak fast and excitedly, like a short radio advert.",
+  ],
+];
+
+for (const [name, input, instructions] of sections) {
+  const response = await client.audio.speech.create({
+    model: "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice: "ryan",
+    input,
+    instructions,
+    response_format: "opus",
+    // @ts-expect-error language is specific to this model
+    language: "English",
+  });
+
+  await writeFile(`${name}.opus`, Buffer.from(await response.arrayBuffer()));
+}
+```
+
+</TabItem>
+<TabItem value="php" label="PHP">
+
+```php
+<?php
+
+$sections = [
+    [
+        "01-intro",
+        "Your hosting, fully managed. No servers to patch and no pager at three in the morning.",
+        "Speak calmly and clearly, like a product narrator.",
+    ],
+    [
+        "02-feature",
+        "Every deploy ships in seconds, and any change is one click away from a rollback.",
+        "Speak in a cheerful, upbeat tone.",
+    ],
+    [
+        "03-cta",
+        "Start your free trial today and put your first site online in ten minutes.",
+        "Speak fast and excitedly, like a short radio advert.",
+    ],
+];
+
+foreach ($sections as [$name, $input, $instructions]) {
+    $payload = [
+        "model" => "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        "voice" => "ryan",
+        "input" => $input,
+        "instructions" => $instructions,
+        "language" => "English",
+        "response_format" => "opus",
+    ];
+
+    $ch = curl_init("https://llm.aihosting.mittwald.de/v1/audio/speech");
+    curl_setopt_array($ch, [
+        CURLOPT_POST => true,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => [
+            "Authorization: Bearer sk-your-api-key-here",
+            "Content-Type: application/json",
+        ],
+        CURLOPT_POSTFIELDS => json_encode($payload),
+    ]);
+
+    file_put_contents("{$name}.opus", curl_exec($ch));
+    curl_close($ch);
+}
+```
+
+</TabItem>
+</Tabs>
+
+Running that produced three files of 26 kB, 25 kB, and 18 kB, and the delivery follows the instructions:
+
+| Section      | Instruction           | Duration | Speaking rate     |
+| ------------ | --------------------- | -------- | ----------------- |
+| `01-intro`   | calm product narrator | 5.76 s   | 14.9 characters/s |
+| `02-feature` | cheerful, upbeat      | 4.88 s   | 16.4 characters/s |
+| `03-cta`     | fast and excited      | 4.24 s   | 17.5 characters/s |
+
+For the German version of the same page, drop `instructions` and vary `voice` and `speed`:
+
+```python
+sections_de = [
+    ("de-01-intro", "Dein Hosting, vollständig verwaltet. Keine Server zum Patchen und kein Pager um drei Uhr nachts.", "serena", 0.95),
+    ("de-02-feature", "Jedes Deployment ist in Sekunden ausgerollt, und jede Änderung lässt sich mit einem Klick zurücknehmen.", "serena", 1.0),
+    ("de-03-cta", "Starte heute deine kostenlose Testphase und bring deine erste Website in zehn Minuten online.", "vivian", 1.15),
+]
+
+for name, text, voice, speed in sections_de:
+    response = client.audio.speech.create(
+        model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        voice=voice,
+        input=text,
+        speed=speed,
+        response_format="opus",
+        extra_body={"language": "German"},
+    )
+    response.write_to_file(f"{name}.opus")
+```
+
+That gave 12.9, 15.5, and 17.1 characters per second across the three sections, so the same build-up in pace without relying on `instructions`.
+
+## Writing text for German {#german-text}
+
+:::warning[Short German text is unreliable]
+Below roughly 80 characters, German synthesis fails often enough to matter. Same voice, `language: "German"`, six runs per length, scored by transcribing the audio back:
+
+| Input length   | Average word error rate | Runs badly wrong |
+| -------------- | ----------------------- | ---------------- |
+| 19 characters  | 0.167                   | 2 of 6           |
+| 58 characters  | 0.259                   | 3 of 6           |
+| 99 characters  | 0.022                   | 0 of 6           |
+| 187 characters | 0.007                   | 0 of 6           |
+
+A failure sounds like English, not like a mistake: "Willkommen bei uns. Wie können wir dir heute weiterhelfen?" came back as "We come in by uns, we come with your heart and vital health." The response is still HTTP 200 and the audio is still well-formed, so nothing downstream catches it.
+
+From about 100 characters upwards we did not reproduce it. If you generate short German lines, such as greetings, button labels, or one-sentence notifications, either batch several of them into one request and cut the audio afterwards, or check the result before you ship it. English is not affected at these lengths.
+:::
+
+German copy needs a pass before you send it. The model reads well-formed German prose correctly, but three things in ordinary source text come out wrong, and none of them fail loudly.
+
+:::warning[Send real umlauts, not `ae`, `oe`, `ue`]
+This is the single biggest quality difference we measured. The same sentence, ten runs each, scored by transcribing the audio back and comparing it to the input:
+
+| Input spelling                              | Runs transcribed back correctly | Average word error rate |
+| ------------------------------------------- | ------------------------------- | ----------------------- |
+| `Größere Änderungen an der Übersicht …`     | 10 of 10                        | 0.000                   |
+| `Groessere Aenderungen an der Uebersicht …` | 0 of 10                         | 0.215                   |
+
+The transliterated version produced "Gräser Erinnerungen", "Braceränderungen", and "Geißere Änderungen" for "Größere Änderungen". If your CMS or export pipeline strips umlauts, restore them before the request.
+:::
+
+Second, expand abbreviations and write numbers out. The compact forms a CMS or a language model produces are read incorrectly:
+
+| You send                     | The model says                        | Write instead                                                      |
+| ---------------------------- | ------------------------------------- | ------------------------------------------------------------------ |
+| `Bestellung 45312`           | "Bestellung 4FOR 5002"                | `fünfundvierzigtausenddreihundertzwölf`                            |
+| `1.299,99 Euro`              | "1.29,999", "Euro" dropped            | `eintausendzweihundertneunundneunzig Euro und neunundneunzig Cent` |
+| `u. a. … z. B. … ggf. inkl.` | "O.A. … setz bei … die geben English" | `unter anderem … zum Beispiel … gegebenenfalls inklusive`          |
+| `GmbH & Co. KG`              | "GmbH & Co, Kagi"                     | `GmbH und Co. KG`                                                  |
+
+Dates such as `20.05.2026`, percentages such as `19 %`, and phone numbers such as `05772 293-100` are read correctly as written. Phone numbers are spoken digit by digit, which is right but slow: budget roughly four times the audio length of ordinary prose for the same number of characters.
+
+English is not affected. `Order 45312 shipped on May 20th, 2026. The total is 1,299.99 euros including 19 percent VAT.` comes back essentially word for word.
+
+Third, English technical terms inside German sentences are the weakest case we found. `Kubernetes-Cluster`, `Continuous Deployment`, and `Zero-Downtime-Updates` in one German sentence came back partly garbled. Proper nouns are unreliable in the same way, and no spelling trick fixes them: we tried a brand name plain, respelled, hyphenated and spaced, and with instructions asking for German pronunciation, and 1 of 21 attempts came out right. There is no pronunciation lexicon on this endpoint. If a name has to be right every time, keep it out of the synthesized copy or splice in a recording of it.
+
+## Reproducibility {#reproducibility}
+
+`seed` is accepted and returns HTTP 200, but it does not give you the same audio twice. Three identical requests with `seed: 42` produced three different files with durations of 6.64 s, 6.48 s, and 6.32 s. All three were perfectly intelligible, so this is a reproducibility limit and not a quality problem.
+
+If you need a clip to stay identical across deploys, generate it once and cache the bytes.
 
 ## Latency
 
@@ -289,13 +572,21 @@ For very long texts, splitting still helps even with streaming, because it lets 
 
 ## Error responses
 
-| Situation                  | Status | Message                                                 |
-| -------------------------- | ------ | ------------------------------------------------------- |
-| `input` is an empty string | 400    | `Input text cannot be empty`                            |
-| Unknown `voice`            | 400    | `Invalid voice '…'. Supported: …`                       |
-| Unknown `language`         | 400    | `Invalid language '…'. Supported: …`                    |
-| `response_format="aac"`    | 400    | `Input should be 'wav', 'pcm', 'flac', 'mp3' or 'opus'` |
-| Unknown model name         | 404    | `The model '…' does not exist.`                         |
+| Situation                                                                  | Status | Message                                                             |
+| -------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------- |
+| `input` is an empty string                                                 | 400    | `Input text cannot be empty`                                        |
+| Unknown `voice`                                                            | 400    | `Invalid voice '…'. Supported: …`                                   |
+| Unknown `language`                                                         | 400    | `Invalid language '…'. Supported: …`                                |
+| `response_format="aac"`                                                    | 400    | `Input should be 'wav', 'pcm', 'flac', 'mp3' or 'opus'`             |
+| `instructions` over 500 characters                                         | 400    | `Instructions too long (max 500 characters)`                        |
+| `ref_audio`, `ref_text`, `speaker_embedding` or `task_type` in the request | 400    | Voice cloning is not available, see [Voice cloning](#voice-cloning) |
+| Unknown model name                                                         | 404    | `The model '…' does not exist.`                                     |
+
+## Voice cloning {#voice-cloning}
+
+Cloning a voice from your own reference audio is not available. This model ships the nine built-in voices and no speaker encoder, so there is nothing that could turn a sample of your voice into one it can speak with. Requests carrying `ref_audio`, `ref_text`, `speaker_embedding` or `task_type` are rejected with HTTP 400 rather than producing an unusable result.
+
+If you need a specific voice, work with the nine you have: pick by pitch as described in [Supported voices](#supported-voices), and use `instructions` and `speed` to shape the delivery.
 
 ## Licence and terms of use
 

--- a/docs/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
+++ b/docs/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
@@ -473,16 +473,15 @@ Those numbers are for a buffered request, where the whole file arrives at once. 
 
 ## Streaming {#streaming}
 
-Set `stream` to `true` and the first audio arrives in well under a second, no matter how long the text is. Measured on the same sentence as the table above:
+Set `stream` to `true` and choose either `stream_format="audio"` or `stream_format="sse"`. The first audio then arrives in well under a second, no matter how long the text is. Measured on the same sentence as the table above:
 
-| Mode                       | Content type        | First chunk |
-| -------------------------- | ------------------- | ----------- |
-| buffered (default)         | `audio/wav`         | 1497 ms     |
-| `"stream": true`           | `text/event-stream` | 175 ms      |
-| `"stream_format": "sse"`   | `text/event-stream` | 57 ms       |
-| `"stream_format": "audio"` | `audio/wav`         | 61 ms       |
+| Mode                     | Content type        | First chunk |
+| ------------------------ | ------------------- | ----------- |
+| buffered (default)       | `audio/wav`         | 1497 ms     |
+| streaming with `"sse"`   | `text/event-stream` | 57 ms       |
+| streaming with `"audio"` | `audio/wav`         | 61 ms       |
 
-The two SSE modes emit OpenAI `speech.audio.delta` and `speech.audio.done` events with Base64 audio in each delta. `"stream_format": "audio"` skips the event framing and sends raw audio chunks in the format you asked for, which is the simpler option when you are piping straight into a player.
+The SSE mode emits OpenAI `speech.audio.delta` and `speech.audio.done` events with Base64 audio in each delta. `"stream_format": "audio"` skips the event framing and sends raw audio chunks in the format you asked for, which is the simpler option when you are piping straight into a player.
 
 <Tabs groupId="language">
 <TabItem value="python" label="Python">
@@ -498,9 +497,10 @@ client = OpenAI(
 with client.audio.speech.with_streaming_response.create(
     model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
     voice="ryan",
-    input="Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+    input="A longer text whose playback should start immediately.",
     response_format="wav",
-    extra_body={"stream_format": "audio"},
+    stream_format="audio",
+    extra_body={"stream": True},
 ) as response:
     response.stream_to_file("ausgabe.wav")
 ```
@@ -512,6 +512,7 @@ with client.audio.speech.with_streaming_response.create(
 import OpenAI from "openai";
 import { createWriteStream } from "node:fs";
 import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
 
 const client = new OpenAI({
   baseURL: "https://llm.aihosting.mittwald.de/v1",
@@ -521,13 +522,16 @@ const client = new OpenAI({
 const response = await client.audio.speech.create({
   model: "Qwen3-TTS-12Hz-1.7B-CustomVoice",
   voice: "ryan",
-  input: "Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+  input: "A longer text whose playback should start immediately.",
   response_format: "wav",
-  // @ts-expect-error stream_format is not in the OpenAI types yet
+  // @ts-expect-error stream is supported by the hosted endpoint
+  stream: true,
   stream_format: "audio",
 });
 
-Readable.fromWeb(response.body).pipe(createWriteStream("ausgabe.wav"));
+await finished(
+  Readable.fromWeb(response.body).pipe(createWriteStream("ausgabe.wav")),
+);
 ```
 
 </TabItem>
@@ -539,8 +543,9 @@ Readable.fromWeb(response.body).pipe(createWriteStream("ausgabe.wav"));
 $payload = [
     "model" => "Qwen3-TTS-12Hz-1.7B-CustomVoice",
     "voice" => "ryan",
-    "input" => "Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+    "input" => "A longer text whose playback should start immediately.",
     "response_format" => "wav",
+    "stream" => true,
     "stream_format" => "audio",
 ];
 
@@ -561,7 +566,6 @@ curl_setopt_array($ch, [
 ]);
 
 curl_exec($ch);
-curl_close($ch);
 fclose($out);
 ```
 

--- a/docs/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
+++ b/docs/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
@@ -12,7 +12,7 @@ The [Text-to-speech guide](../../examples/text-to-speech/) has runnable examples
 
 ## Description
 
-"Qwen3-TTS-12Hz-1.7B-CustomVoice" is a text-to-speech model by Alibaba with 1.7 billion parameters. You send text, you get back an audio file. It is the counterpart to [Whisper-Large-V3-Turbo](./whisper-large-v3-turbo), which goes the other way and turns audio into text.
+"Qwen3-TTS-12Hz-1.7B-CustomVoice" is a text-to-speech model by Alibaba with 1.7 billion parameters. You send text, you get back an audio file. It is the counterpart to [Whisper-Large-V3-Turbo](/docs/v2/platform/aihosting/models/whisper-large-v3-turbo), which goes the other way and turns audio into text.
 
 The model serves the `/v1/audio/speech` endpoint and ships nine built-in voices across thirteen languages and dialects. Speech is generated faster than real time: producing one second of audio takes roughly an eighth of a second on our hardware.
 
@@ -28,7 +28,7 @@ The following limitations apply:
 
 - Voice cloning from your own reference audio is not available on this endpoint
 - `response_format="aac"` is not supported, although the OpenAI API defines it
-- The `language` parameter takes capitalised language names, not the ISO-639-1 codes that [Whisper](./whisper-large-v3-turbo) uses
+- The `language` parameter takes capitalised language names, not the ISO-639-1 codes that [Whisper](/docs/v2/platform/aihosting/models/whisper-large-v3-turbo) uses
 - The model has no chat endpoint. `/v1/chat/completions` is not available for it
 
 :::warning[`language` does not take ISO codes here]
@@ -299,4 +299,4 @@ For very long texts, splitting still helps even with streaming, because it lets 
 
 ## Licence and terms of use
 
-The model is published by Alibaba under the Apache 2.0 licence. Before you can use it, accept its terms of use in mStudio. See [Terms of use](../access-and-usage/terms-of-use/).
+The model is published by Alibaba under the Apache 2.0 licence. Before you can use it, accept its terms of use in mStudio. See [Terms of use](../../access-and-usage/terms-of-use/).

--- a/docs/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
+++ b/docs/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
@@ -49,7 +49,7 @@ All nine work on this endpoint. There is no separate "custom voice" list to requ
 
 `aiden`, `dylan`, `eric`, `ono_anna`, `ryan`, `serena`, `sohee`, `uncle_fu`, `vivian`
 
-`voice` is optional. Leaving it out gives you the model default. An unknown value returns HTTP 400 and lists the valid ones:
+`voice` is optional in the API itself, but the OpenAI Python SDK requires it as a keyword argument, so pass it explicitly. An unknown value returns HTTP 400 and lists the valid ones:
 
 ```text
 Invalid voice 'bob'. Supported: aiden, dylan, eric, ono_anna, ryan, serena, sohee, uncle_fu, vivian

--- a/docs/platform/aihosting/30-models/index.mdx
+++ b/docs/platform/aihosting/30-models/index.mdx
@@ -5,18 +5,18 @@ import DocCardList from "@theme/DocCardList";
 
 We currently offer the following models, which may change or expand over time. Each is described along with model-specific parameters.
 
-| Model Name                    | Type                      | Modalities                                      | Context (Tokens)  | License    |
-| ----------------------------- | ------------------------- | ----------------------------------------------- | ----------------- | ---------- |
-| gpt-oss-120b                  | Chat + reasoning          | Text, tool-calling                              | 131,072           | Apache 2.0 |
-| Qwen3.5-0.8B                  | Chat + reasoning          | Text, tool-calling                              | 262,144           | Apache 2.0 |
-| Ministral-3-14B-Instruct-2512 | Chat + vision             | Text, image, tool-calling                       | 262,144           | Apache 2.0 |
-| Qwen3.5-122B-A10B-FP8         | Chat + reasoning + vision | Text, image, tool-calling                       | 245,760           | Apache 2.0 |
-| Qwen3.6-35B-A3B-FP8           | Chat + reasoning + vision | Text, image, tool-calling                       | 256,000           | Apache 2.0 |
-| Qwen3.8-27B-NVFP4             | Chat + reasoning + vision | Text, image, tool-calling                       | 256,000           | Apache 2.0 |
-| GLM-OCR                       | Document OCR              | PDF, DOCX, PPTX, XLSX, HTML, SVG, image to text | 131,072           | MIT        |
-| Qwen3-Embedding-8B            | Embedding                 | Text to vector                                  | 32,768            | Apache 2.0 |
-| Qwen3-VL-Reranker-2B          | Reranking                 | Text, image to score                            | 32,768            | Apache 2.0 |
-| whisper-large-v3-turbo        | Speech-to-Text            | Audio to text                                   | N/A (audio-based) | MIT        |
+| Model Name                      | Type                      | Modalities                                      | Context (Tokens)  | License    |
+| ------------------------------- | ------------------------- | ----------------------------------------------- | ----------------- | ---------- |
+| gpt-oss-120b                    | Chat + reasoning          | Text, tool-calling                              | 131,072           | Apache 2.0 |
+| Qwen3.5-0.8B                    | Chat + reasoning          | Text, tool-calling                              | 262,144           | Apache 2.0 |
+| Ministral-3-14B-Instruct-2512   | Chat + vision             | Text, image, tool-calling                       | 262,144           | Apache 2.0 |
+| Qwen3.5-122B-A10B-FP8           | Chat + reasoning + vision | Text, image, tool-calling                       | 245,760           | Apache 2.0 |
+| Qwen3.6-35B-A3B-FP8             | Chat + reasoning + vision | Text, image, tool-calling                       | 256,000           | Apache 2.0 |
+| Qwen3.8-27B-NVFP4               | Chat + reasoning + vision | Text, image, tool-calling                       | 256,000           | Apache 2.0 |
+| GLM-OCR                         | Document OCR              | PDF, DOCX, PPTX, XLSX, HTML, SVG, image to text | 131,072           | MIT        |
+| Qwen3-Embedding-8B              | Embedding                 | Text to vector                                  | 32,768            | Apache 2.0 |
+| Qwen3-VL-Reranker-2B            | Reranking                 | Text, image to score                            | 32,768            | Apache 2.0 |
+| whisper-large-v3-turbo          | Speech-to-Text            | Audio to text                                   | N/A (audio-based) | MIT        |
 | Qwen3-TTS-12Hz-1.7B-CustomVoice | Text-to-Speech            | Text to audio                                   | N/A (audio-based) | Apache 2.0 |
 
 Tool-calling in this table reflects support on `/v1/chat/completions`. Support on `/v1/responses` is model-specific — see [Responses API support](../dedicated/openai-compatibility#responses-api) for the exact per-model breakdown.

--- a/docs/platform/aihosting/30-models/index.mdx
+++ b/docs/platform/aihosting/30-models/index.mdx
@@ -17,6 +17,7 @@ We currently offer the following models, which may change or expand over time. E
 | Qwen3-Embedding-8B            | Embedding                 | Text to vector                                  | 32,768            | Apache 2.0 |
 | Qwen3-VL-Reranker-2B          | Reranking                 | Text, image to score                            | 32,768            | Apache 2.0 |
 | whisper-large-v3-turbo        | Speech-to-Text            | Audio to text                                   | N/A (audio-based) | MIT        |
+| Qwen3-TTS-12Hz-1.7B-CustomVoice | Text-to-Speech            | Text to audio                                   | N/A (audio-based) | Apache 2.0 |
 
 Tool-calling in this table reflects support on `/v1/chat/completions`. Support on `/v1/responses` is model-specific — see [Responses API support](../dedicated/openai-compatibility#responses-api) for the exact per-model breakdown.
 
@@ -42,6 +43,8 @@ Tool-calling in this table reflects support on `/v1/chat/completions`. Support o
     use `Qwen3-Embedding-8B`
   - For any audio transcription or voice-command needs \
     use `whisper-large-v3-turbo`
+  - For reading text out loud, for example voice responses, accessibility, or audio versions of written content \
+    use `Qwen3-TTS-12Hz-1.7B-CustomVoice`
   - To improve RAG retrieval precision by adding it as a second-pass reranker after vector search \
     use `Qwen3-VL-Reranker-2B`
 

--- a/docs/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
+++ b/docs/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
@@ -251,3 +251,56 @@ curl -X POST https://llm.aihosting.mittwald.de/v1/audio/transcriptions \
 - Translation functionality (`to_language` parameter) is not supported
 - For best results, always specify the `language` parameter explicitly
 - Segment audio files into chunks smaller than 25 MB and shorter than 10 minutes if needed. Exceeding the duration returns HTTP 400 with `Audio exceeds maximum allowed duration of 600s`. See the [speech-to-text guide](../../examples/whisper/#large-files) for a chunking example
+
+## /v1/audio/speech
+
+This endpoint turns text into speech using [Qwen3-TTS-12Hz-1.7B-CustomVoice](../../models/qwen3-tts-customvoice/). It is the counterpart to `/v1/audio/transcriptions` above: text goes in, an audio file comes back.
+
+```sh
+curl -X POST https://llm.aihosting.mittwald.de/v1/audio/speech \
+    -H "Authorization: Bearer $APIKEY" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+      "input": "Hallo und herzlich willkommen bei mittwald.",
+      "voice": "ryan",
+      "response_format": "mp3"
+    }' \
+    --output willkommen.mp3
+```
+
+The response body is the audio file itself, not JSON. Write it straight to a file or pass it to your audio player. Only errors come back as JSON.
+
+The `input` parameter holds the text to speak and must not be empty. The `model` parameter selects the TTS model.
+
+Additional optional parameters can be provided:
+
+- `voice`: One of `aiden`, `dylan`, `eric`, `ono_anna`, `ryan`, `serena`, `sohee`, `uncle_fu`, `vivian`. Omitting it uses the model default
+- `response_format`: One of `wav` (default), `pcm`, `flac`, `mp3`, `opus`. `aac` is **not** supported
+- `language`: One of `Auto` (default), `Beijing_Dialect`, `Chinese`, `English`, `French`, `German`, `Italian`, `Japanese`, `Korean`, `Portuguese`, `Russian`, `Sichuan_Dialect`, `Spanish`
+- `speed`: Speaking rate between 0.25 and 4.0, default 1.0
+- `stream`: Set to `true` to receive audio as it is generated
+- `stream_format`: `sse` for OpenAI `speech.audio.*` events, or `audio` for raw audio chunks
+
+Streaming cuts the wait for the first audio from about 1500 ms to under 200 ms, so use it whenever someone is waiting for playback:
+
+```sh
+curl -N -X POST https://llm.aihosting.mittwald.de/v1/audio/speech \
+    -H "Authorization: Bearer $APIKEY" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+      "input": "Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+      "voice": "ryan",
+      "response_format": "wav",
+      "stream_format": "audio"
+    }' \
+    --output ausgabe.wav
+```
+
+**Important notes:**
+
+- The two audio endpoints take the `language` parameter in **different formats**. `/v1/audio/transcriptions` wants ISO-639-1 codes such as `de`; `/v1/audio/speech` wants capitalised names such as `German` and rejects `de` with HTTP 400. See [the warning on the model page](../../models/qwen3-tts-customvoice/) before you write shared code against both
+- Without streaming, generation takes roughly an eighth of the playback time you request, and nothing arrives until it is finished
+- Voice cloning from your own reference audio is not offered on this endpoint
+- Split long texts and request the parts separately. See the [text-to-speech guide](../../examples/text-to-speech/#long-texts) for a worked example

--- a/docs/platform/aihosting/50-examples/95-text-to-speech.mdx
+++ b/docs/platform/aihosting/50-examples/95-text-to-speech.mdx
@@ -41,7 +41,7 @@ print("written to willkommen.mp3")
 
 Without streaming, nothing arrives until the whole file is generated. For a 26-second clip that is a 3-second wait. With streaming the first audio arrives in well under a second regardless of length, so use it whenever a person is waiting.
 
-`stream_format="audio"` sends raw audio chunks in the format you asked for, which is the simplest option when you write to a file or pipe into a player.
+Set `stream` to `true` to enable streaming. Then choose `stream_format="audio"` for raw audio chunks in the requested format, which is the simplest option when you write to a file or pipe into a player.
 
 ```python
 import os
@@ -56,11 +56,12 @@ with client.audio.speech.with_streaming_response.create(
     model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
     voice="ryan",
     input=(
-        "Dieser Text ist lang genug, dass sich das Warten auf die vollstaendige "
-        "Datei bemerkbar machen wuerde. Mit Streaming beginnt die Wiedergabe sofort."
+        "This text is long enough for waiting on the complete file to become "
+        "noticeable. With streaming, playback can start immediately."
     ),
     response_format="wav",
-    extra_body={"stream_format": "audio"},
+    stream_format="audio",
+    extra_body={"stream": True},
 ) as response:
     response.stream_to_file("ausgabe.wav")
 ```
@@ -226,7 +227,8 @@ with client.audio.speech.with_streaming_response.create(
     voice="serena",
     input=answer,
     response_format="mp3",
-    extra_body={"stream_format": "audio"},
+    stream_format="audio",
+    extra_body={"stream": True},
 ) as speech:
     speech.stream_to_file("antwort.mp3")
 ```

--- a/docs/platform/aihosting/50-examples/95-text-to-speech.mdx
+++ b/docs/platform/aihosting/50-examples/95-text-to-speech.mdx
@@ -1,0 +1,254 @@
+---
+sidebar_label: Text-to-speech with Qwen3-TTS
+description: Generate speech from text using Qwen3-TTS-12Hz-1.7B-CustomVoice via the OpenAI-compatible API
+title: Text-to-speech with Qwen3-TTS
+---
+
+`Qwen3-TTS-12Hz-1.7B-CustomVoice` is accessible through the same `/v1/audio/speech` endpoint as the OpenAI speech API, so code written for OpenAI works by changing `base_url`. See the [Qwen3-TTS model page](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice) for the full list of voices, languages, formats, and measured latencies.
+
+This is the opposite direction from [speech-to-text with Whisper](./whisper/): text goes in, audio comes out.
+
+## Setup {#setup}
+
+```shellsession
+user@local $ pip install openai
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+## Basic synthesis {#basic}
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+response = client.audio.speech.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="ryan",
+    input="Hallo und herzlich willkommen bei mittwald.",
+    response_format="mp3",
+)
+
+response.write_to_file("willkommen.mp3")
+print("written to willkommen.mp3")
+```
+
+## Streaming, so playback starts sooner {#streaming}
+
+Without streaming, nothing arrives until the whole file is generated. For a 26-second clip that is a 3-second wait. With streaming the first audio arrives in well under a second regardless of length, so use it whenever a person is waiting.
+
+`stream_format="audio"` sends raw audio chunks in the format you asked for, which is the simplest option when you write to a file or pipe into a player.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+with client.audio.speech.with_streaming_response.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="ryan",
+    input=(
+        "Dieser Text ist lang genug, dass sich das Warten auf die vollstaendige "
+        "Datei bemerkbar machen wuerde. Mit Streaming beginnt die Wiedergabe sofort."
+    ),
+    response_format="wav",
+    extra_body={"stream_format": "audio"},
+) as response:
+    response.stream_to_file("ausgabe.wav")
+```
+
+If you want the OpenAI event framing instead, use `stream_format="sse"` and read `speech.audio.delta` events, each carrying Base64 audio, followed by one `speech.audio.done`.
+
+## Choosing a voice {#voices}
+
+Nine voices ship with the model. Generate a sample of each and listen, since the right one depends on your content:
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+VOICES = ["aiden", "dylan", "eric", "ono_anna", "ryan",
+          "serena", "sohee", "uncle_fu", "vivian"]
+
+SAMPLE = "Guten Tag. Dies ist eine Hoerprobe fuer die Sprachausgabe."
+
+for voice in VOICES:
+    response = client.audio.speech.create(
+        model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        voice=voice,
+        input=SAMPLE,
+        response_format="mp3",
+    )
+    response.write_to_file(f"sample_{voice}.mp3")
+    print(f"sample_{voice}.mp3")
+```
+
+Voice cloning from your own recording is not available on this endpoint. The nine built-in voices are the complete set.
+
+## Picking an output format {#formats}
+
+All five formats hold the same audio. They differ in size, which matters if you send the result over the network:
+
+| `response_format` | Size for 4.5 s of speech | Use it for                      |
+| ----------------- | ------------------------ | ------------------------------- |
+| `wav`             | 73 kB                    | Further processing, the default |
+| `pcm`             | 92 kB                    | Feeding a raw audio pipeline    |
+| `flac`            | 50 kB                    | Lossless archiving              |
+| `mp3`             | 15 kB                    | Broad compatibility             |
+| `opus`            | 8.6 kB                   | Delivery to a browser or phone  |
+
+`aac` is not supported and returns HTTP 400.
+
+## Long texts {#long-texts}
+
+Generation time scales with the length of the text, so a very long input means a long single request. Splitting on sentence boundaries lets you start playing the first part while the rest is still being generated, and it keeps any one failure small.
+
+```python
+import os
+import re
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+
+def split_sentences(text, max_chars=350):
+    """Group sentences into chunks of at most max_chars."""
+    sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+    chunks, current = [], ""
+    for sentence in sentences:
+        if current and len(current) + len(sentence) + 1 > max_chars:
+            chunks.append(current)
+            current = sentence
+        else:
+            current = f"{current} {sentence}".strip()
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+LONG_TEXT = (
+    "Der erste Satz eroeffnet den Text. "
+    "Der zweite Satz fuehrt den Gedanken weiter und wird etwas laenger. "
+    "Ein dritter Satz schliesst den Absatz ab."
+)
+
+for index, chunk in enumerate(split_sentences(LONG_TEXT)):
+    response = client.audio.speech.create(
+        model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        voice="ryan",
+        input=chunk,
+        response_format="mp3",
+    )
+    response.write_to_file(f"part_{index:03d}.mp3")
+    print(f"part_{index:03d}.mp3  ({len(chunk)} characters)")
+```
+
+Splitting mid-sentence makes the seam audible, because the model chooses intonation per request. Cut on sentence boundaries, as above.
+
+## Adjusting the speaking rate {#speed}
+
+`speed` scales duration close to inversely. Measured on the same German sentence:
+
+| `speed` | Duration |
+| ------- | -------- |
+| `0.5`   | 9.28 s   |
+| `1.0`   | 4.85 s   |
+| `2.0`   | 2.23 s   |
+
+```python
+response = client.audio.speech.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="ryan",
+    input="Langsam und deutlich gesprochen.",
+    response_format="mp3",
+    speed=0.8,
+)
+```
+
+## Mixed-language text {#languages}
+
+The default `Auto` detects the language, and it handles German and English reliably. Set `language` explicitly when a text mixes languages and you want one of them to win.
+
+```python
+response = client.audio.speech.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="serena",
+    input="Wir deployen das Feature heute, das Rollback-Skript liegt bereit.",
+    response_format="mp3",
+    extra_body={"language": "German"},
+)
+```
+
+Write `German`, not `de`. The transcription endpoint takes ISO-639-1 codes and this one takes capitalised names, which is the most common mistake when the same code calls both.
+
+## Reading a model answer out loud {#chat-pipeline}
+
+A common pipeline: generate an answer with a chat model, then speak it.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+completion = client.chat.completions.create(
+    model="Qwen3.5-0.8B",
+    messages=[
+        {"role": "system", "content": "Antworte in hoechstens drei Saetzen."},
+        {"role": "user", "content": "Was ist ein Reverse Proxy?"},
+    ],
+)
+
+answer = completion.choices[0].message.content
+print(answer)
+
+with client.audio.speech.with_streaming_response.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="serena",
+    input=answer,
+    response_format="mp3",
+    extra_body={"stream_format": "audio"},
+) as speech:
+    speech.stream_to_file("antwort.mp3")
+```
+
+Cap the answer length in the system prompt. Generation time follows the length of the text, and an unbounded model answer turns into an unbounded wait.
+
+## Drop-in replacement for OpenAI {#openai-replacement}
+
+Only `base_url`, `api_key`, and the model name change:
+
+```python
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",   # instead of api.openai.com
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+response = client.audio.speech.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",           # instead of tts-1 or gpt-4o-mini-tts
+    voice="ryan",                                       # different voice names
+    input="Hello and welcome.",
+    response_format="mp3",
+)
+```
+
+Two differences to expect when porting: the voice names are not OpenAI's (`alloy`, `nova` and so on do not exist here), and `response_format="aac"` is unsupported.

--- a/docs/platform/aihosting/50-examples/95-text-to-speech.mdx
+++ b/docs/platform/aihosting/50-examples/95-text-to-speech.mdx
@@ -6,7 +6,7 @@ title: Text-to-speech with Qwen3-TTS
 
 `Qwen3-TTS-12Hz-1.7B-CustomVoice` is accessible through the same `/v1/audio/speech` endpoint as the OpenAI speech API, so code written for OpenAI works by changing `base_url`. See the [Qwen3-TTS model page](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice) for the full list of voices, languages, formats, and measured latencies.
 
-This is the opposite direction from [speech-to-text with Whisper](./whisper/): text goes in, audio comes out.
+This is the opposite direction from [speech-to-text with Whisper](/docs/v2/platform/aihosting/examples/whisper/): text goes in, audio comes out.
 
 ## Setup {#setup}
 

--- a/docs/platform/aihosting/50-examples/95-text-to-speech.mdx
+++ b/docs/platform/aihosting/50-examples/95-text-to-speech.mdx
@@ -252,5 +252,3 @@ response = client.audio.speech.create(
     response_format="mp3",
 )
 ```
-
-Two differences to expect when porting: the voice names are not OpenAI's (`alloy`, `nova` and so on do not exist here), and `response_format="aac"` is unsupported.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
@@ -1,0 +1,301 @@
+---
+sidebar_label: Qwen3-TTS-CustomVoice
+description: Detaillierte Informationen zu Qwen3-TTS-12Hz-1.7B-CustomVoice
+title: Qwen3-TTS-12Hz-1.7B-CustomVoice
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+Im [Text-to-Speech-Guide](../../examples/text-to-speech/) findest du lauffähige Beispiele für die neun Stimmen, die Ausgabeformate, das Sprechtempo und das Aufteilen langer Texte.
+
+## Beschreibung
+
+„Qwen3-TTS-12Hz-1.7B-CustomVoice" ist ein Text-to-Speech-Modell von Alibaba mit 1,7 Milliarden Parametern. Du schickst Text hin und bekommst eine Audiodatei zurück. Es ist das Gegenstück zu [Whisper-Large-V3-Turbo](./whisper-large-v3-turbo), das den umgekehrten Weg geht und aus Audio Text macht.
+
+Das Modell bedient die Route `/v1/audio/speech` und bringt neun eingebaute Stimmen für dreizehn Sprachen und Dialekte mit. Die Sprachausgabe entsteht schneller als in Echtzeit: Für eine Sekunde Audio braucht das Modell auf unserer Hardware etwa eine achtel Sekunde.
+
+Das Modell eignet sich für:
+
+- Sprachausgabe in dreizehn Sprachen und Dialekten
+- Neun verschiedene eingebaute Stimmen, pro Anfrage wählbar
+- Fünf Ausgabeformate, darunter komprimierte für die direkte Auslieferung an den Browser
+- Ein Sprechtempo zwischen 0,25 und 4,0
+- Streaming, damit die Wiedergabe rund 25-mal früher starten kann als beim Warten auf die ganze Datei
+
+Diese Einschränkungen gelten:
+
+- Voice-Cloning mit eigenem Referenz-Audio ist auf dieser Route nicht verfügbar
+- `response_format="aac"` wird nicht unterstützt, obwohl die OpenAI-API es vorsieht
+- Der Parameter `language` erwartet großgeschriebene Sprachnamen, nicht die ISO-639-1-Codes, die [Whisper](./whisper-large-v3-turbo) verwendet
+- Das Modell hat keine Chat-Route. `/v1/chat/completions` steht dafür nicht zur Verfügung
+
+:::warning[`language` nimmt hier keine ISO-Codes]
+Whisper akzeptiert `de`, `en`, `fr`. Dieses Modell weist sie ab und antwortet mit HTTP 400:
+
+```text
+Invalid language 'De'. Supported: Auto, Beijing_Dialect, Chinese, English, French, German, Italian, Japanese, Korean, Portuguese, Russian, Sichuan_Dialect, Spanish
+```
+
+Schreib `German` statt `de`. Wenn du einen gemeinsamen Wrapper um beide Audio-Modelle baust, ist das der Parameter, über den du stolperst: Derselbe Wert ist auf der einen Route gültig und wird auf der anderen abgelehnt.
+
+Du kannst `language` auch ganz weglassen. Der Standard ist `Auto`, und der hat in unseren Tests Deutsch und Englisch zuverlässig erkannt.
+:::
+
+## Verfügbare Stimmen
+
+Alle neun funktionieren auf dieser Route. Es gibt keine getrennte Liste für „Custom Voices", die du erst freischalten müsstest.
+
+`aiden`, `dylan`, `eric`, `ono_anna`, `ryan`, `serena`, `sohee`, `uncle_fu`, `vivian`
+
+`voice` ist optional. Ohne Angabe nimmt das Modell seine Standardstimme. Ein unbekannter Wert führt zu HTTP 400, die Antwort nennt die gültigen Werte:
+
+```text
+Invalid voice 'bob'. Supported: aiden, dylan, eric, ono_anna, ryan, serena, sohee, uncle_fu, vivian
+```
+
+## Gültige Werte für den Parameter `language`
+
+`Auto`, `Beijing_Dialect`, `Chinese`, `English`, `French`, `German`, `Italian`, `Japanese`, `Korean`, `Portuguese`, `Russian`, `Sichuan_Dialect`, `Spanish`
+
+## Ausgabeformate
+
+| `response_format` | Content-Type | Größe für dieselben 4,5 s Sprache |
+| ----------------- | ------------ | --------------------------------- |
+| `wav`             | `audio/wav`  | 73 kB                             |
+| `pcm`             | `audio/pcm`  | 92 kB                             |
+| `flac`            | `audio/flac` | 50 kB                             |
+| `mp3`             | `audio/mpeg` | 15 kB                             |
+| `opus`            | `audio/ogg`  | 8,6 kB                            |
+
+`wav` ist der Standard und die richtige Wahl, wenn du das Audio weiterverarbeitest. Für die Auslieferung an Browser oder Telefon ist `opus` bei Sprachqualität rund ein Zehntel so groß.
+
+`aac` führt zu HTTP 400:
+
+```text
+Input should be 'wav', 'pcm', 'flac', 'mp3' or 'opus'
+```
+
+## Erste Schritte
+
+<Tabs groupId="language">
+<TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+response = client.audio.speech.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="ryan",
+    input="Hallo und herzlich willkommen bei mittwald.",
+    response_format="mp3",
+)
+
+response.write_to_file("willkommen.mp3")
+```
+
+</TabItem>
+<TabItem value="javascript" label="JavaScript">
+
+```javascript
+import OpenAI from "openai";
+import { writeFile } from "node:fs/promises";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const response = await client.audio.speech.create({
+  model: "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+  voice: "ryan",
+  input: "Hallo und herzlich willkommen bei mittwald.",
+  response_format: "mp3",
+});
+
+await writeFile("willkommen.mp3", Buffer.from(await response.arrayBuffer()));
+```
+
+</TabItem>
+<TabItem value="php" label="PHP">
+
+```php
+<?php
+
+$payload = [
+    "model" => "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    "voice" => "ryan",
+    "input" => "Hallo und herzlich willkommen bei mittwald.",
+    "response_format" => "mp3",
+];
+
+$ch = curl_init("https://llm.aihosting.mittwald.de/v1/audio/speech");
+curl_setopt_array($ch, [
+    CURLOPT_POST => true,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER => [
+        "Authorization: Bearer sk-your-api-key-here",
+        "Content-Type: application/json",
+    ],
+    CURLOPT_POSTFIELDS => json_encode($payload),
+]);
+
+file_put_contents("willkommen.mp3", curl_exec($ch));
+curl_close($ch);
+```
+
+</TabItem>
+</Tabs>
+
+## Empfohlene Parameter
+
+| Parameter         | Wert                 | Wirkung                                                  |
+| ----------------- | -------------------- | -------------------------------------------------------- |
+| `voice`           | einer der neun Namen | Optional. Ohne Angabe die Standardstimme                 |
+| `language`        | `Auto`               | Optional. Setz ihn, wenn der Text Sprachen mischt        |
+| `response_format` | `wav` oder `opus`    | `wav` zum Weiterverarbeiten, `opus` zum Ausliefern       |
+| `speed`           | `1.0`                | Zwischen 0,25 und 4,0, siehe [Sprechtempo](#sprechtempo) |
+
+### Sprechtempo {#sprechtempo}
+
+`speed` skaliert die Dauer annähernd umgekehrt proportional. Derselbe deutsche Satz, drei Durchläufe je Einstellung:
+
+| `speed` | Gemessene Dauer |
+| ------- | --------------- |
+| `0.5`   | 9,28 s          |
+| `1.0`   | 4,85 s          |
+| `2.0`   | 2,23 s          |
+
+Die Länge schwankt auch bei identischer Eingabe leicht, weil das Modell sampelt. Nimm die Zahlen als Verlauf, nicht als exakte Werte.
+
+## Latenz
+
+Auf unserer Hardware gemessen, Deutsch und Englisch, eine Anfrage zur Zeit:
+
+| Länge der Eingabe | Zeit bis zum ersten Byte | Erzeugtes Audio |
+| ----------------- | ------------------------ | --------------- |
+| 51 Zeichen        | 443 ms                   | 3,5 s           |
+| 177 Zeichen       | 1497 ms                  | 12,2 s          |
+| 366 Zeichen       | 3206 ms                  | 26,6 s          |
+
+Das Verhältnis von Rechenzeit zu Audiolänge bleibt über diesen Bereich flach bei etwa 0,12. Die Wartezeit kannst du also aus der Textlänge abschätzen: Rechne mit einem Achtel der Abspieldauer, die du anforderst, plus einem kleinen festen Anteil.
+
+Diese Zahlen gelten für eine gepufferte Anfrage, bei der die ganze Datei auf einmal ankommt. Wenn jemand auf das Audio wartet, streame es stattdessen.
+
+## Streaming {#streaming}
+
+Setz `stream` auf `true`, dann kommt das erste Audio in deutlich unter einer Sekunde, egal wie lang der Text ist. Gemessen am selben Satz wie in der Tabelle darüber:
+
+| Modus                      | Content-Type        | Erster Chunk |
+| -------------------------- | ------------------- | ------------ |
+| gepuffert (Standard)       | `audio/wav`         | 1497 ms      |
+| `"stream": true`           | `text/event-stream` | 175 ms       |
+| `"stream_format": "sse"`   | `text/event-stream` | 57 ms        |
+| `"stream_format": "audio"` | `audio/wav`         | 61 ms        |
+
+Die beiden SSE-Modi schicken `speech.audio.delta`- und `speech.audio.done`-Events im OpenAI-Format, das Audio steckt Base64-kodiert in jedem Delta. `"stream_format": "audio"` lässt die Event-Hülle weg und liefert rohe Audio-Chunks im angeforderten Format. Das ist der einfachere Weg, wenn du direkt in einen Player schreibst.
+
+<Tabs groupId="language">
+<TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+with client.audio.speech.with_streaming_response.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="ryan",
+    input="Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+    response_format="wav",
+    extra_body={"stream_format": "audio"},
+) as response:
+    response.stream_to_file("ausgabe.wav")
+```
+
+</TabItem>
+<TabItem value="javascript" label="JavaScript">
+
+```javascript
+import OpenAI from "openai";
+import { createWriteStream } from "node:fs";
+import { Readable } from "node:stream";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const response = await client.audio.speech.create({
+  model: "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+  voice: "ryan",
+  input: "Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+  response_format: "wav",
+  // @ts-expect-error stream_format steht noch nicht in den OpenAI-Typen
+  stream_format: "audio",
+});
+
+Readable.fromWeb(response.body).pipe(createWriteStream("ausgabe.wav"));
+```
+
+</TabItem>
+<TabItem value="php" label="PHP">
+
+```php
+<?php
+
+$payload = [
+    "model" => "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    "voice" => "ryan",
+    "input" => "Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+    "response_format" => "wav",
+    "stream_format" => "audio",
+];
+
+$out = fopen("ausgabe.wav", "w");
+
+$ch = curl_init("https://llm.aihosting.mittwald.de/v1/audio/speech");
+curl_setopt_array($ch, [
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => [
+        "Authorization: Bearer sk-your-api-key-here",
+        "Content-Type: application/json",
+    ],
+    CURLOPT_POSTFIELDS => json_encode($payload),
+    CURLOPT_WRITEFUNCTION => function ($ch, $chunk) use ($out) {
+        fwrite($out, $chunk);
+        return strlen($chunk);
+    },
+]);
+
+curl_exec($ch);
+curl_close($ch);
+fclose($out);
+```
+
+</TabItem>
+</Tabs>
+
+Bei sehr langen Texten lohnt sich das Aufteilen trotzdem, denn dann kannst du die nächste Anfrage schon stellen, während der aktuelle Teil abspielt. Ein ausgearbeitetes Beispiel steht im [Text-to-Speech-Guide](../../examples/text-to-speech/#lange-texte).
+
+## Fehlerantworten
+
+| Situation                     | Status | Meldung                                                 |
+| ----------------------------- | ------ | ------------------------------------------------------- |
+| `input` ist ein leerer String | 400    | `Input text cannot be empty`                            |
+| Unbekannte `voice`            | 400    | `Invalid voice '…'. Supported: …`                       |
+| Unbekannte `language`         | 400    | `Invalid language '…'. Supported: …`                    |
+| `response_format="aac"`       | 400    | `Input should be 'wav', 'pcm', 'flac', 'mp3' or 'opus'` |
+| Unbekannter Modellname        | 404    | `The model '…' does not exist.`                         |
+
+## Lizenz und Nutzungsbedingungen
+
+Alibaba veröffentlicht das Modell unter der Apache-2.0-Lizenz. Bevor du es nutzen kannst, musst du die Nutzungsbedingungen im mStudio annehmen. Siehe [Nutzungsbedingungen](../access-and-usage/terms-of-use/).

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
@@ -29,6 +29,9 @@ Diese Einschränkungen gelten:
 - `response_format="aac"` wird nicht unterstützt, obwohl die OpenAI-API es vorsieht
 - Der Parameter `language` erwartet großgeschriebene Sprachnamen, nicht die ISO-639-1-Codes, die [Whisper](/docs/v2/platform/aihosting/models/whisper-large-v3-turbo) verwendet
 - Das Modell hat keine Chat-Route. `/v1/chat/completions` steht dafür nicht zur Verfügung
+- Es gibt keine Auszeichnungssprache. `[angry]`, `<laugh>` und SSML-Tags werden vorgelesen oder verschluckt, siehe [Sprechweise über `instructions` steuern](#stimmfuehrung)
+- Deutscher Text braucht eine Vorbereitung, bevor du ihn schickst, und kurze deutsche Zeilen sind unzuverlässig, siehe [Text für Deutsch aufbereiten](#deutscher-text)
+- `seed` wird angenommen, liefert aber kein reproduzierbares Ergebnis, siehe [Reproduzierbarkeit](#reproduzierbarkeit)
 
 :::warning[`language` nimmt hier keine ISO-Codes]
 Whisper akzeptiert `de`, `en`, `fr`. Dieses Modell weist sie ab und antwortet mit HTTP 400:
@@ -40,6 +43,15 @@ Invalid language 'De'. Supported: Auto, Beijing_Dialect, Chinese, English, Frenc
 Schreib `German` statt `de`. Wenn du einen gemeinsamen Wrapper um beide Audio-Modelle baust, ist das der Parameter, über den du stolperst: Derselbe Wert ist auf der einen Route gültig und wird auf der anderen abgelehnt.
 
 Du kannst `language` auch ganz weglassen. Der Standard ist `Auto`, und der hat in unseren Tests Deutsch und Englisch zuverlässig erkannt.
+
+Ein falscher, aber gültiger Wert ist schlimmer als ein ungültiger, denn er liefert weiter HTTP 200. Deutscher Text mit `language: "English"` kommt als englisch klingender Unsinn zurück:
+
+```text
+Eingabe:    Die Lieferung kommt am Dienstagmorgen an, und die Rechnung wurde bereits an Ihre Adresse geschickt.
+Gesprochen: Deliver on camped on beanstalk market and keongty you were the brights and your addres
+```
+
+`German`, `Auto` und Weglassen liefern alle korrektes Deutsch. Gib also den richtigen Wert an oder gar keinen, und verdrahte in einem Wrapper, der auch deutsche Texte verarbeitet, kein `English` als Standard.
 :::
 
 ## Verfügbare Stimmen
@@ -47,6 +59,22 @@ Du kannst `language` auch ganz weglassen. Der Standard ist `Auto`, und der hat i
 Alle neun funktionieren auf dieser Route. Es gibt keine getrennte Liste für „Custom Voices", die du erst freischalten müsstest.
 
 `aiden`, `dylan`, `eric`, `ono_anna`, `ryan`, `serena`, `sohee`, `uncle_fu`, `vivian`
+
+Jede Stimme spricht jede unterstützte Sprache, und alle neun kamen in unseren Tests auf Deutsch und Englisch verständlich zurück. Wähl also nach dem Klang, nicht nach der Muttersprache der Stimme. Gemessene mittlere Tonhöhe auf englischem Text:
+
+| Stimme     | Muttersprache        | Tonhöhe |
+| ---------- | -------------------- | ------- |
+| `aiden`    | Englisch             | 147 Hz  |
+| `dylan`    | Chinesisch (Peking)  | 164 Hz  |
+| `ryan`     | Englisch             | 171 Hz  |
+| `eric`     | Chinesisch (Sichuan) | 177 Hz  |
+| `uncle_fu` | Chinesisch           | 218 Hz  |
+| `sohee`    | Koreanisch           | 220 Hz  |
+| `serena`   | Chinesisch           | 246 Hz  |
+| `vivian`   | Chinesisch           | 250 Hz  |
+| `ono_anna` | Japanisch            | 264 Hz  |
+
+Zwei Dinge solltest du wissen, bevor du eine Stimme für Deutsch aussuchst. Die Stimmen mit einer anderen Muttersprache haben einen hörbaren Akzent, das ist Geschmackssache und kein Fehler. Und `instructions` wirkt praktisch nur auf englischem Text mit einer englischsprachigen Stimme, siehe [Sprechweise über `instructions` steuern](#stimmfuehrung). Auf Deutsch ist die Stimme selbst also der einzige Hebel, mit dem du den Charakter der Ausgabe steuerst.
 
 `voice` ist in der API selbst optional, das OpenAI-Python-SDK verlangt es aber als Keyword-Argument. Gib es also explizit mit. Ein unbekannter Wert führt zu HTTP 400, die Antwort nennt die gültigen Werte:
 
@@ -75,6 +103,8 @@ Invalid voice 'bob'. Supported: aiden, dylan, eric, ono_anna, ryan, serena, sohe
 ```text
 Input should be 'wav', 'pcm', 'flac', 'mp3' or 'opus'
 ```
+
+Das Audio ist in jedem Format 24 kHz, 16 Bit, mono. Die Lautheit ist nicht normalisiert: Über unseren Testsatz lag der Spitzenpegel zwischen 0,23 und 0,89 der Vollaussteuerung, das sind rund 11 dB zwischen dem leisesten und dem lautesten Clip. Wenn du mehrere Clips hintereinander abspielst, schick sie vorher durch eine Lautheitsnormalisierung.
 
 ## Erste Schritte
 
@@ -154,12 +184,14 @@ curl_close($ch);
 
 ## Empfohlene Parameter
 
-| Parameter         | Wert                 | Wirkung                                                  |
-| ----------------- | -------------------- | -------------------------------------------------------- |
-| `voice`           | einer der neun Namen | Optional. Ohne Angabe die Standardstimme                 |
-| `language`        | `Auto`               | Optional. Setz ihn, wenn der Text Sprachen mischt        |
-| `response_format` | `wav` oder `opus`    | `wav` zum Weiterverarbeiten, `opus` zum Ausliefern       |
-| `speed`           | `1.0`                | Zwischen 0,25 und 4,0, siehe [Sprechtempo](#sprechtempo) |
+| Parameter         | Wert                               | Wirkung                                                                                       |
+| ----------------- | ---------------------------------- | --------------------------------------------------------------------------------------------- |
+| `voice`           | einer der neun Namen               | Optional. Ohne Angabe die Standardstimme                                                      |
+| `language`        | `Auto`                             | Optional. Setz ihn, wenn der Text Sprachen mischt                                             |
+| `response_format` | `wav` oder `opus`                  | `wav` zum Weiterverarbeiten, `opus` zum Ausliefern                                            |
+| `speed`           | `1.0`                              | Zwischen 0,25 und 4,0, siehe [Sprechtempo](#sprechtempo)                                      |
+| `instructions`    | freier Text, höchstens 500 Zeichen | Optional. Beschreibt, wie gesprochen werden soll, siehe [Sprechweise steuern](#stimmfuehrung) |
+| `seed`            | eine ganze Zahl                    | Wird angenommen, reproduziert aber nicht, siehe [Reproduzierbarkeit](#reproduzierbarkeit)     |
 
 ### Sprechtempo {#sprechtempo}
 
@@ -172,6 +204,257 @@ curl_close($ch);
 | `2.0`   | 2,23 s          |
 
 Die Länge schwankt auch bei identischer Eingabe leicht, weil das Modell sampelt. Nimm die Zahlen als Verlauf, nicht als exakte Werte.
+
+Beim Streaming wirkt `speed` nicht. Wenn gestreamtes Audio langsamer oder schneller laufen soll, ändere die Abspielgeschwindigkeit auf deiner Seite.
+
+## Sprechweise über `instructions` steuern {#stimmfuehrung}
+
+Diese Route kennt keine Auszeichnungssprache. Tags in eckigen oder spitzen Klammern und SSML werden nicht ausgewertet. Sie werden entweder vorgelesen oder verschluckt, und was davon passiert, ist nicht vorhersagbar:
+
+| Du schickst                                            | Das Modell sagt                                            |
+| ------------------------------------------------------ | ---------------------------------------------------------- |
+| `[wütend] Die Lieferung kommt am Dienstagmorgen an.`   | „**Wütend.** Die Lieferung kommt am Dienstagmorgen an."    |
+| `[angry] The delivery arrives on Tuesday morning.`     | „**Hey,** the delivery arrives on Tuesday morning."        |
+| `<laugh> The delivery arrives on Tuesday morning.`     | „The delivery arrives on Tuesday morning." (kein Lachen)   |
+| `(excited) The delivery arrives on Tuesday morning!`   | „The delivery arrives on Tuesday morning." (keine Emotion) |
+| `The delivery arrives … <break time="1s"/> Thank you.` | „The delivery arrives … **They** thank you."               |
+
+Nimm die Auszeichnungen aus deinem Text heraus und schreib stattdessen in den Parameter `instructions`, wie die Zeile klingen soll. Ein normaler Satz reicht, höchstens 500 Zeichen. Längere Werte führen zu HTTP 400.
+
+:::warning[`instructions` wirkt auf Englisch, auf Deutsch kaum]
+Auf unserer Hardware gemessen, fünf Durchläufe je Einstellung, englischer Text auf der Stimme `ryan`: Die Tonhöhe bewegt sich zwischen 156 Hz ohne `instructions` und 222 Hz bei „shout", das Sprechtempo zwischen 10,6 Zeichen pro Sekunde bei „whisper" und 18,6 bei „speak very fast and excitedly". Beides geht in die Richtung, die du angibst.
+
+Auf deutschem Text bleibt davon fast nichts übrig. Die Spanne der Tonhöhe über alle Emotionen schrumpft auf 17 Hz, die des Tempos auf 1,1 Zeichen pro Sekunde, und das liegt im Rauschen zwischen zwei Durchläufen. Die Anweisung auf Deutsch zu formulieren ändert daran nichts.
+
+Nimm für Deutsch eine andere `voice` und stell `speed` ein, statt eine Emotion zu beschreiben.
+:::
+
+### Beispiel: Vertonung einer Kundenseite, Abschnitt für Abschnitt
+
+Eine Webagentur baut eine Landingpage für einen Kunden und will jeden Abschnitt vertont haben: eine ruhige Produkteinleitung, einen freundlicheren Absatz zu den Funktionen und einen Call-to-Action mit etwas Druck. Eine Stimme über alle Abschnitte hält es als denselben Sprecher erkennbar, `instructions` ändert die Sprechweise, und `opus` hält die Dateien klein genug, um sie mit der Seite auszuliefern.
+
+`language` und `instructions` gehen unterschiedlich raus: `instructions` ist in den OpenAI-SDKs ein regulärer Parameter, `language` gehört zu diesem Modell und geht deshalb in `extra_body`.
+
+<Tabs groupId="language">
+<TabItem value="python" label="Python">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key="sk-your-api-key-here",
+)
+
+sections = [
+    (
+        "01-intro",
+        "Your hosting, fully managed. No servers to patch and no pager at three in the morning.",
+        "Speak calmly and clearly, like a product narrator.",
+    ),
+    (
+        "02-feature",
+        "Every deploy ships in seconds, and any change is one click away from a rollback.",
+        "Speak in a cheerful, upbeat tone.",
+    ),
+    (
+        "03-cta",
+        "Start your free trial today and put your first site online in ten minutes.",
+        "Speak fast and excitedly, like a short radio advert.",
+    ),
+]
+
+for name, text, instructions in sections:
+    response = client.audio.speech.create(
+        model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        voice="ryan",
+        input=text,
+        instructions=instructions,
+        response_format="opus",
+        extra_body={"language": "English"},
+    )
+    response.write_to_file(f"{name}.opus")
+```
+
+</TabItem>
+<TabItem value="javascript" label="JavaScript">
+
+```javascript
+import OpenAI from "openai";
+import { writeFile } from "node:fs/promises";
+
+const client = new OpenAI({
+  baseURL: "https://llm.aihosting.mittwald.de/v1",
+  apiKey: "sk-your-api-key-here",
+});
+
+const sections = [
+  [
+    "01-intro",
+    "Your hosting, fully managed. No servers to patch and no pager at three in the morning.",
+    "Speak calmly and clearly, like a product narrator.",
+  ],
+  [
+    "02-feature",
+    "Every deploy ships in seconds, and any change is one click away from a rollback.",
+    "Speak in a cheerful, upbeat tone.",
+  ],
+  [
+    "03-cta",
+    "Start your free trial today and put your first site online in ten minutes.",
+    "Speak fast and excitedly, like a short radio advert.",
+  ],
+];
+
+for (const [name, input, instructions] of sections) {
+  const response = await client.audio.speech.create({
+    model: "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice: "ryan",
+    input,
+    instructions,
+    response_format: "opus",
+    // @ts-expect-error language gehört zu diesem Modell
+    language: "English",
+  });
+
+  await writeFile(`${name}.opus`, Buffer.from(await response.arrayBuffer()));
+}
+```
+
+</TabItem>
+<TabItem value="php" label="PHP">
+
+```php
+<?php
+
+$sections = [
+    [
+        "01-intro",
+        "Your hosting, fully managed. No servers to patch and no pager at three in the morning.",
+        "Speak calmly and clearly, like a product narrator.",
+    ],
+    [
+        "02-feature",
+        "Every deploy ships in seconds, and any change is one click away from a rollback.",
+        "Speak in a cheerful, upbeat tone.",
+    ],
+    [
+        "03-cta",
+        "Start your free trial today and put your first site online in ten minutes.",
+        "Speak fast and excitedly, like a short radio advert.",
+    ],
+];
+
+foreach ($sections as [$name, $input, $instructions]) {
+    $payload = [
+        "model" => "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        "voice" => "ryan",
+        "input" => $input,
+        "instructions" => $instructions,
+        "language" => "English",
+        "response_format" => "opus",
+    ];
+
+    $ch = curl_init("https://llm.aihosting.mittwald.de/v1/audio/speech");
+    curl_setopt_array($ch, [
+        CURLOPT_POST => true,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => [
+            "Authorization: Bearer sk-your-api-key-here",
+            "Content-Type: application/json",
+        ],
+        CURLOPT_POSTFIELDS => json_encode($payload),
+    ]);
+
+    file_put_contents("{$name}.opus", curl_exec($ch));
+    curl_close($ch);
+}
+```
+
+</TabItem>
+</Tabs>
+
+Das ergab drei Dateien mit 26 kB, 25 kB und 18 kB, und die Sprechweise folgt den Anweisungen:
+
+| Abschnitt    | Anweisung               | Dauer  | Sprechtempo    |
+| ------------ | ----------------------- | ------ | -------------- |
+| `01-intro`   | ruhiger Produktsprecher | 5,76 s | 14,9 Zeichen/s |
+| `02-feature` | fröhlich, gut gelaunt   | 4,88 s | 16,4 Zeichen/s |
+| `03-cta`     | schnell und begeistert  | 4,24 s | 17,5 Zeichen/s |
+
+Für die deutsche Fassung derselben Seite lass `instructions` weg und variier stattdessen `voice` und `speed`:
+
+```python
+sections_de = [
+    ("de-01-intro", "Dein Hosting, vollständig verwaltet. Keine Server zum Patchen und kein Pager um drei Uhr nachts.", "serena", 0.95),
+    ("de-02-feature", "Jedes Deployment ist in Sekunden ausgerollt, und jede Änderung lässt sich mit einem Klick zurücknehmen.", "serena", 1.0),
+    ("de-03-cta", "Starte heute deine kostenlose Testphase und bring deine erste Website in zehn Minuten online.", "vivian", 1.15),
+]
+
+for name, text, voice, speed in sections_de:
+    response = client.audio.speech.create(
+        model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        voice=voice,
+        input=text,
+        speed=speed,
+        response_format="opus",
+        extra_body={"language": "German"},
+    )
+    response.write_to_file(f"{name}.opus")
+```
+
+Gemessen kamen dabei 12,9, 15,5 und 17,1 Zeichen pro Sekunde heraus, also derselbe Aufbau im Tempo, ohne `instructions`.
+
+## Text für Deutsch aufbereiten {#deutscher-text}
+
+:::warning[Kurze deutsche Texte sind unzuverlässig]
+Unterhalb von etwa 80 Zeichen geht die deutsche Sprachausgabe oft genug daneben, dass es auffällt. Gleiche Stimme, `language: "German"`, sechs Durchläufe je Länge, bewertet durch Rücktranskription:
+
+| Länge der Eingabe | Mittlere Wortfehlerrate | Deutlich falsche Durchläufe |
+| ----------------- | ----------------------- | --------------------------- |
+| 19 Zeichen        | 0,167                   | 2 von 6                     |
+| 58 Zeichen        | 0,259                   | 3 von 6                     |
+| 99 Zeichen        | 0,022                   | 0 von 6                     |
+| 187 Zeichen       | 0,007                   | 0 von 6                     |
+
+Ein Fehlschlag klingt englisch, nicht nach einem Versprecher: Aus „Willkommen bei uns. Wie können wir dir heute weiterhelfen?" wurde „We come in by uns, we come with your heart and vital health." Die Antwort bleibt HTTP 200 und das Audio bleibt technisch einwandfrei, es fällt also nirgends automatisch auf.
+
+Ab etwa 100 Zeichen haben wir das nicht mehr reproduziert. Wenn du kurze deutsche Zeilen erzeugst, also Begrüßungen, Beschriftungen oder einzelne Hinweise, fass entweder mehrere davon in eine Anfrage zusammen und schneide das Audio hinterher, oder hör dir das Ergebnis an, bevor es live geht. Englisch ist bei diesen Längen nicht betroffen.
+:::
+
+Deutsche Texte brauchen einen Durchgang, bevor du sie schickst. Gut geschriebene deutsche Prosa liest das Modell korrekt, aber drei Dinge aus ganz normalen Quelltexten kommen falsch heraus, und keines davon scheitert hörbar am Statuscode.
+
+:::warning[Schick echte Umlaute, kein `ae`, `oe`, `ue`]
+Das ist der größte Qualitätsunterschied, den wir gemessen haben. Derselbe Satz, je zehn Durchläufe, bewertet durch Rücktranskription des Audios und Vergleich mit der Eingabe:
+
+| Schreibweise in der Eingabe                 | Korrekt zurücktranskribiert | Mittlere Wortfehlerrate |
+| ------------------------------------------- | --------------------------- | ----------------------- |
+| `Größere Änderungen an der Übersicht …`     | 10 von 10                   | 0,000                   |
+| `Groessere Aenderungen an der Uebersicht …` | 0 von 10                    | 0,215                   |
+
+Aus „Größere Änderungen" wurden in der umschriebenen Fassung „Gräser Erinnerungen", „Braceränderungen" und „Geißere Änderungen". Wenn dein CMS oder deine Exportstrecke Umlaute ersetzt, stell sie vor der Anfrage wieder her.
+:::
+
+Zweitens: Schreib Abkürzungen und Zahlen aus. Die kurzen Formen, die ein CMS oder ein Sprachmodell liefert, werden falsch gelesen:
+
+| Du schickst                  | Das Modell sagt                       | Schreib stattdessen                                                |
+| ---------------------------- | ------------------------------------- | ------------------------------------------------------------------ |
+| `Bestellung 45312`           | „Bestellung 4FOR 5002"                | `fünfundvierzigtausenddreihundertzwölf`                            |
+| `1.299,99 Euro`              | „1.29,999", „Euro" fällt weg          | `eintausendzweihundertneunundneunzig Euro und neunundneunzig Cent` |
+| `u. a. … z. B. … ggf. inkl.` | „O.A. … setz bei … die geben English" | `unter anderem … zum Beispiel … gegebenenfalls inklusive`          |
+| `GmbH & Co. KG`              | „GmbH & Co, Kagi"                     | `GmbH und Co. KG`                                                  |
+
+Datumsangaben wie `20.05.2026`, Prozentwerte wie `19 %` und Telefonnummern wie `05772 293-100` werden so gelesen, wie sie dastehen. Telefonnummern spricht das Modell Ziffer für Ziffer, das ist richtig, dauert aber: Rechne bei gleicher Zeichenzahl mit etwa der vierfachen Audiolänge gegenüber normaler Prosa.
+
+Englisch ist davon nicht betroffen. `Order 45312 shipped on May 20th, 2026. The total is 1,299.99 euros including 19 percent VAT.` kommt praktisch wortwörtlich zurück.
+
+Drittens: Englische Fachbegriffe mitten im deutschen Satz sind der schwächste Fall, den wir gefunden haben. `Kubernetes-Cluster`, `Continuous Deployment` und `Zero-Downtime-Updates` in einem deutschen Satz kamen teilweise verstümmelt zurück. Eigennamen sind auf dieselbe Weise unzuverlässig, und keine Schreibweise repariert das: Wir haben einen Markennamen normal, umgeschrieben, mit Bindestrich und mit Leerzeichen probiert, dazu `instructions` mit der Bitte um deutsche Aussprache, und 1 von 21 Versuchen kam richtig heraus. Ein Aussprachelexikon gibt es auf dieser Route nicht. Muss ein Name jedes Mal sitzen, lass ihn aus dem vertonten Text heraus oder schneide eine Aufnahme davon ein.
+
+## Reproduzierbarkeit {#reproduzierbarkeit}
+
+`seed` wird angenommen und liefert HTTP 200, aber nicht zweimal dasselbe Audio. Drei identische Anfragen mit `seed: 42` ergaben drei verschiedene Dateien mit 6,64 s, 6,48 s und 6,32 s Länge. Alle drei waren einwandfrei verständlich, das ist also eine Grenze der Reproduzierbarkeit und kein Qualitätsproblem.
+
+Wenn ein Clip über mehrere Deployments hinweg identisch bleiben soll, erzeug ihn einmal und leg die Datei ab.
 
 ## Latenz
 
@@ -288,13 +571,21 @@ Bei sehr langen Texten lohnt sich das Aufteilen trotzdem, denn dann kannst du di
 
 ## Fehlerantworten
 
-| Situation                     | Status | Meldung                                                 |
-| ----------------------------- | ------ | ------------------------------------------------------- |
-| `input` ist ein leerer String | 400    | `Input text cannot be empty`                            |
-| Unbekannte `voice`            | 400    | `Invalid voice '…'. Supported: …`                       |
-| Unbekannte `language`         | 400    | `Invalid language '…'. Supported: …`                    |
-| `response_format="aac"`       | 400    | `Input should be 'wav', 'pcm', 'flac', 'mp3' or 'opus'` |
-| Unbekannter Modellname        | 404    | `The model '…' does not exist.`                         |
+| Situation                                                                    | Status | Meldung                                                            |
+| ---------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------ |
+| `input` ist ein leerer String                                                | 400    | `Input text cannot be empty`                                       |
+| Unbekannte `voice`                                                           | 400    | `Invalid voice '…'. Supported: …`                                  |
+| Unbekannte `language`                                                        | 400    | `Invalid language '…'. Supported: …`                               |
+| `response_format="aac"`                                                      | 400    | `Input should be 'wav', 'pcm', 'flac', 'mp3' or 'opus'`            |
+| `instructions` länger als 500 Zeichen                                        | 400    | `Instructions too long (max 500 characters)`                       |
+| `ref_audio`, `ref_text`, `speaker_embedding` oder `task_type` in der Anfrage | 400    | Voice-Cloning gibt es nicht, siehe [Voice-Cloning](#voice-cloning) |
+| Unbekannter Modellname                                                       | 404    | `The model '…' does not exist.`                                    |
+
+## Voice-Cloning {#voice-cloning}
+
+Eine Stimme aus eigenem Referenz-Audio zu klonen, gibt es hier nicht. Dieses Modell bringt die neun eingebauten Stimmen mit und keinen Speaker-Encoder, es fehlt also das Bauteil, das aus einer Aufnahme deiner Stimme eine sprechbare Stimme machen würde. Anfragen mit `ref_audio`, `ref_text`, `speaker_embedding` oder `task_type` weisen wir mit HTTP 400 ab, statt ein unbrauchbares Ergebnis zu liefern.
+
+Wenn du eine bestimmte Stimme brauchst, arbeite mit den neun vorhandenen: wähl nach Tonhöhe wie unter [Verfügbare Stimmen](#verfügbare-stimmen) beschrieben, und form die Sprechweise über `instructions` und `speed`.
 
 ## Lizenz und Nutzungsbedingungen
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
@@ -48,7 +48,7 @@ Alle neun funktionieren auf dieser Route. Es gibt keine getrennte Liste für „
 
 `aiden`, `dylan`, `eric`, `ono_anna`, `ryan`, `serena`, `sohee`, `uncle_fu`, `vivian`
 
-`voice` ist optional. Ohne Angabe nimmt das Modell seine Standardstimme. Ein unbekannter Wert führt zu HTTP 400, die Antwort nennt die gültigen Werte:
+`voice` ist in der API selbst optional, das OpenAI-Python-SDK verlangt es aber als Keyword-Argument. Gib es also explizit mit. Ein unbekannter Wert führt zu HTTP 400, die Antwort nennt die gültigen Werte:
 
 ```text
 Invalid voice 'bob'. Supported: aiden, dylan, eric, ono_anna, ryan, serena, sohee, uncle_fu, vivian

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
@@ -11,7 +11,7 @@ Im [Text-to-Speech-Guide](../../examples/text-to-speech/) findest du lauffähige
 
 ## Beschreibung
 
-„Qwen3-TTS-12Hz-1.7B-CustomVoice" ist ein Text-to-Speech-Modell von Alibaba mit 1,7 Milliarden Parametern. Du schickst Text hin und bekommst eine Audiodatei zurück. Es ist das Gegenstück zu [Whisper-Large-V3-Turbo](./whisper-large-v3-turbo), das den umgekehrten Weg geht und aus Audio Text macht.
+„Qwen3-TTS-12Hz-1.7B-CustomVoice" ist ein Text-to-Speech-Modell von Alibaba mit 1,7 Milliarden Parametern. Du schickst Text hin und bekommst eine Audiodatei zurück. Es ist das Gegenstück zu [Whisper-Large-V3-Turbo](/docs/v2/platform/aihosting/models/whisper-large-v3-turbo), das den umgekehrten Weg geht und aus Audio Text macht.
 
 Das Modell bedient die Route `/v1/audio/speech` und bringt neun eingebaute Stimmen für dreizehn Sprachen und Dialekte mit. Die Sprachausgabe entsteht schneller als in Echtzeit: Für eine Sekunde Audio braucht das Modell auf unserer Hardware etwa eine achtel Sekunde.
 
@@ -27,7 +27,7 @@ Diese Einschränkungen gelten:
 
 - Voice-Cloning mit eigenem Referenz-Audio ist auf dieser Route nicht verfügbar
 - `response_format="aac"` wird nicht unterstützt, obwohl die OpenAI-API es vorsieht
-- Der Parameter `language` erwartet großgeschriebene Sprachnamen, nicht die ISO-639-1-Codes, die [Whisper](./whisper-large-v3-turbo) verwendet
+- Der Parameter `language` erwartet großgeschriebene Sprachnamen, nicht die ISO-639-1-Codes, die [Whisper](/docs/v2/platform/aihosting/models/whisper-large-v3-turbo) verwendet
 - Das Modell hat keine Chat-Route. `/v1/chat/completions` steht dafür nicht zur Verfügung
 
 :::warning[`language` nimmt hier keine ISO-Codes]
@@ -298,4 +298,4 @@ Bei sehr langen Texten lohnt sich das Aufteilen trotzdem, denn dann kannst du di
 
 ## Lizenz und Nutzungsbedingungen
 
-Alibaba veröffentlicht das Modell unter der Apache-2.0-Lizenz. Bevor du es nutzen kannst, musst du die Nutzungsbedingungen im mStudio annehmen. Siehe [Nutzungsbedingungen](../access-and-usage/terms-of-use/).
+Alibaba veröffentlicht das Modell unter der Apache-2.0-Lizenz. Bevor du es nutzen kannst, musst du die Nutzungsbedingungen im mStudio annehmen. Siehe [Nutzungsbedingungen](../../access-and-usage/terms-of-use/).

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
@@ -231,7 +231,7 @@ Nimm für Deutsch eine andere `voice` und stell `speed` ein, statt eine Emotion 
 
 ### Beispiel: Vertonung einer Kundenseite, Abschnitt für Abschnitt
 
-Eine Webagentur baut eine Landingpage für einen Kunden und will jeden Abschnitt vertont haben: eine ruhige Produkteinleitung, einen freundlicheren Absatz zu den Funktionen und einen Call-to-Action mit etwas Druck. Eine Stimme über alle Abschnitte hält es als denselben Sprecher erkennbar, `instructions` ändert die Sprechweise, und `opus` hält die Dateien klein genug, um sie mit der Seite auszuliefern.
+Eine Webagentur baut eine Landingpage für einen Kunden und will jeden Abschnitt vertont haben: Eine ruhige Produkteinleitung, einen freundlicheren Absatz zu den Funktionen und einen Call-to-Action mit etwas Druck. Eine Stimme über alle Abschnitte hält es als denselben Sprecher erkennbar, `instructions` ändert die Sprechweise, und `opus` hält die Dateien klein genug, um sie mit der Seite auszuliefern.
 
 `language` und `instructions` gehen unterschiedlich raus: `instructions` ist in den OpenAI-SDKs ein regulärer Parameter, `language` gehört zu diesem Modell und geht deshalb in `extra_body`.
 
@@ -589,7 +589,7 @@ Bei sehr langen Texten lohnt sich das Aufteilen trotzdem, denn dann kannst du di
 
 Eine Stimme aus eigenem Referenz-Audio zu klonen, gibt es hier nicht. Dieses Modell bringt die neun eingebauten Stimmen mit und keinen Speaker-Encoder, es fehlt also das Bauteil, das aus einer Aufnahme deiner Stimme eine sprechbare Stimme machen würde. Anfragen mit `ref_audio`, `ref_text`, `speaker_embedding` oder `task_type` weisen wir mit HTTP 400 ab, statt ein unbrauchbares Ergebnis zu liefern.
 
-Wenn du eine bestimmte Stimme brauchst, arbeite mit den neun vorhandenen: wähl nach Tonhöhe wie unter [Verfügbare Stimmen](#verfügbare-stimmen) beschrieben, und form die Sprechweise über `instructions` und `speed`.
+Wenn du eine bestimmte Stimme brauchst, arbeite mit den neun vorhandenen: Wähl nach Tonhöhe wie unter [Verfügbare Stimmen](#verfügbare-stimmen) beschrieben, und form die Sprechweise über `instructions` und `speed`.
 
 ## Lizenz und Nutzungsbedingungen
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/55-qwen3-tts-customvoice.mdx
@@ -472,16 +472,15 @@ Diese Zahlen gelten für eine gepufferte Anfrage, bei der die ganze Datei auf ei
 
 ## Streaming {#streaming}
 
-Setz `stream` auf `true`, dann kommt das erste Audio in deutlich unter einer Sekunde, egal wie lang der Text ist. Gemessen am selben Satz wie in der Tabelle darüber:
+Setz `stream` auf `true` und wähle dazu entweder `stream_format="audio"` oder `stream_format="sse"`. Dann kommt das erste Audio in deutlich unter einer Sekunde, egal wie lang der Text ist. Gemessen am selben Satz wie in der Tabelle darüber:
 
-| Modus                      | Content-Type        | Erster Chunk |
-| -------------------------- | ------------------- | ------------ |
-| gepuffert (Standard)       | `audio/wav`         | 1497 ms      |
-| `"stream": true`           | `text/event-stream` | 175 ms       |
-| `"stream_format": "sse"`   | `text/event-stream` | 57 ms        |
-| `"stream_format": "audio"` | `audio/wav`         | 61 ms        |
+| Modus                   | Content-Type        | Erster Chunk |
+| ----------------------- | ------------------- | ------------ |
+| gepuffert (Standard)    | `audio/wav`         | 1497 ms      |
+| Streaming mit `"sse"`   | `text/event-stream` | 57 ms        |
+| Streaming mit `"audio"` | `audio/wav`         | 61 ms        |
 
-Die beiden SSE-Modi schicken `speech.audio.delta`- und `speech.audio.done`-Events im OpenAI-Format, das Audio steckt Base64-kodiert in jedem Delta. `"stream_format": "audio"` lässt die Event-Hülle weg und liefert rohe Audio-Chunks im angeforderten Format. Das ist der einfachere Weg, wenn du direkt in einen Player schreibst.
+Der SSE-Modus schickt `speech.audio.delta`- und `speech.audio.done`-Events im OpenAI-Format, das Audio steckt Base64-kodiert in jedem Delta. `"stream_format": "audio"` lässt die Event-Hülle weg und liefert rohe Audio-Chunks im angeforderten Format. Das ist der einfachere Weg, wenn du direkt in einen Player schreibst.
 
 <Tabs groupId="language">
 <TabItem value="python" label="Python">
@@ -497,9 +496,10 @@ client = OpenAI(
 with client.audio.speech.with_streaming_response.create(
     model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
     voice="ryan",
-    input="Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+    input="Ein längerer Text, bei dem die Wiedergabe sofort starten soll.",
     response_format="wav",
-    extra_body={"stream_format": "audio"},
+    stream_format="audio",
+    extra_body={"stream": True},
 ) as response:
     response.stream_to_file("ausgabe.wav")
 ```
@@ -511,6 +511,7 @@ with client.audio.speech.with_streaming_response.create(
 import OpenAI from "openai";
 import { createWriteStream } from "node:fs";
 import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
 
 const client = new OpenAI({
   baseURL: "https://llm.aihosting.mittwald.de/v1",
@@ -520,13 +521,16 @@ const client = new OpenAI({
 const response = await client.audio.speech.create({
   model: "Qwen3-TTS-12Hz-1.7B-CustomVoice",
   voice: "ryan",
-  input: "Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+  input: "Ein längerer Text, bei dem die Wiedergabe sofort starten soll.",
   response_format: "wav",
-  // @ts-expect-error stream_format steht noch nicht in den OpenAI-Typen
+  // @ts-expect-error stream wird vom gehosteten Endpunkt unterstützt
+  stream: true,
   stream_format: "audio",
 });
 
-Readable.fromWeb(response.body).pipe(createWriteStream("ausgabe.wav"));
+await finished(
+  Readable.fromWeb(response.body).pipe(createWriteStream("ausgabe.wav")),
+);
 ```
 
 </TabItem>
@@ -538,8 +542,9 @@ Readable.fromWeb(response.body).pipe(createWriteStream("ausgabe.wav"));
 $payload = [
     "model" => "Qwen3-TTS-12Hz-1.7B-CustomVoice",
     "voice" => "ryan",
-    "input" => "Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+    "input" => "Ein längerer Text, bei dem die Wiedergabe sofort starten soll.",
     "response_format" => "wav",
+    "stream" => true,
     "stream_format" => "audio",
 ];
 
@@ -560,7 +565,6 @@ curl_setopt_array($ch, [
 ]);
 
 curl_exec($ch);
-curl_close($ch);
 fclose($out);
 ```
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
@@ -5,18 +5,18 @@ import DocCardList from "@theme/DocCardList";
 
 Wir bieten aktuell die nachfolgenden Modelle an, die sich im Laufe der Zeit ändern oder erweitern können. Diese werden beschrieben und modellspezifische Parameter aufgeführt.
 
-| Modellname                    | Typ                       | Modalitäten                                   | Context (Tokens)    | Lizenz     |
-| ----------------------------- | ------------------------- | --------------------------------------------- | ------------------- | ---------- |
-| gpt-oss-120b                  | Chat + Reasoning          | Text, Tool-Calling                            | 131.072             | Apache 2.0 |
-| Qwen3.5-0.8B                  | Chat + Reasoning          | Text, Tool-Calling                            | 262.144             | Apache 2.0 |
-| Ministral-3-14B-Instruct-2512 | Chat + Vision             | Text, Bild, Tool-Calling                      | 262.144             | Apache 2.0 |
-| Qwen3.5-122B-A10B-FP8         | Chat + Reasoning + Vision | Text, Bild, Tool-Calling                      | 245.760             | Apache 2.0 |
-| Qwen3.6-35B-A3B-FP8           | Chat + Reasoning + Vision | Text, Bild, Tool-Calling                      | 256.000             | Apache 2.0 |
-| Qwen3.8-27B-NVFP4             | Chat + Reasoning + Vision | Text, Bild, Tool-Calling                      | 256.000             | Apache 2.0 |
-| GLM-OCR                       | Dokument OCR              | PDF, DOCX, PPTX, XLSX, HTML, SVG, Bild → Text | 131.072             | MIT        |
-| Qwen3-Embedding-8B            | Embedding                 | Text → Vektor                                 | 32.768              | Apache 2.0 |
-| Qwen3-VL-Reranker-2B          | Reranking                 | Text, Bild → Score                            | 32.768              | Apache 2.0 |
-| whisper-large-v3-turbo        | Speech-to-Text            | Audio → Text                                  | n/a (Audio-basiert) | MIT        |
+| Modellname                      | Typ                       | Modalitäten                                   | Context (Tokens)    | Lizenz     |
+| ------------------------------- | ------------------------- | --------------------------------------------- | ------------------- | ---------- |
+| gpt-oss-120b                    | Chat + Reasoning          | Text, Tool-Calling                            | 131.072             | Apache 2.0 |
+| Qwen3.5-0.8B                    | Chat + Reasoning          | Text, Tool-Calling                            | 262.144             | Apache 2.0 |
+| Ministral-3-14B-Instruct-2512   | Chat + Vision             | Text, Bild, Tool-Calling                      | 262.144             | Apache 2.0 |
+| Qwen3.5-122B-A10B-FP8           | Chat + Reasoning + Vision | Text, Bild, Tool-Calling                      | 245.760             | Apache 2.0 |
+| Qwen3.6-35B-A3B-FP8             | Chat + Reasoning + Vision | Text, Bild, Tool-Calling                      | 256.000             | Apache 2.0 |
+| Qwen3.8-27B-NVFP4               | Chat + Reasoning + Vision | Text, Bild, Tool-Calling                      | 256.000             | Apache 2.0 |
+| GLM-OCR                         | Dokument OCR              | PDF, DOCX, PPTX, XLSX, HTML, SVG, Bild → Text | 131.072             | MIT        |
+| Qwen3-Embedding-8B              | Embedding                 | Text → Vektor                                 | 32.768              | Apache 2.0 |
+| Qwen3-VL-Reranker-2B            | Reranking                 | Text, Bild → Score                            | 32.768              | Apache 2.0 |
+| whisper-large-v3-turbo          | Speech-to-Text            | Audio → Text                                  | n/a (Audio-basiert) | MIT        |
 | Qwen3-TTS-12Hz-1.7B-CustomVoice | Text-to-Speech            | Text → Audio                                  | n/a (Audio-basiert) | Apache 2.0 |
 
 Tool-Calling in dieser Tabelle bezieht sich auf die Unterstützung über `/v1/chat/completions`. Die Unterstützung über `/v1/responses` ist modellspezifisch — die genaue Aufschlüsselung pro Modell findet sich unter [Responses-API-Support](../dedicated/openai-compatibility#responses-api).

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
@@ -17,6 +17,7 @@ Wir bieten aktuell die nachfolgenden Modelle an, die sich im Laufe der Zeit änd
 | Qwen3-Embedding-8B            | Embedding                 | Text → Vektor                                 | 32.768              | Apache 2.0 |
 | Qwen3-VL-Reranker-2B          | Reranking                 | Text, Bild → Score                            | 32.768              | Apache 2.0 |
 | whisper-large-v3-turbo        | Speech-to-Text            | Audio → Text                                  | n/a (Audio-basiert) | MIT        |
+| Qwen3-TTS-12Hz-1.7B-CustomVoice | Text-to-Speech            | Text → Audio                                  | n/a (Audio-basiert) | Apache 2.0 |
 
 Tool-Calling in dieser Tabelle bezieht sich auf die Unterstützung über `/v1/chat/completions`. Die Unterstützung über `/v1/responses` ist modellspezifisch — die genaue Aufschlüsselung pro Modell findet sich unter [Responses-API-Support](../dedicated/openai-compatibility#responses-api).
 
@@ -41,6 +42,8 @@ Tool-Calling in dieser Tabelle bezieht sich auf die Unterstützung über `/v1/ch
     verwende `Qwen3-Embedding-8B`
   - Für alle Transkriptions- oder Sprachbefehl-Anforderungen \
     verwende `whisper-large-v3-turbo`
+  - Zum Vorlesen von Texten, etwa für Sprachantworten, Barrierefreiheit oder Audiofassungen geschriebener Inhalte \
+    verwende `Qwen3-TTS-12Hz-1.7B-CustomVoice`
   - Für eine verbesserte Präzision beim RAG-Retrieval durch einen zweiten Reranking-Schritt nach der Vektorsuche \
     verwende `Qwen3-VL-Reranker-2B`
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/40-api-endpoints/10-supported-endpoints.mdx
@@ -251,3 +251,56 @@ curl -X POST https://llm.aihosting.mittwald.de/v1/audio/transcriptions \
 - Übersetzungsfunktion (`to_language`-Parameter) wird nicht unterstützt
 - Für beste Ergebnisse sollte der `language`-Parameter immer explizit angegeben werden
 - Segmentiere Audiodateien bei Bedarf in Teile kleiner als 25 MB und kürzer als 10 Minuten. Wird die Länge überschritten, kommt HTTP 400 mit `Audio exceeds maximum allowed duration of 600s` zurück. Ein Beispiel dazu im [Spracherkennungs-Guide](../../examples/whisper/#grosse-dateien)
+
+## /v1/audio/speech
+
+Dieser Endpunkt wandelt Text in Sprache um, mit [Qwen3-TTS-12Hz-1.7B-CustomVoice](../../models/qwen3-tts-customvoice/). Er ist das Gegenstück zu `/v1/audio/transcriptions` darüber: Text rein, Audiodatei raus.
+
+```sh
+curl -X POST https://llm.aihosting.mittwald.de/v1/audio/speech \
+    -H "Authorization: Bearer $APIKEY" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+      "input": "Hallo und herzlich willkommen bei mittwald.",
+      "voice": "ryan",
+      "response_format": "mp3"
+    }' \
+    --output willkommen.mp3
+```
+
+Der Antwortkörper ist die Audiodatei selbst, kein JSON. Schreib ihn direkt in eine Datei oder gib ihn an deinen Player weiter. Nur Fehler kommen als JSON zurück.
+
+Der Parameter `input` enthält den zu sprechenden Text und darf nicht leer sein. `model` wählt das TTS-Modell.
+
+Weitere optionale Parameter:
+
+- `voice`: Einer von `aiden`, `dylan`, `eric`, `ono_anna`, `ryan`, `serena`, `sohee`, `uncle_fu`, `vivian`. Ohne Angabe nimmt das Modell seine Standardstimme
+- `response_format`: Einer von `wav` (Standard), `pcm`, `flac`, `mp3`, `opus`. `aac` wird **nicht** unterstützt
+- `language`: Einer von `Auto` (Standard), `Beijing_Dialect`, `Chinese`, `English`, `French`, `German`, `Italian`, `Japanese`, `Korean`, `Portuguese`, `Russian`, `Sichuan_Dialect`, `Spanish`
+- `speed`: Sprechtempo zwischen 0,25 und 4,0, Standard 1,0
+- `stream`: Auf `true` gesetzt kommt das Audio, während es erzeugt wird
+- `stream_format`: `sse` für OpenAI-`speech.audio.*`-Events, `audio` für rohe Audio-Chunks
+
+Streaming senkt die Wartezeit auf das erste Audio von rund 1500 ms auf unter 200 ms. Nimm es immer, wenn jemand auf die Wiedergabe wartet:
+
+```sh
+curl -N -X POST https://llm.aihosting.mittwald.de/v1/audio/speech \
+    -H "Authorization: Bearer $APIKEY" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+      "input": "Ein laengerer Text, bei dem die Wiedergabe sofort starten soll.",
+      "voice": "ryan",
+      "response_format": "wav",
+      "stream_format": "audio"
+    }' \
+    --output ausgabe.wav
+```
+
+**Wichtige Hinweise:**
+
+- Die beiden Audio-Endpunkte erwarten den Parameter `language` in **unterschiedlichen Formaten**. `/v1/audio/transcriptions` will ISO-639-1-Codes wie `de`, `/v1/audio/speech` will großgeschriebene Namen wie `German` und weist `de` mit HTTP 400 ab. Lies die Warnung auf der [Modellseite](../../models/qwen3-tts-customvoice/), bevor du gemeinsamen Code für beide schreibst
+- Ohne Streaming braucht die Erzeugung etwa ein Achtel der angeforderten Abspieldauer, und vorher kommt nichts an
+- Voice-Cloning mit eigenem Referenz-Audio wird auf diesem Endpunkt nicht angeboten
+- Teil lange Texte auf und fordere die Teile einzeln an. Ein ausgearbeitetes Beispiel steht im [Text-to-Speech-Guide](../../examples/text-to-speech/#lange-texte)

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/95-text-to-speech.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/95-text-to-speech.mdx
@@ -6,7 +6,7 @@ title: Sprachausgabe mit Qwen3-TTS
 
 `Qwen3-TTS-12Hz-1.7B-CustomVoice` erreichst du über dieselbe Route `/v1/audio/speech` wie die OpenAI-Speech-API. Code, der für OpenAI geschrieben wurde, funktioniert, wenn du `base_url` änderst. Alle Stimmen, Sprachen, Formate und gemessenen Latenzen stehen auf der [Modellseite zu Qwen3-TTS](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice).
 
-Das ist die Gegenrichtung zur [Spracherkennung mit Whisper](./whisper/): Text rein, Audio raus.
+Das ist die Gegenrichtung zur [Spracherkennung mit Whisper](/docs/v2/platform/aihosting/examples/whisper/): Text rein, Audio raus.
 
 ## Vorbereitung {#vorbereitung}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/95-text-to-speech.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/95-text-to-speech.mdx
@@ -252,5 +252,3 @@ response = client.audio.speech.create(
     response_format="mp3",
 )
 ```
-
-Zwei Unterschiede fallen beim Portieren auf: Die Stimmennamen sind nicht die von OpenAI (`alloy`, `nova` und die anderen gibt es hier nicht), und `response_format="aac"` wird nicht unterstützt.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/95-text-to-speech.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/95-text-to-speech.mdx
@@ -41,7 +41,7 @@ print("geschrieben nach willkommen.mp3")
 
 Ohne Streaming kommt gar nichts an, bis die ganze Datei fertig ist. Bei einem Clip von 26 Sekunden sind das 3 Sekunden Wartezeit. Mit Streaming kommt das erste Audio in deutlich unter einer Sekunde, unabhängig von der Länge. Nimm es also immer, wenn jemand darauf wartet.
 
-`stream_format="audio"` liefert rohe Audio-Chunks im angeforderten Format. Das ist der einfachste Weg, wenn du in eine Datei schreibst oder direkt in einen Player gibst.
+Setz `stream` auf `true`, um Streaming einzuschalten. Wähle dann `stream_format="audio"` für rohe Audio-Chunks im angeforderten Format. Das ist der einfachste Weg, wenn du in eine Datei schreibst oder direkt in einen Player gibst.
 
 ```python
 import os
@@ -56,11 +56,12 @@ with client.audio.speech.with_streaming_response.create(
     model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
     voice="ryan",
     input=(
-        "Dieser Text ist lang genug, dass sich das Warten auf die vollstaendige "
-        "Datei bemerkbar machen wuerde. Mit Streaming beginnt die Wiedergabe sofort."
+        "Dieser Text ist lang genug, dass sich das Warten auf die vollständige "
+        "Datei bemerkbar machen würde. Mit Streaming beginnt die Wiedergabe sofort."
     ),
     response_format="wav",
-    extra_body={"stream_format": "audio"},
+    stream_format="audio",
+    extra_body={"stream": True},
 ) as response:
     response.stream_to_file("ausgabe.wav")
 ```
@@ -226,7 +227,8 @@ with client.audio.speech.with_streaming_response.create(
     voice="serena",
     input=answer,
     response_format="mp3",
-    extra_body={"stream_format": "audio"},
+    stream_format="audio",
+    extra_body={"stream": True},
 ) as speech:
     speech.stream_to_file("antwort.mp3")
 ```

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/95-text-to-speech.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/95-text-to-speech.mdx
@@ -1,0 +1,254 @@
+---
+sidebar_label: Sprachausgabe mit Qwen3-TTS
+description: Sprache aus Text erzeugen mit Qwen3-TTS-12Hz-1.7B-CustomVoice über die OpenAI-kompatible API
+title: Sprachausgabe mit Qwen3-TTS
+---
+
+`Qwen3-TTS-12Hz-1.7B-CustomVoice` erreichst du über dieselbe Route `/v1/audio/speech` wie die OpenAI-Speech-API. Code, der für OpenAI geschrieben wurde, funktioniert, wenn du `base_url` änderst. Alle Stimmen, Sprachen, Formate und gemessenen Latenzen stehen auf der [Modellseite zu Qwen3-TTS](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice).
+
+Das ist die Gegenrichtung zur [Spracherkennung mit Whisper](./whisper/): Text rein, Audio raus.
+
+## Vorbereitung {#vorbereitung}
+
+```shellsession
+user@local $ pip install openai
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+## Einfache Sprachausgabe {#einfach}
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+response = client.audio.speech.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="ryan",
+    input="Hallo und herzlich willkommen bei mittwald.",
+    response_format="mp3",
+)
+
+response.write_to_file("willkommen.mp3")
+print("geschrieben nach willkommen.mp3")
+```
+
+## Streaming, damit die Wiedergabe früher startet {#streaming}
+
+Ohne Streaming kommt gar nichts an, bis die ganze Datei fertig ist. Bei einem Clip von 26 Sekunden sind das 3 Sekunden Wartezeit. Mit Streaming kommt das erste Audio in deutlich unter einer Sekunde, unabhängig von der Länge. Nimm es also immer, wenn jemand darauf wartet.
+
+`stream_format="audio"` liefert rohe Audio-Chunks im angeforderten Format. Das ist der einfachste Weg, wenn du in eine Datei schreibst oder direkt in einen Player gibst.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+with client.audio.speech.with_streaming_response.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="ryan",
+    input=(
+        "Dieser Text ist lang genug, dass sich das Warten auf die vollstaendige "
+        "Datei bemerkbar machen wuerde. Mit Streaming beginnt die Wiedergabe sofort."
+    ),
+    response_format="wav",
+    extra_body={"stream_format": "audio"},
+) as response:
+    response.stream_to_file("ausgabe.wav")
+```
+
+Wenn du stattdessen die Event-Hülle von OpenAI willst, nimm `stream_format="sse"` und lies `speech.audio.delta`-Events, die jeweils Base64-Audio tragen, gefolgt von einem `speech.audio.done`.
+
+## Die passende Stimme finden {#stimmen}
+
+Neun Stimmen kommen mit dem Modell. Erzeug von jeder eine Hörprobe und hör sie dir an, denn die passende hängt von deinen Inhalten ab:
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+VOICES = ["aiden", "dylan", "eric", "ono_anna", "ryan",
+          "serena", "sohee", "uncle_fu", "vivian"]
+
+SAMPLE = "Guten Tag. Dies ist eine Hoerprobe fuer die Sprachausgabe."
+
+for voice in VOICES:
+    response = client.audio.speech.create(
+        model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        voice=voice,
+        input=SAMPLE,
+        response_format="mp3",
+    )
+    response.write_to_file(f"sample_{voice}.mp3")
+    print(f"sample_{voice}.mp3")
+```
+
+Voice-Cloning mit einer eigenen Aufnahme gibt es auf dieser Route nicht. Die neun eingebauten Stimmen sind die vollständige Auswahl.
+
+## Das richtige Ausgabeformat {#formate}
+
+Alle fünf Formate enthalten dasselbe Audio. Sie unterscheiden sich in der Größe, und die zählt, sobald du das Ergebnis über das Netz schickst:
+
+| `response_format` | Größe für 4,5 s Sprache | Wofür                                |
+| ----------------- | ----------------------- | ------------------------------------ |
+| `wav`             | 73 kB                   | Weiterverarbeitung, der Standard     |
+| `pcm`             | 92 kB                   | Rohe Audio-Pipeline                  |
+| `flac`            | 50 kB                   | Verlustfreie Archivierung            |
+| `mp3`             | 15 kB                   | Breite Kompatibilität                |
+| `opus`            | 8,6 kB                  | Auslieferung an Browser oder Telefon |
+
+`aac` wird nicht unterstützt und führt zu HTTP 400.
+
+## Lange Texte {#lange-texte}
+
+Die Erzeugungsdauer wächst mit der Textlänge, ein sehr langer Text wird also eine einzelne lange Anfrage. Wenn du an Satzgrenzen aufteilst, kannst du den ersten Teil schon abspielen, während der Rest noch entsteht, und ein einzelner Fehlschlag bleibt klein.
+
+```python
+import os
+import re
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+
+def split_sentences(text, max_chars=350):
+    """Fasst Saetze zu Bloecken von hoechstens max_chars zusammen."""
+    sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+    chunks, current = [], ""
+    for sentence in sentences:
+        if current and len(current) + len(sentence) + 1 > max_chars:
+            chunks.append(current)
+            current = sentence
+        else:
+            current = f"{current} {sentence}".strip()
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+LONG_TEXT = (
+    "Der erste Satz eroeffnet den Text. "
+    "Der zweite Satz fuehrt den Gedanken weiter und wird etwas laenger. "
+    "Ein dritter Satz schliesst den Absatz ab."
+)
+
+for index, chunk in enumerate(split_sentences(LONG_TEXT)):
+    response = client.audio.speech.create(
+        model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        voice="ryan",
+        input=chunk,
+        response_format="mp3",
+    )
+    response.write_to_file(f"part_{index:03d}.mp3")
+    print(f"part_{index:03d}.mp3  ({len(chunk)} Zeichen)")
+```
+
+Teilst du mitten im Satz, hört man die Naht, weil das Modell die Betonung pro Anfrage neu wählt. Schneide an Satzgrenzen, wie oben.
+
+## Sprechtempo anpassen {#sprechtempo}
+
+`speed` skaliert die Dauer annähernd umgekehrt proportional. Am selben deutschen Satz gemessen:
+
+| `speed` | Dauer  |
+| ------- | ------ |
+| `0.5`   | 9,28 s |
+| `1.0`   | 4,85 s |
+| `2.0`   | 2,23 s |
+
+```python
+response = client.audio.speech.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="ryan",
+    input="Langsam und deutlich gesprochen.",
+    response_format="mp3",
+    speed=0.8,
+)
+```
+
+## Gemischtsprachige Texte {#sprachen}
+
+Der Standard `Auto` erkennt die Sprache und kommt mit Deutsch und Englisch zuverlässig zurecht. Setz `language` explizit, wenn ein Text Sprachen mischt und eine davon gewinnen soll.
+
+```python
+response = client.audio.speech.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="serena",
+    input="Wir deployen das Feature heute, das Rollback-Skript liegt bereit.",
+    response_format="mp3",
+    extra_body={"language": "German"},
+)
+```
+
+Schreib `German`, nicht `de`. Die Transkriptionsroute nimmt ISO-639-1-Codes und diese hier großgeschriebene Namen. Das ist der häufigste Fehler, wenn derselbe Code beide aufruft.
+
+## Eine Modellantwort vorlesen lassen {#chat-pipeline}
+
+Eine häufige Kette: Antwort mit einem Chat-Modell erzeugen, dann sprechen lassen.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+completion = client.chat.completions.create(
+    model="Qwen3.5-0.8B",
+    messages=[
+        {"role": "system", "content": "Antworte in hoechstens drei Saetzen."},
+        {"role": "user", "content": "Was ist ein Reverse Proxy?"},
+    ],
+)
+
+answer = completion.choices[0].message.content
+print(answer)
+
+with client.audio.speech.with_streaming_response.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    voice="serena",
+    input=answer,
+    response_format="mp3",
+    extra_body={"stream_format": "audio"},
+) as speech:
+    speech.stream_to_file("antwort.mp3")
+```
+
+Begrenz die Antwortlänge im System-Prompt. Die Erzeugungsdauer folgt der Textlänge, und eine unbegrenzte Modellantwort wird zu einer unbegrenzten Wartezeit.
+
+## Ersatz für OpenAI {#openai-ersatz}
+
+Es ändern sich nur `base_url`, `api_key` und der Modellname:
+
+```python
+client = OpenAI(
+    base_url="https://llm.aihosting.mittwald.de/v1",   # statt api.openai.com
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+response = client.audio.speech.create(
+    model="Qwen3-TTS-12Hz-1.7B-CustomVoice",           # statt tts-1 oder gpt-4o-mini-tts
+    voice="ryan",                                       # andere Stimmennamen
+    input="Hallo und willkommen.",
+    response_format="mp3",
+)
+```
+
+Zwei Unterschiede fallen beim Portieren auf: Die Stimmennamen sind nicht die von OpenAI (`alloy`, `nova` und die anderen gibt es hier nicht), und `response_format="aac"` wird nicht unterstützt.


### PR DESCRIPTION
Documents **Qwen3-TTS-12Hz-1.7B-CustomVoice**, the first text-to-speech model on the AI hosting platform.

`/v1/audio/speech` is a new route, not just a new model name, so this touches the endpoint reference as well as the model list.

## What's here

| File | |
|---|---|
| `30-models/55-qwen3-tts-customvoice.mdx` | New model page (EN + DE) |
| `50-examples/95-text-to-speech.mdx` | New guide (EN + DE) |
| `30-models/index.mdx` | Table row + model-picking entry (EN + DE) |
| `40-api-endpoints/10-supported-endpoints.mdx` | New `/v1/audio/speech` section (EN + DE) |

## Every number on these pages is measured

Nothing was copied from the model card. All of it came from a running deployment:

- **Nine voices**, each generated and checked: `aiden`, `dylan`, `eric`, `ono_anna`, `ryan`, `serena`, `sohee`, `uncle_fu`, `vivian`
- **Five output formats** work (`wav`, `pcm`, `flac`, `mp3`, `opus`) with the byte sizes shown in the table; `aac` returns 400 even though the OpenAI API defines it
- **Thirteen `language` values**, taken from the API's own rejection message
- **Speed curve**: 0.5 gives 9.28 s, 1.0 gives 4.85 s, 2.0 gives 2.23 s on the same sentence
- **Latency**: 443 ms to first byte at 51 characters, up to 3206 ms at 366, with the ratio flat at about 0.12
- **Streaming**: first chunk at 77–90 ms median against roughly 1500 ms buffered

Twelve of the thirteen documented code paths were executed against the deployment and pass. The thirteenth was an error in my own draft, see below.

## Two traps documented on purpose

1. **`language` takes `German`, not `de`.** The transcription route takes ISO-639-1 codes and this one refuses them with HTTP 400. Anyone wrapping both audio routes in one helper will hit this, so it is a warning admonition on the model page and a bullet on the endpoint page.
2. **Voice cloning is not offered.** This checkpoint ships nine fixed voices and no speaker encoder, so cloning from a reference recording cannot work. The pages state that plainly rather than staying silent about it.

## Corrected while writing

My first draft claimed `/v1/audio/speech` had no streaming, because `httpx.post` buffered the SSE response and I read that as a non-streaming reply. It streams in three modes. Fixed before commit, and the latency section now separates buffered from streamed.

I had also documented `voice` as optional. It is optional at the API level, but the OpenAI Python SDK requires it as a keyword argument, so the examples always pass it.

## Checks

- [x] `npx prettier --write` over all eight files
- [x] EN and DE say the same thing, section for section
- [x] German page has no `slug:`, anchors named in German (`#sprechtempo`, `#lange-texte`)
- [x] `npm run build` clean for both locales, no broken links. Four relative links were wrong in the first draft and are fixed; the remaining broken-anchor warnings are on `containers/` and `openwebui/` and predate this branch