### PR TITLE
docs(aihosting): BFSG accessibility and e-commerce pipeline tutorials

### DIFF
--- a/docs/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
+++ b/docs/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
@@ -15,6 +15,7 @@ import TabItem from "@theme/TabItem";
 It supports and is suitable for:
 
 - Text generation within a chat completion (text to text)
+- Image understanding from Base64 data URLs — descriptions, alt texts, visual classification
 - Tool-calling for agentic workflows
 - Thinking / reasoning for step-by-step problem solving (opt-in)
 - High-throughput, latency-sensitive pipelines
@@ -23,7 +24,8 @@ It supports and is suitable for:
 The following limitations apply:
 
 - Maximum context length: 262,144 tokens
-- No image / vision support
+- Images must be sent as Base64 data URLs — remote image URLs return HTTP 400
+- In multi-image requests only the first image is reliably described — send one image per request
 - Response quality and reasoning depth are lower than larger models
 - Thinking mode is **disabled by default** — opt in per request via `chat_template_kwargs`
 
@@ -189,10 +191,10 @@ category = response.choices[0].message.content.strip()
 
 :::tip Guide ideas
 - **Cascade routing**: Use `Qwen3.5-0.8B` to classify query complexity (simple / code / math / vision), then route to the appropriate tier:
-  - Simple text → `Qwen3.5-0.8B` handles it directly
+  - Simple text or basic vision (descriptions, alt texts) → `Qwen3.5-0.8B` handles it directly
   - Moderate → `Qwen3.6-35B-A3B-FP8` (reasoning + vision, mid cost)
   - Complex / frontier → `Qwen3.5-122B-A10B-FP8`
-  - Vision only → `Ministral-3-14B-Instruct-2512` (cheapest vision model)
+  - Demanding vision → `Ministral-3-14B-Instruct-2512`
 
   A well-tuned cascade can cut costs by 40–80% while maintaining quality on 95% of queries.
 - **Batch pre-processing**: Summarise, extract entities, or tag documents at scale before passing a curated subset to a heavier model.

--- a/docs/platform/aihosting/30-models/index.mdx
+++ b/docs/platform/aihosting/30-models/index.mdx
@@ -8,7 +8,7 @@ We currently offer the following models, which may change or expand over time. E
 | Model Name                      | Type                      | Modalities                                      | Context (Tokens)  | License    |
 | ------------------------------- | ------------------------- | ----------------------------------------------- | ----------------- | ---------- |
 | gpt-oss-120b                    | Chat + reasoning          | Text, tool-calling                              | 131,072           | Apache 2.0 |
-| Qwen3.5-0.8B                    | Chat + reasoning          | Text, tool-calling                              | 262,144           | Apache 2.0 |
+| Qwen3.5-0.8B                    | Chat + reasoning + vision | Text, image, tool-calling                       | 262,144           | Apache 2.0 |
 | Ministral-3-14B-Instruct-2512   | Chat + vision             | Text, image, tool-calling                       | 262,144           | Apache 2.0 |
 | Qwen3.5-122B-A10B-FP8           | Chat + reasoning + vision | Text, image, tool-calling                       | 245,760           | Apache 2.0 |
 | Qwen3.6-35B-A3B-FP8             | Chat + reasoning + vision | Text, image, tool-calling                       | 256,000           | Apache 2.0 |
@@ -25,7 +25,7 @@ Tool-calling in this table reflects support on `/v1/chat/completions`. Support o
 
 - For complex text-centric workloads and advanced automations when precision and vast knowledge are required \
   use `gpt-oss-120b`.
-- For high-throughput, cost-sensitive tasks that don't require vision (e.g. simple Q&A, routing, classification, and batch processing) \
+- For high-throughput, cost-sensitive tasks — simple Q&A, routing, classification, batch processing, and basic image descriptions \
   use `Qwen3.5-0.8B`.
 - For broad, scalable, cost-conscious chat and basic multimodal (text + image) workflows \
   use `Ministral-3-14B-Instruct-2512`.

--- a/docs/platform/aihosting/50-examples/100-bfsg-accessibility.mdx
+++ b/docs/platform/aihosting/50-examples/100-bfsg-accessibility.mdx
@@ -1,0 +1,396 @@
+---
+sidebar_label: BFSG accessibility pipeline
+description: Audit a website for missing alt texts, generate them with Qwen3.5-0.8B, add audio versions with Qwen3-TTS, and ship a human review sheet
+title: BFSG accessibility pipeline
+---
+
+Since 28 June 2025, the [Barrierefreiheitsstärkungsgesetz (BFSG)](https://www.gesetze-im-internet.de/bfsg/) has required consumer-facing websites and shops in Germany to meet accessibility requirements, with fines of up to 100,000 euros for violations. Two of the most common gaps are **images without meaningful alt text** and **no audio alternative for text-heavy pages**.
+
+This guide builds a pipeline that finds both gaps, drafts fixes with mittwald AI Hosting models, and hands the result to a human reviewer — a workflow your agency can run for every client site:
+
+| Stage | Model | What it does |
+| ----- | ----- | ------------ |
+| 1 — Audit | none (plain HTML parsing) | Finds `<img>` tags with missing, empty, or placeholder alt texts |
+| 2 — Alt text | [Qwen3.5-0.8B](/docs/v2/platform/aihosting/models/qwen3-5-0-8b) | Writes a German alt text per image and flags decorative ones |
+| 3 — Audio | [Qwen3-TTS-12Hz-1.7B-CustomVoice](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice) | Reads key pages aloud as Opus files for on-page playback |
+| 4 — Review | human | Signs off every suggestion before anything goes live |
+
+:::note[Scope]
+The BFSG applies to businesses selling goods or services to consumers; very small companies (fewer than 10 employees and under 2 million euros annual turnover) are exempt. This guide is engineering documentation, not legal advice — check whether a given client is in scope before quoting a compliance project.
+:::
+
+The pipeline runs against a local copy of the site's HTML, so you never point it at a live client site while testing.
+
+## Setup {#setup}
+
+```shellsession
+user@local $ pip install openai beautifulsoup4 pillow
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+Create a small fixture site to work on. Two pages are enough to exercise every stage:
+
+```html
+<!-- site/index.html -->
+<!DOCTYPE html>
+<html lang="de">
+<head><meta charset="utf-8"><title>Garten &amp; Wohnen</title></head>
+<body>
+<h1>Ihr Shop fuer Garten und Wohnen</h1>
+<p>Willkommen bei uns! Entdecken Sie ueber 500 Produkte.</p>
+<img src="img/hund.jpg">
+<img src="img/kanu.jpg" alt="">
+<img src="img/robbe.jpg" alt="Bild1">
+<img src="logo.png" alt="Garten und Wohnen Logo">
+</body>
+</html>
+```
+
+```html
+<!-- site/kontakt.html -->
+<!DOCTYPE html>
+<html lang="de">
+<head><meta charset="utf-8"><title>Kontakt</title></head>
+<body>
+<h1>Kontakt</h1>
+<p>Sie erreichen uns moeglichst werktags zwischen neun und sechzehn Uhr unter der
+Telefonnummer 05772 293-100. Schreiben Sie uns auch gerne eine E-Mail an
+info@example-shop.de. Unser Team antwortet in der Regel innerhalb eines
+Werktages auf Ihre Anfrage.</p>
+<img src="img/team.jpg">
+</body>
+</html>
+```
+
+Put real JPEGs into `site/img/` (any photos do). Note what the fixture deliberately contains: an image with **no** `alt` attribute, one with an **empty** `alt` (decorative), one with a **placeholder** alt (`Bild1`), one with a good alt, and a referenced image whose file is missing. Old client sites typically spell German without umlauts (`fuer`, `ueber`) — the fixture keeps that on purpose.
+
+## Stage 1 — Audit: find the broken images {#stage-audit}
+
+Parse every HTML file and classify each `<img>`:
+
+```python
+import base64
+import io
+import os
+import re
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+from PIL import Image
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+SITE = Path("site")
+BAD_ALT_RE = re.compile(r"^(bild|foto|image|picture|abbildung)\s*\d*$", re.I)
+
+
+def encode_image(path: Path, max_px: int = 1024) -> str:
+    """Resize to max_px on the longest edge and return a Base64 data URL."""
+    with Image.open(path) as img:
+        w, h = img.size
+        scale = min(1.0, max_px / max(w, h))
+        if scale < 1.0:
+            img = img.resize((int(w * scale), int(h * scale)), Image.LANCZOS)
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=85)
+        b64 = base64.b64encode(buf.getvalue()).decode()
+    return f"data:image/jpeg;base64,{b64}"
+
+
+def audit_site(site: Path) -> list[dict]:
+    """Find every <img> in the site and classify its alt attribute."""
+    findings = []
+    for html_file in sorted(site.glob("**/*.html")):
+        soup = BeautifulSoup(html_file.read_text(encoding="utf-8"), "html.parser")
+        for tag in soup.find_all("img"):
+            src = tag.get("src", "")
+            alt = tag.get("alt")
+            if alt is None:
+                status = "missing"
+            elif alt.strip() == "":
+                status = "empty"          # intentional: decorative image
+            elif BAD_ALT_RE.match(alt.strip()) or len(alt.strip()) < 5:
+                status = "bad"
+            else:
+                status = "ok"
+            findings.append({
+                "page": html_file.name,
+                "src": src,
+                "alt": alt,
+                "status": status,
+                "path": (html_file.parent / src).resolve(),
+            })
+    return findings
+```
+
+An empty `alt=""` is **not** a defect — it is the correct way to mark a decorative image, so the audit keeps it as-is. Running the audit on the fixture:
+
+```text
+missing  index.html      img/hund.jpg    alt=None
+empty    index.html      img/kanu.jpg    alt=''
+bad      index.html      img/robbe.jpg   alt='Bild1'
+ok       index.html      logo.png        alt='Garten und Wohnen Logo'
+missing  kontakt.html    img/team.jpg    alt=None
+```
+
+For a real client site, fetch the pages with `requests` first and store them under `site/` — the rest of the pipeline works on local files, which keeps re-runs cheap and reproducible.
+
+## Stage 2 — Alt texts: one image per request {#stage-alt-texts}
+
+Send each flagged image to `Qwen3.5-0.8B` with a strict output contract. The prompt is in German on purpose: the model writes German alt texts, and the measured output quality is better when the rules are stated in the target language.
+
+```python
+ALT_MODEL = "Qwen3.5-0.8B"
+
+ALT_PROMPT = (
+    "Du bist Accessibility-Experte und schreibst Alt-Texte auf Deutsch. "
+    "Regeln: maximal 125 Zeichen, kein 'Bild von' oder 'Foto von', "
+    "Inhalt und Zweck beschreiben, keine Stilangaben (Farben, Licht), "
+    "keine Spekulationen. Ein Bild ist nur dekorativ, wenn es eindeutig ziert "
+    "(Hintergrundmuster, Trennlinie, Logo neben gleichlautendem Text). "
+    "Im Zweifel gilt: informativ. "
+    "Antworte nur mit JSON: {\"decorative\": true/false, \"alt\": \"...\"}."
+)
+
+
+def generate_alt(image_path: Path, context: str = "") -> dict:
+    """One image per request — see the multi-image note below."""
+    content = [{"type": "image_url", "image_url": {"url": encode_image(image_path)}}]
+    if context:
+        content.insert(0, {"type": "text", "text": f"Das Bild steht auf der Seite '{context}'."})
+    content.append({"type": "text", "text": ALT_PROMPT})
+    resp = client.chat.completions.create(
+        model=ALT_MODEL,
+        messages=[{"role": "user", "content": content}],
+        temperature=0.3,
+        max_tokens=300,
+    )
+    raw = resp.choices[0].message.content.strip()
+    raw = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw)
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError:
+        # small models occasionally answer in plain text — treat it as the alt text
+        result = {"decorative": False, "alt": raw[:125]}
+    return {
+        "decorative": bool(result.get("decorative")),
+        "alt": str(result.get("alt", ""))[:125],
+        "usage": resp.usage.total_tokens,
+    }
+```
+
+:::warning[Do not batch multiple images into one request]
+We tested sending three images in a single message and asking for one alt text each. In every run, the model described only the first image and stopped. Send one image per request and loop — that is what the stage-4 driver below does.
+:::
+
+Images must be Base64 data URLs; remote image URLs are rejected with HTTP 400. See [Encoding and resizing images](/docs/v2/platform/aihosting/examples/python#vision-encoding) for the general pattern.
+
+### Choosing the model {#model-choice}
+
+`Qwen3.5-0.8B` is the cheapest model in the catalogue and handles standard product and team photos well, but it is a small model. On the same fixture images, side by side:
+
+| Image | `Qwen3.5-0.8B` | `Ministral-3-14B-Instruct-2512` |
+| ----- | -------------- | ------------------------------- |
+| Puppy on wooden floor | "Ein schwarzer Labrador-Pudel sitzt auf einer Holzplatte und blickt nach oben." | "Schwarzer Labradorwelpe mit aufmerksamen Augen sitzt auf Holzuntergrund." |
+| Walruses on a beach | "Walder auf Sand" | "Zwei Walrosse auf sandigem Untergrund mit typischen Stoßzähnen und faltiger Haut, ruhend am Strand." |
+
+If a page carries hero imagery where wording matters, switch `ALT_MODEL` to `Ministral-3-14B-Instruct-2512` for those images. Either way, nothing ships without the review stage.
+
+## Stage 3 — Audio versions for key pages {#stage-audio}
+
+Not every page needs an audio version — pick the ones visitors actually read: home, contact, shipping terms, imprint. Extract their visible text, prepare it for German speech synthesis, and render it with [Qwen3-TTS](/docs/v2/platform/aihosting/examples/text-to-speech).
+
+```python
+import json
+
+TTS_MODEL = "Qwen3-TTS-12Hz-1.7B-CustomVoice"
+VOICE = "serena"
+
+
+def restore_umlauts(text: str) -> str:
+    """Restore umlauts stripped by old CMS exports. Heuristic — review the result."""
+    for ascii_form, umlaut in (("AE", "Ä"), ("OE", "Ö"), ("UE", "Ü"),
+                               ("ae", "ä"), ("oe", "ö"), ("ue", "ü")):
+        text = text.replace(ascii_form, umlaut)
+    return text
+
+
+def prepare_german_text(text: str) -> str:
+    """Apply the German TTS preparation rules from the Qwen3-TTS model page."""
+    text = text.replace("&amp;", "und").replace("&", "und")
+    text = re.sub(r"\s+", " ", text).strip()
+    return restore_umlauts(text)
+
+
+def chunk_sentences(text: str, min_chars: int = 100, max_chars: int = 350) -> list[str]:
+    """Group sentences into chunks of at least min_chars (short German lines are unreliable)."""
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    chunks, current = [], ""
+    for sentence in sentences:
+        if current and len(current) + len(sentence) + 1 > max_chars:
+            chunks.append(current)
+            current = sentence
+        else:
+            current = f"{current} {sentence}".strip()
+    if current:
+        chunks.append(current)
+    # merge a trailing short chunk into the previous one
+    if len(chunks) > 1 and len(chunks[-1]) < min_chars:
+        chunks[-2] = f"{chunks[-2]} {chunks[-1]}"
+        chunks.pop()
+    return chunks
+
+
+def synthesize_page(page_name: str, body_text: str, out_dir: Path) -> list[Path]:
+    prepared = prepare_german_text(body_text)
+    files = []
+    for i, chunk in enumerate(chunk_sentences(prepared)):
+        out = out_dir / f"{page_name}_{i:02d}.opus"
+        response = client.audio.speech.create(
+            model=TTS_MODEL,
+            voice=VOICE,
+            input=chunk,
+            response_format="opus",
+            extra_body={"language": "German"},
+        )
+        response.write_to_file(out)
+        files.append(out)
+    return files
+```
+
+Three things in `prepare_german_text` and `chunk_sentences` come straight from the measurements on the [Qwen3-TTS model page](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice#german-text):
+
+- **Real umlauts, not `ae`/`oe`/`ue`.** Transliterated German comes out badly wrong (average word error rate 0.215 vs 0.000 with real umlauts in our tests). The `restore_umlauts` step is a heuristic — words like "Duell" become "Düell" — which is another reason the review stage exists.
+- **Chunks of at least ~100 characters.** Below roughly 80 characters, German synthesis fails often enough to matter, and the failure sounds like fluent English.
+- **Numbers and abbreviations.** Dates and percentages are read correctly as written, but order numbers and prices are not. Expand them in the source text or accept that the spoken version will stumble — the reviewer hears this.
+
+Use `opus` for on-page playback: it is roughly a tenth of the size of `wav` at speech quality. Loudness is not normalised across clips, so if a page plays several clips back to back, run them through a loudness normaliser first. Voice choice is a taste call — `serena` and `vivian` are the higher-pitched voices, see [Choosing a voice](/docs/v2/platform/aihosting/examples/text-to-speech#voices).
+
+On the fixture, the contact page (258 characters including a phone number) renders to a 24.7-second Opus file in a single request:
+
+```text
+kontakt.html: 259 chars -> 1 chunks
+  [258 chars] -> kontakt_00.opus (106 kB)
+```
+
+Phone numbers are spoken digit by digit, which is correct but slow — budget roughly four times the audio length of ordinary prose for the same character count.
+
+## Stage 4 — Human review {#stage-review}
+
+Generate a review sheet that a person signs off line by line. This step is not optional: the stage-2 model produced "Walder auf Sand" for a walrus photo, and an accessibility feature that misdescribes content is worse than none.
+
+```python
+def write_review_sheet(findings: list[dict], results: dict, audio: dict, out: Path) -> None:
+    lines = [
+        "# Review — Barrierefreiheit (BFSG)",
+        "",
+        "Bitte jeden Vorschlag prüfen, bevor er live geht. AI-Alt-Texte können falsch sein.",
+        "",
+        "| | Seite | Datei | Aktueller Alt | Vorschlag | OK? |",
+        "|---|-------|-------|---------------|-----------|-----|",
+    ]
+    for f in findings:
+        if f["status"] == "ok":
+            continue
+        key = f"{f['page']}::{f['src']}"
+        r = results.get(key)
+        if f["status"] == "empty":
+            suggestion = "(dekorativ — leer lassen)"
+        elif r is None:
+            suggestion = "(nicht generiert — Datei fehlt?)"
+        elif r["decorative"]:
+            suggestion = '"" (dekorativ)'
+        else:
+            suggestion = f'"{r["alt"]}"'
+        lines.append(f"| [ ] | {f['page']} | {f['src']} | `{f['alt']}` | {suggestion} | ☐ |")
+    lines += ["", "## Audio-Versionen", ""]
+    for page, files in audio.items():
+        for fp in files:
+            lines.append(f"- {page}: {fp.name} ({fp.stat().st_size // 1024} kB)")
+    lines.append("")
+    out.write_text("\n".join(lines), encoding="utf-8")
+```
+
+The sheet for the fixture:
+
+```markdown
+# Review — Barrierefreiheit (BFSG)
+
+Bitte jeden Vorschlag prüfen, bevor er live geht. AI-Alt-Texte können falsch sein.
+
+| | Seite | Datei | Aktueller Alt | Vorschlag | OK? |
+|---|-------|-------|---------------|-----------|-----|
+| [ ] | index.html | img/hund.jpg | `None` | "" (dekorativ) | ☐ |
+| [ ] | index.html | img/kanu.jpg | `` | (dekorativ — leer lassen) | ☐ |
+| [ ] | index.html | img/robbe.jpg | `Bild1` | "" (dekorativ) | ☐ |
+| [ ] | kontakt.html | img/team.jpg | `None` | (nicht generiert — Datei fehlt?) | ☐ |
+
+## Audio-Versionen
+
+- index.html: index_00.opus (30 kB)
+- kontakt.html: kontakt_00.opus (106 kB)
+```
+
+After sign-off, apply the accepted alt texts to the HTML (or hand the sheet to the client's CMS editor) and serve the Opus files next to the pages they belong to. Re-running the audit afterwards should report only `ok` and deliberate `empty` entries.
+
+## Full pipeline {#full-pipeline}
+
+```python
+def main():
+    print("== Stage 1: audit ==")
+    findings = audit_site(SITE)
+    for f in findings:
+        print(f"  {f['status']:8s} {f['page']:15s} {f['src']:15s} alt={f['alt']!r}")
+
+    print("\n== Stage 2: alt texts ==")
+    results = {}
+    for f in findings:
+        if f["status"] not in ("missing", "bad"):
+            continue
+        key = f"{f['page']}::{f['src']}"
+        if not f["path"].exists():
+            print(f"  SKIP {key} (file not found)")
+            continue
+        r = generate_alt(f["path"], context=f["page"])
+        results[key] = r
+        print(f"  {key}: decorative={r['decorative']} alt={r['alt']!r} ({r['usage']} tokens)")
+
+    print("\n== Stage 3: audio versions ==")
+    audio = {}
+    for page in ("index.html", "kontakt.html"):
+        soup = BeautifulSoup((SITE / page).read_text(encoding="utf-8"), "html.parser")
+        text = " ".join(p.get_text() for p in soup.find_all(["h1", "p"]))
+        out_dir = Path("audio") / page.replace(".html", "")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        audio[page] = synthesize_page(page, text, out_dir)
+        for fp in audio[page]:
+            print(f"  {page} -> {fp} ({fp.stat().st_size // 1024} kB)")
+
+    print("\n== Stage 4: review sheet ==")
+    write_review_sheet(findings, results, audio, Path("REVIEW.md"))
+    print("  wrote REVIEW.md")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## Cost profile {#cost-profile}
+
+Measured on the public gateway with an 800×600 JPEG:
+
+| Call | Tokens / size | Notes |
+| ---- | ------------- | ----- |
+| One alt text (`Qwen3.5-0.8B`) | ~640 total (~475 multimodal) | ~0.7 s round trip |
+| One alt text (`Ministral-3-14B-Instruct-2512`) | ~725 total | ~0.6 s round trip |
+| One audio chunk (~260 chars, `opus`) | 106 kB file, 24.7 s of audio | ~2 s generation |
+
+A 100-image client site costs roughly 60,000 tokens of `Qwen3.5-0.8B` traffic plus a handful of TTS requests for the key pages. `Qwen3.5-0.8B` is the most cost-efficient model in the catalogue, which is what makes a per-site audit a billable line item instead of a manual afternoon.
+
+## Limitations {#limitations}
+
+- **Human review is part of the process.** Small-model alt texts contain errors (see the walrus example), the umlaut restoration is a heuristic, and only a person can judge whether an image is decorative in context.
+- **The audit covers `<img>` tags.** Background images in CSS, SVGs with embedded text, and video without captions are not checked — extend `audit_site` for those if the client site uses them.
+- **Audio versions cover the pages you choose.** The BFSG does not require every page to have an audio alternative; picking the text-heavy ones is a sensible interpretation, not a guarantee.
+- **Nothing here is legal advice.** Scope, exemptions, and penalties belong in a conversation with the client's counsel.

--- a/docs/platform/aihosting/50-examples/100-bfsg-accessibility.mdx
+++ b/docs/platform/aihosting/50-examples/100-bfsg-accessibility.mdx
@@ -8,12 +8,12 @@ Since 28 June 2025, the [Barrierefreiheitsstärkungsgesetz (BFSG)](https://www.g
 
 This guide builds a pipeline that finds both gaps, drafts fixes with mittwald AI Hosting models, and hands the result to a human reviewer — a workflow your agency can run for every client site:
 
-| Stage | Model | What it does |
-| ----- | ----- | ------------ |
-| 1 — Audit | none (plain HTML parsing) | Finds `<img>` tags with missing, empty, or placeholder alt texts |
-| 2 — Alt text | [Qwen3.5-0.8B](/docs/v2/platform/aihosting/models/qwen3-5-0-8b) | Writes a German alt text per image and flags decorative ones |
-| 3 — Audio | [Qwen3-TTS-12Hz-1.7B-CustomVoice](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice) | Reads key pages aloud as Opus files for on-page playback |
-| 4 — Review | human | Signs off every suggestion before anything goes live |
+| Stage        | Model                                                                                       | What it does                                                     |
+| ------------ | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| 1 — Audit    | none (plain HTML parsing)                                                                   | Finds `<img>` tags with missing, empty, or placeholder alt texts |
+| 2 — Alt text | [Qwen3.5-0.8B](/docs/v2/platform/aihosting/models/qwen3-5-0-8b)                             | Writes a German alt text per image and flags decorative ones     |
+| 3 — Audio    | [Qwen3-TTS-12Hz-1.7B-CustomVoice](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice) | Reads key pages aloud as Opus files for on-page playback         |
+| 4 — Review   | human                                                                                       | Signs off every suggestion before anything goes live             |
 
 :::note[Scope]
 The BFSG applies to businesses selling goods or services to consumers; very small companies (fewer than 10 employees and under 2 million euros annual turnover) are exempt. This guide is engineering documentation, not legal advice — check whether a given client is in scope before quoting a compliance project.
@@ -34,15 +34,18 @@ Create a small fixture site to work on. Two pages are enough to exercise every s
 <!-- site/index.html -->
 <!DOCTYPE html>
 <html lang="de">
-<head><meta charset="utf-8"><title>Garten &amp; Wohnen</title></head>
-<body>
-<h1>Ihr Shop fuer Garten und Wohnen</h1>
-<p>Willkommen bei uns! Entdecken Sie ueber 500 Produkte.</p>
-<img src="img/hund.jpg">
-<img src="img/kanu.jpg" alt="">
-<img src="img/robbe.jpg" alt="Bild1">
-<img src="logo.png" alt="Garten und Wohnen Logo">
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Garten &amp; Wohnen</title>
+  </head>
+  <body>
+    <h1>Ihr Shop fuer Garten und Wohnen</h1>
+    <p>Willkommen bei uns! Entdecken Sie ueber 500 Produkte.</p>
+    <img src="img/hund.jpg" />
+    <img src="img/kanu.jpg" alt="" />
+    <img src="img/robbe.jpg" alt="Bild1" />
+    <img src="logo.png" alt="Garten und Wohnen Logo" />
+  </body>
 </html>
 ```
 
@@ -50,15 +53,20 @@ Create a small fixture site to work on. Two pages are enough to exercise every s
 <!-- site/kontakt.html -->
 <!DOCTYPE html>
 <html lang="de">
-<head><meta charset="utf-8"><title>Kontakt</title></head>
-<body>
-<h1>Kontakt</h1>
-<p>Sie erreichen uns moeglichst werktags zwischen neun und sechzehn Uhr unter der
-Telefonnummer 05772 293-100. Schreiben Sie uns auch gerne eine E-Mail an
-info@example-shop.de. Unser Team antwortet in der Regel innerhalb eines
-Werktages auf Ihre Anfrage.</p>
-<img src="img/team.jpg">
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Kontakt</title>
+  </head>
+  <body>
+    <h1>Kontakt</h1>
+    <p>
+      Sie erreichen uns moeglichst werktags zwischen neun und sechzehn Uhr unter
+      der Telefonnummer 05772 293-100. Schreiben Sie uns auch gerne eine E-Mail
+      an info@example-shop.de. Unser Team antwortet in der Regel innerhalb eines
+      Werktages auf Ihre Anfrage.
+    </p>
+    <img src="img/team.jpg" />
+  </body>
 </html>
 ```
 
@@ -140,7 +148,7 @@ For a real client site, fetch the pages with `requests` first and store them und
 
 Send each flagged image to `Qwen3.5-0.8B` with a strict output contract. The prompt is in German on purpose: the model writes German alt texts, and the measured output quality is better when the rules are stated in the target language.
 
-```python
+````python
 ALT_MODEL = "Qwen3.5-0.8B"
 
 ALT_PROMPT = (
@@ -178,7 +186,7 @@ def generate_alt(image_path: Path, context: str = "") -> dict:
         "alt": str(result.get("alt", ""))[:125],
         "usage": resp.usage.total_tokens,
     }
-```
+````
 
 :::warning[Do not batch multiple images into one request]
 We tested sending three images in a single message and asking for one alt text each. In every run, the model described only the first image and stopped. Send one image per request and loop — that is what the stage-4 driver below does.
@@ -190,10 +198,10 @@ Images must be Base64 data URLs; remote image URLs are rejected with HTTP 400. S
 
 `Qwen3.5-0.8B` is the cheapest model in the catalogue and handles standard product and team photos well, but it is a small model. On the same fixture images, side by side:
 
-| Image | `Qwen3.5-0.8B` | `Ministral-3-14B-Instruct-2512` |
-| ----- | -------------- | ------------------------------- |
-| Puppy on wooden floor | "Ein schwarzer Labrador-Pudel sitzt auf einer Holzplatte und blickt nach oben." | "Schwarzer Labradorwelpe mit aufmerksamen Augen sitzt auf Holzuntergrund." |
-| Walruses on a beach | "Walder auf Sand" | "Zwei Walrosse auf sandigem Untergrund mit typischen Stoßzähnen und faltiger Haut, ruhend am Strand." |
+| Image                 | `Qwen3.5-0.8B`                                                                  | `Ministral-3-14B-Instruct-2512`                                                                       |
+| --------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Puppy on wooden floor | "Ein schwarzer Labrador-Pudel sitzt auf einer Holzplatte und blickt nach oben." | "Schwarzer Labradorwelpe mit aufmerksamen Augen sitzt auf Holzuntergrund."                            |
+| Walruses on a beach   | "Walder auf Sand"                                                               | "Zwei Walrosse auf sandigem Untergrund mit typischen Stoßzähnen und faltiger Haut, ruhend am Strand." |
 
 If a page carries hero imagery where wording matters, switch `ALT_MODEL` to `Ministral-3-14B-Instruct-2512` for those images. Either way, nothing ships without the review stage.
 
@@ -319,12 +327,12 @@ The sheet for the fixture:
 
 Bitte jeden Vorschlag prüfen, bevor er live geht. AI-Alt-Texte können falsch sein.
 
-| | Seite | Datei | Aktueller Alt | Vorschlag | OK? |
-|---|-------|-------|---------------|-----------|-----|
-| [ ] | index.html | img/hund.jpg | `None` | "" (dekorativ) | ☐ |
-| [ ] | index.html | img/kanu.jpg | `` | (dekorativ — leer lassen) | ☐ |
-| [ ] | index.html | img/robbe.jpg | `Bild1` | "" (dekorativ) | ☐ |
-| [ ] | kontakt.html | img/team.jpg | `None` | (nicht generiert — Datei fehlt?) | ☐ |
+|     | Seite        | Datei         | Aktueller Alt | Vorschlag                        | OK? |
+| --- | ------------ | ------------- | ------------- | -------------------------------- | --- |
+| [ ] | index.html   | img/hund.jpg  | `None`        | "" (dekorativ)                   | ☐   |
+| [ ] | index.html   | img/kanu.jpg  | ``            | (dekorativ — leer lassen)        | ☐   |
+| [ ] | index.html   | img/robbe.jpg | `Bild1`       | "" (dekorativ)                   | ☐   |
+| [ ] | kontakt.html | img/team.jpg  | `None`        | (nicht generiert — Datei fehlt?) | ☐   |
 
 ## Audio-Versionen
 
@@ -380,11 +388,11 @@ if __name__ == "__main__":
 
 Measured on the public gateway with an 800×600 JPEG:
 
-| Call | Tokens / size | Notes |
-| ---- | ------------- | ----- |
-| One alt text (`Qwen3.5-0.8B`) | ~640 total (~475 multimodal) | ~0.7 s round trip |
-| One alt text (`Ministral-3-14B-Instruct-2512`) | ~725 total | ~0.6 s round trip |
-| One audio chunk (~260 chars, `opus`) | 106 kB file, 24.7 s of audio | ~2 s generation |
+| Call                                           | Tokens / size                | Notes             |
+| ---------------------------------------------- | ---------------------------- | ----------------- |
+| One alt text (`Qwen3.5-0.8B`)                  | ~640 total (~475 multimodal) | ~0.7 s round trip |
+| One alt text (`Ministral-3-14B-Instruct-2512`) | ~725 total                   | ~0.6 s round trip |
+| One audio chunk (~260 chars, `opus`)           | 106 kB file, 24.7 s of audio | ~2 s generation   |
 
 A 100-image client site costs roughly 60,000 tokens of `Qwen3.5-0.8B` traffic plus a handful of TTS requests for the key pages. `Qwen3.5-0.8B` is the most cost-efficient model in the catalogue, which is what makes a per-site audit a billable line item instead of a manual afternoon.
 

--- a/docs/platform/aihosting/50-examples/110-ecommerce-product-pipeline.mdx
+++ b/docs/platform/aihosting/50-examples/110-ecommerce-product-pipeline.mdx
@@ -1,0 +1,354 @@
+---
+sidebar_label: E-commerce product pipeline
+description: Turn product photos into German names, descriptions, tags and alt texts with Qwen3.8-27B-NVFP4 and push them into Shopware via the Admin API
+title: E-commerce product pipeline
+---
+
+New products arrive at agencies as photos — usually without any metadata. Someone shoots or downloads a picture, drops it into a folder, and the shop team has to write the name, description, tags and alt text by hand. This guide builds a pipeline that does that step automatically with [Qwen3.8-27B-NVFP4](/docs/v2/platform/aihosting/models/qwen3-8-27b-nvfp4) and writes the result into a running Shopware instance:
+
+| Stage | Model | What it does |
+| ----- | ----- | ------------ |
+| 1 — Generate | [Qwen3.8-27B-NVFP4](/docs/v2/platform/aihosting/models/qwen3-8-27b-nvfp4) | Writes a German product name, description, tags and an image alt text per photo (strict JSON contract) |
+| 2 — Review | human | Signs off every text before anything goes live |
+| 3 — Push | none (Shopware Admin API) | Creates tags, uploads the media and creates the product with SEO fields |
+
+:::note[Scope]
+The pipeline targets **Shopware 6.6 LTS** (tested on 6.6.10). Catalog writes go through the **Admin API**, not the Store-API — the Store-API serves the storefront (reads, cart, checkout) and exposes no product-write routes. If your client runs an older 6.x version, the same endpoints exist under the `/api/v2` prefix; everything else in this guide is unchanged.
+:::
+
+## Setup {#setup}
+
+```shellsession
+user@local $ pip install openai pillow requests
+```
+
+You need two things: access to the vision model and a Shopware instance with integration credentials.
+
+For the model, use the playground gateway until Qwen3.8 lands on the public gateway — the base URL below needs no API key:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="https://qwen3-8-27b-nvfp4.llm-1.m3.services/v1", api_key="x")
+VISION_MODEL = "Qwen3.8-27B-NVFP4"
+```
+
+For Shopware, create an integration in the Admin UI: **Settings → Integrations → Create integration** (with admin rights), then copy the *access key* and *secret*. For local testing, the quickest way to get a 6.6 instance is a single container:
+
+```shellsession
+user@local $ docker run -d --name sw-test -p 80:80 dockware/shopware:6.6-latest
+```
+
+Create three fixture photos in `products/`. The filenames are deliberately misleading — `mug-001.jpg` is actually a plate — to prove the model looks at the pixels, not the filename:
+
+| File | Content | Known price |
+| ---- | ------- | ----------- |
+| `products/mug-001.jpg` | White dinner plate with a rim ornament | 14.90 EUR |
+| `products/backpack-001.jpg` | Embroidered leather backpack | 89.00 EUR |
+| `products/headphones-001.jpg` | DSLR camera set with lens and notebook | 249.00 EUR |
+
+That is all the input data: three JPEGs and a price each. Everything else comes out of stage 1.
+
+## Stage 1 — Product data from photos {#stage-generate}
+
+Send each photo to `Qwen3.8-27B-NVFP4` with a strict output contract. The prompt is in German on purpose: the model writes German product copy, and the measured output quality is better when the rules are stated in the target language (same pattern as the [BFSG accessibility pipeline](/docs/v2/platform/aihosting/examples/bfsg-accessibility#stage-alt-texts)).
+
+```python
+import base64
+import io
+import json
+import re
+import time
+from pathlib import Path
+
+from PIL import Image
+
+PROMPT = (
+    "Du bist E-Commerce-Experte und schreibst Produkttexte auf Deutsch fuer einen Online-Shop. "
+    "Beschreibe das Produkt auf dem Bild sachlich und kauftraechtig. "
+    "Regeln: name maximal 60 Zeichen, description 2-4 Saetze ohne uebertreibungen, "
+    "tags sind 3-5 kurze Keywords, alt_text maximal 125 Zeichen und beschreibt nur das Bild. "
+    "Keine Erfindungen von Marken oder Eigenschaften, die nicht sichtbar sind. "
+    'Antworte nur mit JSON: {"name": "...", "description": "...", '
+    '"tags": ["...", "..."], "alt_text": "..."}'
+)
+
+
+def encode_image(path: Path, max_px: int = 1024) -> str:
+    """Resize to max_px on the longest edge and return a Base64 data URL."""
+    with Image.open(path) as img:
+        w, h = img.size
+        scale = min(1.0, max_px / max(w, h))
+        if scale < 1.0:
+            img = img.resize((int(w * scale), int(h * scale)), Image.LANCZOS)
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=85)
+    return f"data:image/jpeg;base64,{base64.b64encode(buf.getvalue()).decode()}"
+
+
+def generate_product_data(image_path: Path) -> dict:
+    t0 = time.time()
+    resp = client.chat.completions.create(
+        model=VISION_MODEL,
+        messages=[{"role": "user", "content": [
+            {"type": "image_url", "image_url": {"url": encode_image(image_path)}},
+            {"type": "text", "text": PROMPT},
+        ]}],
+        temperature=0.4,
+        max_tokens=2000,  # reasoning tokens count against this budget
+    )
+    dt = time.time() - t0
+    raw = resp.choices[0].message.content.strip()
+    raw = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw)
+    data = json.loads(raw)
+    return {
+        "name": str(data["name"])[:60],
+        "description": str(data["description"]),
+        "tags": [str(t)[:40] for t in data.get("tags", [])][:5],
+        "alt_text": str(data.get("alt_text", ""))[:125],
+        "seconds": round(dt, 1),
+        "tokens": resp.usage.total_tokens,
+        "reasoning_tokens": resp.usage.completion_tokens_details.reasoning_tokens,
+    }
+```
+
+Images must be Base64 data URLs; see [Encoding and resizing images](/docs/v2/platform/aihosting/examples/python#vision-encoding) for the general pattern.
+
+:::warning[Reasoning tokens eat your max_tokens budget]
+`Qwen3.8-27B-NVFP4` is a reasoning model: before it answers, it spends tokens on internal reasoning that you cannot see but that counts against `max_tokens`. Measured on the fixture photos with `max_tokens=600`: the response came back with `finish_reason=length` and either truncated or **empty** content (the reasoning alone used 524–600 of the 600-token budget). With `max_tokens=2000` every call completed. Budget at least 2000 tokens for product copy, and treat an empty `content` as a retry signal, not a model failure.
+:::
+
+Two behaviours worth knowing from the fixture run:
+
+- **Brands only when visible.** The camera photo carries a legible Canon logo, so the model wrote "Canon Spiegelreflexkamera" — correct, because it is visible. The prompt explicitly forbids inventing brands or properties that are not in the image; small models are less disciplined here, which is what the review stage is for.
+- **Filenames are ignored.** `mug-001.jpg` came back as "Weißer Teller …" (a plate), because that is what the photo shows.
+
+## Stage 2 — Human review {#stage-review}
+
+Generate a review sheet that a person signs off line by line, exactly like the [BFSG pipeline's review stage](/docs/v2/platform/aihosting/examples/bfsg-accessibility#stage-review). Nothing goes into the shop before this step:
+
+```python
+def write_review_sheet(results: dict, out: Path) -> None:
+    lines = [
+        "# Review — Produkttexte (E-Commerce-Pipeline)",
+        "",
+        "Bitte jeden Text pruefen, bevor er im Shop erscheint.",
+        "",
+        "| | SKU | Name | Beschreibung | Tags | Alt-Text | OK? |",
+        "|---|-----|------|--------------|------|----------|-----|",
+    ]
+    for sku, r in results.items():
+        lines.append(
+            f"| [ ] | {sku} | {r['name']} | {r['description'][:80]}… "
+            f"| {', '.join(r['tags'])} | {r['alt_text'][:50]}… | ☐ |"
+        )
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+```
+
+The sheet for the fixture:
+
+```markdown
+# Review — Produkttexte (E-Commerce-Pipeline)
+
+Bitte jeden Text pruefen, bevor er im Shop erscheint.
+
+| | SKU | Name | Beschreibung | Tags | Alt-Text | OK? |
+|---|-----|------|--------------|------|----------|-----|
+| [ ] | mug-001 | Weißer Teller mit dezentem Randmuster | Dieser weiße Teller überzeugt durch sein schlichtes, rundes Design. Ein dezent g… | Teller, Weiß, Randmuster, Essgeschirr, Rund | Weißer runder Teller mit dezentem grauem Wellenmus… | ☐ |
+| [ ] | backpack-001 | Ethnisch bestickter Leder-Rucksack mit Schultergurt | Dieser Rucksack aus dunklem Leder wird über einer Schulter getragen und besticht… | Rucksack, Leder, bestickt, ethno, Frauen | Person in lila T-Shirt und Jeans trägt einen dunkl… | ☐ |
+| [ ] | headphones-001 | Canon DSLR Kamera Set mit Objektiv und Notizbuch | Das Set enthält eine schwarze Canon-Spiegelreflexkamera mit aufgesetztem Objekti… | Kamera, Canon, Notizbuch, Fotografie, Zubehör | Schwarze Canon DSLR mit Objektiv, zweites Objektiv… | ☐ |
+```
+
+After sign-off, apply the accepted texts and run stage 3. Re-running the pipeline afterwards should produce an empty diff in the review sheet.
+
+## Stage 3 — Push to Shopware {#stage-shopware}
+
+### Authentication {#authentication}
+
+The Admin API authenticates with a short-lived JWT exchanged for the integration credentials (`client_credentials` grant):
+
+```python
+import requests
+
+SHOPWARE_URL = "http://localhost/api"  # Admin API base (no version prefix on 6.6+)
+INTEGRATION_KEY = "SWIA…"          # Admin UI -> Settings -> Integrations
+INTEGRATION_SECRET = "…"
+
+
+def get_jwt() -> str:
+    r = requests.post(
+        f"{SHOPWARE_URL}/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": INTEGRATION_KEY,
+            "client_secret": INTEGRATION_SECRET,
+        },
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()["access_token"]
+```
+
+The token expires after 10 minutes — refresh it for long catalog runs.
+
+### Write semantics: 204 plus exact filter {#write-semantics}
+
+Two quirks of the current Admin API shape, both verified against 6.6.10:
+
+- **Write operations return `204 No Content`** — no body, no created id. To work with the entity afterwards, look it up again with an **exact filter** (`equalsAll`). Fuzzy `search-term` matching is not reliable for this (it happily matches `-001` across different files).
+- **Multipart file uploads break under PHP-FPM.** The classic `POST /api/_action/media/{id}/upload` with `multipart/form-data` fails with `CONTENT__MEDIA_INVALID_CONTENT_LENGTH`, because PHP-FPM empties `php://input` for multipart bodies. Send the file as a **raw binary body** instead (or point the endpoint at a URL with `Content-Type: application/json` and `{"url": "..."}` if the image already lives on a CDN).
+
+```python
+def sw(method: str, path: str, token: str, **kwargs):
+    r = requests.request(method, f"{SHOPWARE_URL}/{path.lstrip('/')}",
+                         headers={"Authorization": f"Bearer {token}"},
+                         timeout=60, **kwargs)
+    if r.status_code >= 400:
+        raise RuntimeError(f"{method} {path} -> {r.status_code}: {r.text[:400]}")
+    return r
+
+
+def find_id(entity: str, field: str, value: str, token: str) -> str:
+    """Writes return 204 without an id — look the entity up by an exact filter."""
+    r = sw("GET", entity, token, params={
+        "filter[0][type]": "equalsAll",
+        "filter[0][field]": field,
+        "filter[0][value]": value,
+        "fields[]": "id",
+    })
+    elements = r.json()["data"]
+    if not elements:
+        raise RuntimeError(f"{entity} with {field}={value!r} not found")
+    return elements[0]["id"]
+
+
+def ensure_tag(name: str, token: str) -> str:
+    r = sw("GET", "tag", token, params={
+        "filter[0][type]": "equalsAll",
+        "filter[0][field]": "name",
+        "filter[0][value]": name,
+        "fields[]": "id",
+    })
+    if r.json()["data"]:
+        return r.json()["data"][0]["id"]
+    sw("POST", "tag", token, json={"name": name})
+    return find_id("tag", "name", name, token)
+
+
+def create_media(file_name: str, alt: str, image_bytes: bytes, token: str) -> str:
+    sw("POST", "media", token, json={"fileName": file_name, "alt": alt})
+    media_id = find_id("media", "fileName", file_name, token)
+    # raw binary body: multipart/form-data breaks under PHP-FPM (php://input is empty)
+    r = requests.post(
+        f"{SHOPWARE_URL}/_action/media/{media_id}/upload",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "image/jpeg"},
+        params={"fileName": file_name, "extension": "jpg"},
+        data=image_bytes,
+        timeout=60,
+    )
+    if r.status_code >= 400:
+        raise RuntimeError(f"media upload -> {r.status_code}: {r.text[:400]}")
+    return media_id
+```
+
+### Creating the product {#creating-the-product}
+
+The product payload needs a few fields that are easy to miss (each one was a hard 400 during testing): `taxId`, `stock`, a `price` entry with `currencyId`/`gross`/`net`/`linked`, and media entries keyed by `mediaId` — not `id`. The German texts go into `translations`; the SEO fields are called `metaTitle`/`metaDescription` there.
+
+```python
+TAX_RATE = 19.0  # German standard VAT
+
+
+def create_product(sku: str, data: dict, price_gross: float,
+                   tax_id: str, currency_id: str, de_lang: str,
+                   media_id: str, tag_ids: list[str], token: str) -> None:
+    net = round(price_gross / (1 + TAX_RATE / 100), 2)
+    payload = {
+        "productNumber": sku,
+        "name": data["name"],
+        "description": data["description"],
+        "taxId": tax_id,
+        "stock": 10,
+        "price": [{"currencyId": currency_id, "gross": price_gross,
+                   "net": net, "linked": True}],
+        "media": [{"mediaId": media_id}],
+        "tags": [{"id": tid} for tid in tag_ids],
+        "translations": [{
+            "languageId": de_lang,
+            "name": data["name"],
+            "description": data["description"],
+            "metaTitle": f"{data['name']} – kaufen online",
+            "metaDescription": data["description"].split(". ")[0][:158],
+        }],
+    }
+    sw("POST", "product", token, json=payload)
+```
+
+The driver resolves the fixed ids once (tax rate, EUR currency, German language) and loops over the reviewed products:
+
+```python
+CATALOG = {
+    "mug-001": {"price_gross": 14.90},
+    "backpack-001": {"price_gross": 89.00},
+    "headphones-001": {"price_gross": 249.00},
+}
+
+
+def main():
+    # stages 1 and 2 first — see above; `results` holds the reviewed data
+    token = get_jwt()
+
+    taxes = sw("GET", "tax", token, params={"limit": 50,
+                                            "fields[]": "id", "fields[]": "taxRate"})
+    tax_id = next(d["id"] for d in taxes.json()["data"]
+                  if d["attributes"].get("taxRate") == TAX_RATE)
+    currencies = sw("GET", "currency", token, params={"limit": 50,
+                                                      "fields[]": "id", "fields[]": "name"})
+    currency_id = next(d["id"] for d in currencies.json()["data"]
+                       if "Euro" in str(d["attributes"].get("name")))
+    languages = sw("GET", "language", token, params={"limit": 50,
+                                                     "fields[]": "id", "fields[]": "name"})
+    de_lang = next(d["id"] for d in languages.json()["data"]
+                   if d["attributes"].get("name") == "Deutsch")
+
+    for sku, data in results.items():
+        image_bytes = (PRODUCTS_DIR / f"{sku}.jpg").read_bytes()
+        media_id = create_media(f"{sku}.jpg", data["alt_text"], image_bytes, token)
+        tag_ids = [ensure_tag(t, token) for t in data["tags"]]
+        create_product(sku, data, CATALOG[sku]["price_gross"], tax_id,
+                       currency_id, de_lang, media_id, tag_ids, token)
+        print(f"  {sku}: product + media + {len(tag_ids)} tags created")
+```
+
+Verified result on the fixture run — all three products exist in the shop with generated German copy:
+
+```text
+mug-001       "Weißer Teller mit dezentem Randmuster"
+              metaTitle: "Weißer Teller mit dezentem Randmuster – kaufen online"
+              price: 14.90 gross / 12.52 net EUR, stock 10, 5 tags, cover media with alt text
+backpack-001  "Ethnisch bestickter Leder-Rucksack mit Schultergurt"
+              price: 89.00 gross / 74.79 net EUR, stock 10, 5 tags
+headphones-001 "Canon DSLR Kamera Set mit Objektiv und Notizbuch"
+               price: 249.00 gross / 209.24 net EUR, stock 10, 5 tags
+```
+
+Products without a category do not appear in storefront listings — assign categories in the Admin UI (or extend the pipeline with a category mapping) as part of the review sign-off.
+
+## Cost profile {#cost-profile}
+
+Measured on the playground with ~600 px JPEGs:
+
+| Call | Tokens | Time | Notes |
+| ---- | ------ | ---- | ----- |
+| One product (incl. reasoning) | 957–1,178 total | 6.4–9.0 s | 369–504 of those are reasoning tokens |
+| Three-product fixture | ~3,200 total | ~24 s | plus trivial Admin API traffic |
+
+A 50-photo catalog costs roughly 50,000–60,000 tokens of `Qwen3.8-27B-NVFP4` traffic — a few cents on the 5-million-token plans, which makes a full catalog import a billable automation instead of a week of copywriting. If you want cheaper drafts, `Ministral-3-14B-Instruct-2512` on the public gateway handles standard product photos well; the JSON contract and the rest of the pipeline stay identical.
+
+## Limitations {#limitations}
+
+- **Human review is part of the process.** Vision models misdescribe images, the brand rule is prompt-enforced but not guaranteed, and only a person can judge whether a generated claim is safe to publish.
+- **Price, stock and category are inputs, not outputs.** The model sees the product, not your margin. Keep those in the `CATALOG` table (or read them from a spreadsheet).
+- **The Shopware parts were tested on 6.6 LTS.** Shopware 6.7 moved the Store-API to `/store-api` and reshaped some Admin API responses; the flow documented here (JWT, exact filters, raw-binary media upload) is what 6.6 LTS gives you today.
+- **One language per run.** The example writes German only; add another `translations` entry per language and let the model translate its own output if you need multilingual shops.
+- **Nothing here is a replacement for the client's editorial standards.** Shops with regulated product claims (food, cosmetics, medical) need an extra compliance check in the review sheet.

--- a/docs/platform/aihosting/50-examples/110-ecommerce-product-pipeline.mdx
+++ b/docs/platform/aihosting/50-examples/110-ecommerce-product-pipeline.mdx
@@ -6,11 +6,11 @@ title: E-commerce product pipeline
 
 New products arrive at agencies as photos — usually without any metadata. Someone shoots or downloads a picture, drops it into a folder, and the shop team has to write the name, description, tags and alt text by hand. This guide builds a pipeline that does that step automatically with [Qwen3.8-27B-NVFP4](/docs/v2/platform/aihosting/models/qwen3-8-27b-nvfp4) and writes the result into a running Shopware instance:
 
-| Stage | Model | What it does |
-| ----- | ----- | ------------ |
+| Stage        | Model                                                                     | What it does                                                                                           |
+| ------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | 1 — Generate | [Qwen3.8-27B-NVFP4](/docs/v2/platform/aihosting/models/qwen3-8-27b-nvfp4) | Writes a German product name, description, tags and an image alt text per photo (strict JSON contract) |
-| 2 — Review | human | Signs off every text before anything goes live |
-| 3 — Push | none (Shopware Admin API) | Creates tags, uploads the media and creates the product with SEO fields |
+| 2 — Review   | human                                                                     | Signs off every text before anything goes live                                                         |
+| 3 — Push     | none (Shopware Admin API)                                                 | Creates tags, uploads the media and creates the product with SEO fields                                |
 
 :::note[Scope]
 The pipeline targets **Shopware 6.6 LTS** (tested on 6.6.10). Catalog writes go through the **Admin API**, not the Store-API — the Store-API serves the storefront (reads, cart, checkout) and exposes no product-write routes. If your client runs an older 6.x version, the same endpoints exist under the `/api/v2` prefix; everything else in this guide is unchanged.
@@ -33,7 +33,7 @@ client = OpenAI(base_url="https://qwen3-8-27b-nvfp4.llm-1.m3.services/v1", api_k
 VISION_MODEL = "Qwen3.8-27B-NVFP4"
 ```
 
-For Shopware, create an integration in the Admin UI: **Settings → Integrations → Create integration** (with admin rights), then copy the *access key* and *secret*. For local testing, the quickest way to get a 6.6 instance is a single container:
+For Shopware, create an integration in the Admin UI: **Settings → Integrations → Create integration** (with admin rights), then copy the _access key_ and _secret_. For local testing, the quickest way to get a 6.6 instance is a single container:
 
 ```shellsession
 user@local $ docker run -d --name sw-test -p 80:80 dockware/shopware:6.6-latest
@@ -41,11 +41,11 @@ user@local $ docker run -d --name sw-test -p 80:80 dockware/shopware:6.6-latest
 
 Create three fixture photos in `products/`. The filenames are deliberately misleading — `mug-001.jpg` is actually a plate — to prove the model looks at the pixels, not the filename:
 
-| File | Content | Known price |
-| ---- | ------- | ----------- |
-| `products/mug-001.jpg` | White dinner plate with a rim ornament | 14.90 EUR |
-| `products/backpack-001.jpg` | Embroidered leather backpack | 89.00 EUR |
-| `products/headphones-001.jpg` | DSLR camera set with lens and notebook | 249.00 EUR |
+| File                          | Content                                | Known price |
+| ----------------------------- | -------------------------------------- | ----------- |
+| `products/mug-001.jpg`        | White dinner plate with a rim ornament | 14.90 EUR   |
+| `products/backpack-001.jpg`   | Embroidered leather backpack           | 89.00 EUR   |
+| `products/headphones-001.jpg` | DSLR camera set with lens and notebook | 249.00 EUR  |
 
 That is all the input data: three JPEGs and a price each. Everything else comes out of stage 1.
 
@@ -53,7 +53,7 @@ That is all the input data: three JPEGs and a price each. Everything else comes 
 
 Send each photo to `Qwen3.8-27B-NVFP4` with a strict output contract. The prompt is in German on purpose: the model writes German product copy, and the measured output quality is better when the rules are stated in the target language (same pattern as the [BFSG accessibility pipeline](/docs/v2/platform/aihosting/examples/bfsg-accessibility#stage-alt-texts)).
 
-```python
+````python
 import base64
 import io
 import json
@@ -110,7 +110,7 @@ def generate_product_data(image_path: Path) -> dict:
         "tokens": resp.usage.total_tokens,
         "reasoning_tokens": resp.usage.completion_tokens_details.reasoning_tokens,
     }
-```
+````
 
 Images must be Base64 data URLs; see [Encoding and resizing images](/docs/v2/platform/aihosting/examples/python#vision-encoding) for the general pattern.
 
@@ -152,11 +152,11 @@ The sheet for the fixture:
 
 Bitte jeden Text pruefen, bevor er im Shop erscheint.
 
-| | SKU | Name | Beschreibung | Tags | Alt-Text | OK? |
-|---|-----|------|--------------|------|----------|-----|
-| [ ] | mug-001 | Weißer Teller mit dezentem Randmuster | Dieser weiße Teller überzeugt durch sein schlichtes, rundes Design. Ein dezent g… | Teller, Weiß, Randmuster, Essgeschirr, Rund | Weißer runder Teller mit dezentem grauem Wellenmus… | ☐ |
-| [ ] | backpack-001 | Ethnisch bestickter Leder-Rucksack mit Schultergurt | Dieser Rucksack aus dunklem Leder wird über einer Schulter getragen und besticht… | Rucksack, Leder, bestickt, ethno, Frauen | Person in lila T-Shirt und Jeans trägt einen dunkl… | ☐ |
-| [ ] | headphones-001 | Canon DSLR Kamera Set mit Objektiv und Notizbuch | Das Set enthält eine schwarze Canon-Spiegelreflexkamera mit aufgesetztem Objekti… | Kamera, Canon, Notizbuch, Fotografie, Zubehör | Schwarze Canon DSLR mit Objektiv, zweites Objektiv… | ☐ |
+|     | SKU            | Name                                                | Beschreibung                                                                      | Tags                                          | Alt-Text                                            | OK? |
+| --- | -------------- | --------------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------- | --------------------------------------------------- | --- |
+| [ ] | mug-001        | Weißer Teller mit dezentem Randmuster               | Dieser weiße Teller überzeugt durch sein schlichtes, rundes Design. Ein dezent g… | Teller, Weiß, Randmuster, Essgeschirr, Rund   | Weißer runder Teller mit dezentem grauem Wellenmus… | ☐   |
+| [ ] | backpack-001   | Ethnisch bestickter Leder-Rucksack mit Schultergurt | Dieser Rucksack aus dunklem Leder wird über einer Schulter getragen und besticht… | Rucksack, Leder, bestickt, ethno, Frauen      | Person in lila T-Shirt und Jeans trägt einen dunkl… | ☐   |
+| [ ] | headphones-001 | Canon DSLR Kamera Set mit Objektiv und Notizbuch    | Das Set enthält eine schwarze Canon-Spiegelreflexkamera mit aufgesetztem Objekti… | Kamera, Canon, Notizbuch, Fotografie, Zubehör | Schwarze Canon DSLR mit Objektiv, zweites Objektiv… | ☐   |
 ```
 
 After sign-off, apply the accepted texts and run stage 3. Re-running the pipeline afterwards should produce an empty diff in the review sheet.
@@ -338,10 +338,10 @@ Products without a category do not appear in storefront listings — assign cate
 
 Measured on the playground with ~600 px JPEGs:
 
-| Call | Tokens | Time | Notes |
-| ---- | ------ | ---- | ----- |
+| Call                          | Tokens          | Time      | Notes                                 |
+| ----------------------------- | --------------- | --------- | ------------------------------------- |
 | One product (incl. reasoning) | 957–1,178 total | 6.4–9.0 s | 369–504 of those are reasoning tokens |
-| Three-product fixture | ~3,200 total | ~24 s | plus trivial Admin API traffic |
+| Three-product fixture         | ~3,200 total    | ~24 s     | plus trivial Admin API traffic        |
 
 A 50-photo catalog costs roughly 50,000–60,000 tokens of `Qwen3.8-27B-NVFP4` traffic — a few cents on the 5-million-token plans, which makes a full catalog import a billable automation instead of a week of copywriting. If you want cheaper drafts, `Ministral-3-14B-Instruct-2512` on the public gateway handles standard product photos well; the JSON contract and the rest of the pipeline stay identical.
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/90-qwen3-5-0-8b.mdx
@@ -14,6 +14,7 @@ import TabItem from "@theme/TabItem";
 Geeignet für und unterstützt:
 
 - Textgenerierung innerhalb einer Chat-Completion (Text zu Text)
+- Bildverständnis aus Base64-Data-URLs — Beschreibungen, Alt-Texte, visuelle Klassifizierung
 - Tool-Calling für agentische Workflows
 - Thinking / Reasoning für schrittweises Problemlösen (opt-in)
 - Hochdurchsatz- und latenzempfindliche Pipelines
@@ -22,7 +23,8 @@ Geeignet für und unterstützt:
 Folgende Einschränkungen gelten:
 
 - Maximale Kontextlänge: 262.144 Token
-- Keine Bild-/Vision-Unterstützung
+- Bilder müssen als Base64-Data-URL gesendet werden — externe Bild-URLs geben HTTP 400 zurück
+- In Mehrbild-Anfragen wird nur das erste Bild zuverlässig beschrieben — ein Bild pro Anfrage senden
 - Antwortqualität und Reasoning-Tiefe sind geringer als bei größeren Modellen
 - Thinking-Modus ist standardmäßig **deaktiviert** – opt-in pro Anfrage via `chat_template_kwargs`
 
@@ -187,10 +189,10 @@ category = response.choices[0].message.content.strip()
 
 :::tip Guide-Ideen
 - **Cascade-Routing**: `Qwen3.5-0.8B` klassifiziert die Anfragekomplexität und leitet an die passende Stufe weiter:
-  - Einfacher Text → `Qwen3.5-0.8B` beantwortet direkt
+  - Einfacher Text oder einfache Vision (Beschreibungen, Alt-Texte) → `Qwen3.5-0.8B` beantwortet direkt
   - Mittelstufe → `Qwen3.6-35B-A3B-FP8` (Reasoning + Vision, mittlere Kosten)
   - Komplex / Frontier → `Qwen3.5-122B-A10B-FP8`
-  - Nur Vision → `Ministral-3-14B-Instruct-2512` (günstigstes Vision-Modell)
+  - Anspruchsvolle Vision → `Ministral-3-14B-Instruct-2512`
 
   Eine gut abgestimmte Kaskade kann Kosten um 40–80 % senken und gleichzeitig bei 95 % der Anfragen die Qualität erhalten.
 - **Batch-Vorverarbeitung**: Dokumente in großem Umfang zusammenfassen, Entitäten extrahieren oder taggen, bevor eine kuratierte Teilmenge an ein leistungsstärkeres Modell übergeben wird.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/30-models/index.mdx
@@ -8,7 +8,7 @@ Wir bieten aktuell die nachfolgenden Modelle an, die sich im Laufe der Zeit änd
 | Modellname                      | Typ                       | Modalitäten                                   | Context (Tokens)    | Lizenz     |
 | ------------------------------- | ------------------------- | --------------------------------------------- | ------------------- | ---------- |
 | gpt-oss-120b                    | Chat + Reasoning          | Text, Tool-Calling                            | 131.072             | Apache 2.0 |
-| Qwen3.5-0.8B                    | Chat + Reasoning          | Text, Tool-Calling                            | 262.144             | Apache 2.0 |
+| Qwen3.5-0.8B                    | Chat + Reasoning + Vision | Text, Bild, Tool-Calling                      | 262.144             | Apache 2.0 |
 | Ministral-3-14B-Instruct-2512   | Chat + Vision             | Text, Bild, Tool-Calling                      | 262.144             | Apache 2.0 |
 | Qwen3.5-122B-A10B-FP8           | Chat + Reasoning + Vision | Text, Bild, Tool-Calling                      | 245.760             | Apache 2.0 |
 | Qwen3.6-35B-A3B-FP8             | Chat + Reasoning + Vision | Text, Bild, Tool-Calling                      | 256.000             | Apache 2.0 |
@@ -25,7 +25,7 @@ Tool-Calling in dieser Tabelle bezieht sich auf die Unterstützung über `/v1/ch
 
 - Für komplexe textzentrierte Workloads und fortgeschrittene Automatisierungen, bei denen hohe Präzision und umfangreiches Wissen erforderlich sind \
   verwende `gpt-oss-120b`.
-- Für hochdurchsatz- und kostensensitive Aufgaben ohne Vision-Bedarf, etwa einfache Frage-Antwort-Szenarien, Routing, Klassifizierung und Batch-Verarbeitung \
+- Für hochdurchsatz- und kostensensitive Aufgaben — einfache Frage-Antwort-Szenarien, Routing, Klassifizierung, Batch-Verarbeitung und grundlegende Bildbeschreibungen \
   verwende `Qwen3.5-0.8B`.
 - Für generelle, skalierbare und kostenbewusste Chat- sowie einfache multimodale Workflows (Text + Bild) \
   verwende `Ministral-3-14B-Instruct-2512`.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/100-bfsg-accessibility.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/100-bfsg-accessibility.mdx
@@ -62,7 +62,7 @@ Werktages auf Ihre Anfrage.</p>
 </html>
 ```
 
-Leg echte JPEGs in `site/img/` (beliebige Fotos). Beachte, was die Beispiel-Website bewusst enthält: ein Bild **ohne** `alt`-Attribut, eines mit **leerem** `alt` (dekorativ), eines mit **Platzhalter**-Alt (`Bild1`), eines mit gutem Alt-Text und ein referenziertes Bild, dessen Datei fehlt. Alte Kundenwebsites schreiben Deutsch oft ohne Umlaute (`fuer`, `ueber`) — die Beispiele behalten das absichtlich so.
+Leg echte JPEGs in `site/img/` (beliebige Fotos). Beachte, was die Beispiel-Website bewusst enthält: Ein Bild **ohne** `alt`-Attribut, eines mit **leerem** `alt` (dekorativ), eines mit **Platzhalter**-Alt (`Bild1`), eines mit gutem Alt-Text und ein referenziertes Bild, dessen Datei fehlt. Alte Kundenwebsites schreiben Deutsch oft ohne Umlaute (`fuer`, `ueber`) — die Beispiele behalten das absichtlich so.
 
 ## Stufe 1 — Audit: kaputte Bilder finden {#stufe-audit}
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/100-bfsg-accessibility.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/100-bfsg-accessibility.mdx
@@ -1,0 +1,396 @@
+---
+sidebar_label: BFSG-Barrierefreiheits-Pipeline
+description: Website auf fehlende Alt-Texte prüfen, mit Qwen3.5-0.8B generieren, Audio-Versionen mit Qwen3-TTS erzeugen und ein Review-Dokument für die Freigabe erstellen
+title: BFSG-Barrierefreiheits-Pipeline
+---
+
+Seit dem 28. Juni 2025 gelten die Anforderungen des [Barrierefreiheitsstärkungsgesetzes (BFSG)](https://www.gesetze-im-internet.de/bfsg/) für verbraucherorientierte Websites und Shops in Deutschland — mit Bußgeldern bis zu 100.000 Euro bei Verstößen. Die beiden häufigsten Lücken sind **Bilder ohne aussagekräftigen Alt-Text** und **keine Audio-Alternative für textlastige Seiten**.
+
+Diese Anleitung baut eine Pipeline, die beide Lücken findet, mit mittwald AI Hosting-Modellen Vorschläge erstellt und das Ergebnis an einen menschlichen Prüfer übergibt — ein Workflow, den deine Agentur für jede Kundenwebsite durchlaufen kann:
+
+| Stufe | Modell | Was es macht |
+| ----- | ------ | ------------ |
+| 1 — Audit | keines (reines HTML-Parsing) | Findet `<img>`-Tags mit fehlendem, leerem oder Platzhalter-Alt-Text |
+| 2 — Alt-Texte | [Qwen3.5-0.8B](/docs/v2/platform/aihosting/models/qwen3-5-0-8b) | Schreibt pro Bild einen deutschen Alt-Text und markiert dekorative Bilder |
+| 3 — Audio | [Qwen3-TTS-12Hz-1.7B-CustomVoice](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice) | liest wichtige Seiten als Opus-Dateien vor, die auf der Seite abgespielt werden können |
+| 4 — Review | Mensch | prüft jeden Vorschlag, bevor etwas live geht |
+
+:::note[Anwendungsbereich]
+Der BFSG gilt für Unternehmen, die Waren oder Dienste an Verbraucher verkaufen; sehr kleine Unternehmen (weniger als 10 Mitarbeiter und unter 2 Millionen Euro Jahresumsatz) sind ausgenommen. Diese Anleitung ist technische Dokumentation, keine Rechtsberatung — kläre vor einem Compliance-Auftrag, ob der betroffene Kunde überhaupt im Anwendungsbereich liegt.
+:::
+
+Die Pipeline läuft gegen eine lokale Kopie des Website-HTML, damit du beim Testen nie auf eine live geschaltete Kundenwebsite zeigst.
+
+## Vorbereitung {#vorbereitung}
+
+```shellsession
+user@local $ pip install openai beautifulsoup4 pillow
+user@local $ export OPENAI_API_KEY="sk-…"
+```
+
+Lege eine kleine Beispiel-Website an. Zwei Seiten reichen, um alle Stufen zu üben:
+
+```html
+<!-- site/index.html -->
+<!DOCTYPE html>
+<html lang="de">
+<head><meta charset="utf-8"><title>Garten &amp; Wohnen</title></head>
+<body>
+<h1>Ihr Shop fuer Garten und Wohnen</h1>
+<p>Willkommen bei uns! Entdecken Sie ueber 500 Produkte.</p>
+<img src="img/hund.jpg">
+<img src="img/kanu.jpg" alt="">
+<img src="img/robbe.jpg" alt="Bild1">
+<img src="logo.png" alt="Garten und Wohnen Logo">
+</body>
+</html>
+```
+
+```html
+<!-- site/kontakt.html -->
+<!DOCTYPE html>
+<html lang="de">
+<head><meta charset="utf-8"><title>Kontakt</title></head>
+<body>
+<h1>Kontakt</h1>
+<p>Sie erreichen uns moeglichst werktags zwischen neun und sechzehn Uhr unter der
+Telefonnummer 05772 293-100. Schreiben Sie uns auch gerne eine E-Mail an
+info@example-shop.de. Unser Team antwortet in der Regel innerhalb eines
+Werktages auf Ihre Anfrage.</p>
+<img src="img/team.jpg">
+</body>
+</html>
+```
+
+Leg echte JPEGs in `site/img/` (beliebige Fotos). Beachte, was die Beispiel-Website bewusst enthält: ein Bild **ohne** `alt`-Attribut, eines mit **leerem** `alt` (dekorativ), eines mit **Platzhalter**-Alt (`Bild1`), eines mit gutem Alt-Text und ein referenziertes Bild, dessen Datei fehlt. Alte Kundenwebsites schreiben Deutsch oft ohne Umlaute (`fuer`, `ueber`) — die Beispiele behalten das absichtlich so.
+
+## Stufe 1 — Audit: kaputte Bilder finden {#stufe-audit}
+
+Parse jede HTML-Datei und klassifiziere jedes `<img>`:
+
+```python
+import base64
+import io
+import os
+import re
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+from PIL import Image
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.aihosting.mittwald.de/v1")
+
+SITE = Path("site")
+BAD_ALT_RE = re.compile(r"^(bild|foto|image|picture|abbildung)\s*\d*$", re.I)
+
+
+def encode_image(path: Path, max_px: int = 1024) -> str:
+    """Bild auf max_px an der längsten Seite skalieren und als Base64-Data-URL zurückgeben."""
+    with Image.open(path) as img:
+        w, h = img.size
+        scale = min(1.0, max_px / max(w, h))
+        if scale < 1.0:
+            img = img.resize((int(w * scale), int(h * scale)), Image.LANCZOS)
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=85)
+        b64 = base64.b64encode(buf.getvalue()).decode()
+    return f"data:image/jpeg;base64,{b64}"
+
+
+def audit_site(site: Path) -> list[dict]:
+    """Alle <img>-Tags der Website finden und ihr alt-Attribut klassifizieren."""
+    findings = []
+    for html_file in sorted(site.glob("**/*.html")):
+        soup = BeautifulSoup(html_file.read_text(encoding="utf-8"), "html.parser")
+        for tag in soup.find_all("img"):
+            src = tag.get("src", "")
+            alt = tag.get("alt")
+            if alt is None:
+                status = "missing"
+            elif alt.strip() == "":
+                status = "empty"          # beabsichtigt: dekoratives Bild
+            elif BAD_ALT_RE.match(alt.strip()) or len(alt.strip()) < 5:
+                status = "bad"
+            else:
+                status = "ok"
+            findings.append({
+                "page": html_file.name,
+                "src": src,
+                "alt": alt,
+                "status": status,
+                "path": (html_file.parent / src).resolve(),
+            })
+    return findings
+```
+
+Ein leeres `alt=""` ist **kein** Defekt — es ist der korrekte Weg, ein dekoratives Bild zu kennzeichnen, daher belässt das Audit es so. Das Audit auf der Beispiel-Website ergibt:
+
+```text
+missing  index.html      img/hund.jpg    alt=None
+empty    index.html      img/kanu.jpg    alt=''
+bad      index.html      img/robbe.jpg   alt='Bild1'
+ok       index.html      logo.png        alt='Garten und Wohnen Logo'
+missing  kontakt.html    img/team.jpg    alt=None
+```
+
+Für eine echte Kundenwebsite holst du die Seiten vorher mit `requests` und legst sie unter `site/` ab — der Rest der Pipeline arbeitet auf lokalen Dateien, dadurch bleiben Wiederholungen billig und reproduzierbar.
+
+## Stufe 2 — Alt-Texte: ein Bild pro Anfrage {#stufe-alt-texte}
+
+Sende jedes markierte Bild an `Qwen3.5-0.8B` mit einem strengen Ausgabeformat. Der Prompt ist bewusst auf Deutsch: Das Modell schreibt deutsche Alt-Texte, und die gemessene Qualität ist besser, wenn die Regeln in der Zielsprache formuliert sind.
+
+```python
+ALT_MODEL = "Qwen3.5-0.8B"
+
+ALT_PROMPT = (
+    "Du bist Accessibility-Experte und schreibst Alt-Texte auf Deutsch. "
+    "Regeln: maximal 125 Zeichen, kein 'Bild von' oder 'Foto von', "
+    "Inhalt und Zweck beschreiben, keine Stilangaben (Farben, Licht), "
+    "keine Spekulationen. Ein Bild ist nur dekorativ, wenn es eindeutig ziert "
+    "(Hintergrundmuster, Trennlinie, Logo neben gleichlautendem Text). "
+    "Im Zweifel gilt: informativ. "
+    "Antworte nur mit JSON: {\"decorative\": true/false, \"alt\": \"...\"}."
+)
+
+
+def generate_alt(image_path: Path, context: str = "") -> dict:
+    """Ein Bild pro Anfrage — siehe den Hinweis zu Mehrbild-Anfragen unten."""
+    content = [{"type": "image_url", "image_url": {"url": encode_image(image_path)}}]
+    if context:
+        content.insert(0, {"type": "text", "text": f"Das Bild steht auf der Seite '{context}'."})
+    content.append({"type": "text", "text": ALT_PROMPT})
+    resp = client.chat.completions.create(
+        model=ALT_MODEL,
+        messages=[{"role": "user", "content": content}],
+        temperature=0.3,
+        max_tokens=300,
+    )
+    raw = resp.choices[0].message.content.strip()
+    raw = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw)
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError:
+        # Kleine Modelle antworten gelegentlich als Fließtext — dann ist das der Alt-Text
+        result = {"decorative": False, "alt": raw[:125]}
+    return {
+        "decorative": bool(result.get("decorative")),
+        "alt": str(result.get("alt", ""))[:125],
+        "usage": resp.usage.total_tokens,
+    }
+```
+
+:::warning[Mehrere Bilder nicht in einer Anfrage zusammenfassen]
+Wir haben getestet, drei Bilder in einer einzigen Nachricht zu senden und je einen Alt-Text zu verlangen. In jedem Lauf beschrieb das Modell nur das erste Bild und stoppte. Sende ein Bild pro Anfrage und iteriere — genau das macht der Treiber in Stufe 4.
+:::
+
+Bilder müssen als Base64-Data-URL gesendet werden; externe Bild-URLs werden mit HTTP 400 abgewiesen. Zum allgemeinen Muster siehe [Bilder kodieren und verkleinern](/docs/v2/platform/aihosting/examples/python#vision-encoding).
+
+### Modellwahl {#modellwahl}
+
+`Qwen3.5-0.8B` ist das günstigste Modell im Katalog und kommt mit üblichen Produkt- und Teambildern gut zurecht, aber es ist ein kleines Modell. Auf denselben Beispiel-Bildern im Vergleich:
+
+| Bild | `Qwen3.5-0.8B` | `Ministral-3-14B-Instruct-2512` |
+| ---- | -------------- | ------------------------------- |
+| Welpe auf Holzdielen | „Ein schwarzer Labrador-Pudel sitzt auf einer Holzplatte und blickt nach oben.“ | „Schwarzer Labradorwelpe mit aufmerksamen Augen sitzt auf Holzuntergrund.“ |
+| Walrosse am Strand | „Walder auf Sand“ | „Zwei Walrosse auf sandigem Untergrund mit typischen Stoßzähnen und faltiger Haut, ruhend am Strand.“ |
+
+Trägt eine Seite Hero-Bilder, bei denen die Formulierung zählt, wechsle `ALT_MODEL` für diese Bilder auf `Ministral-3-14B-Instruct-2512`. In beiden Fällen geht nichts ohne die Review-Stufe live.
+
+## Stufe 3 — Audio-Versionen für wichtige Seiten {#stufe-audio}
+
+Nicht jede Seite braucht eine Audio-Version — wähle die, die Besucher tatsächlich lesen: Startseite, Kontakt, Versandbedingungen, Impressum. Extrahiere ihren sichtbaren Text, bereite ihn für die deutsche Sprachausgabe vor und erzeuge ihn mit [Qwen3-TTS](/docs/v2/platform/aihosting/examples/text-to-speech).
+
+```python
+import json
+
+TTS_MODEL = "Qwen3-TTS-12Hz-1.7B-CustomVoice"
+VOICE = "serena"
+
+
+def restore_umlauts(text: str) -> str:
+    """Umlaute wiederherstellen, die alte CMS-Exporte entfernt haben. Heuristik — Ergebnis prüfen."""
+    for ascii_form, umlaut in (("AE", "Ä"), ("OE", "Ö"), ("UE", "Ü"),
+                               ("ae", "ä"), ("oe", "ö"), ("ue", "ü")):
+        text = text.replace(ascii_form, umlaut)
+    return text
+
+
+def prepare_german_text(text: str) -> str:
+    """Deutsche Vorbereitungsregeln aus der Qwen3-TTS-Modellseite anwenden."""
+    text = text.replace("&amp;", "und").replace("&", "und")
+    text = re.sub(r"\s+", " ", text).strip()
+    return restore_umlauts(text)
+
+
+def chunk_sentences(text: str, min_chars: int = 100, max_chars: int = 350) -> list[str]:
+    """Sätze zu Blöcken von mindestens min_chars zusammenfassen (kurze deutsche Zeilen sind unzuverlässig)."""
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    chunks, current = [], ""
+    for sentence in sentences:
+        if current and len(current) + len(sentence) + 1 > max_chars:
+            chunks.append(current)
+            current = sentence
+        else:
+            current = f"{current} {sentence}".strip()
+    if current:
+        chunks.append(current)
+    # einen kurzen Schlussblock in den vorherigen aufnehmen
+    if len(chunks) > 1 and len(chunks[-1]) < min_chars:
+        chunks[-2] = f"{chunks[-2]} {chunks[-1]}"
+        chunks.pop()
+    return chunks
+
+
+def synthesize_page(page_name: str, body_text: str, out_dir: Path) -> list[Path]:
+    prepared = prepare_german_text(body_text)
+    files = []
+    for i, chunk in enumerate(chunk_sentences(prepared)):
+        out = out_dir / f"{page_name}_{i:02d}.opus"
+        response = client.audio.speech.create(
+            model=TTS_MODEL,
+            voice=VOICE,
+            input=chunk,
+            response_format="opus",
+            extra_body={"language": "German"},
+        )
+        response.write_to_file(out)
+        files.append(out)
+    return files
+```
+
+Drei Dinge in `prepare_german_text` und `chunk_sentences` kommen direkt aus den Messungen auf der [Qwen3-TTS-Modellseite](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice#deutscher-text):
+
+- **Echte Umlaute statt `ae`/`oe`/`ue`.** Transliteriertes Deutsch kommt deutlich falsch raus (durchschnittlicher Wortfehleranteil 0,215 statt 0,000 mit echten Umlauten in unseren Tests). `restore_umlauts` ist eine Heuristik — Wörter wie „Duell“ werden zu „Düell“ — noch ein Grund, warum die Review-Stufe existiert.
+- **Blöcke von mindestens ca. 100 Zeichen.** Unter etwa 80 Zeichen scheitert die deutsche Synthese häufig genug, um relevant zu sein, und der Fehler klingt wie flüssiges Englisch.
+- **Zahlen und Abkürzungen.** Daten und Prozentzahlen werden korrekt so vorgelesen, wie geschrieben, aber Bestellnummern und Preise nicht. Expandiére sie im Quelltext oder akzeptiere, dass die gesprochene Version stockt — der Prüfer hört das.
+
+Verwende `opus` für die Wiedergabe auf der Seite: Es ist bei Sprachqualität etwa ein Zehntel der Größe von `wav`. Die Lautstärke ist zwischen Clips nicht normalisiert — wenn eine Seite mehrere Clips nacheinander abspielt, schicke sie vorher durch einen Loudness-Normalisierer. Die Stimmenwahl ist Geschmackssache — `serena` und `vivian` sind die höheren Stimmen, siehe [Eine Stimme wählen](/docs/v2/platform/aihosting/examples/text-to-speech#stimmen).
+
+Auf der Beispiel-Website rendert die Kontaktseite (258 Zeichen inklusive Telefonnummer) in einer einzigen Anfrage eine 24,7-Sekunden-Opus-Datei:
+
+```text
+kontakt.html: 259 chars -> 1 chunks
+  [258 chars] -> kontakt_00.opus (106 kB)
+```
+
+Telefonnummern werden zifferweise vorgelesen, was richtig, aber langsam ist — plane für dieselbe Zeichenzahl etwa das Vierfache der Audiolänge gegenüber normalem Fließtext ein.
+
+## Stufe 4 — Menschliches Review {#stufe-review}
+
+Erzeuge ein Review-Dokument, das eine Person zeilenweise freigibt. Dieser Schritt ist nicht optional: Das Modell aus Stufe 2 lieferte „Walder auf Sand“ für ein Walross-Foto, und ein Barrierefreiheits-Feature, das Inhalte falsch beschreibt, ist schlimmer als keins.
+
+```python
+def write_review_sheet(findings: list[dict], results: dict, audio: dict, out: Path) -> None:
+    lines = [
+        "# Review — Barrierefreiheit (BFSG)",
+        "",
+        "Bitte jeden Vorschlag prüfen, bevor er live geht. AI-Alt-Texte können falsch sein.",
+        "",
+        "| | Seite | Datei | Aktueller Alt | Vorschlag | OK? |",
+        "|---|-------|-------|---------------|-----------|-----|",
+    ]
+    for f in findings:
+        if f["status"] == "ok":
+            continue
+        key = f"{f['page']}::{f['src']}"
+        r = results.get(key)
+        if f["status"] == "empty":
+            suggestion = "(dekorativ — leer lassen)"
+        elif r is None:
+            suggestion = "(nicht generiert — Datei fehlt?)"
+        elif r["decorative"]:
+            suggestion = '"" (dekorativ)'
+        else:
+            suggestion = f'"{r["alt"]}"'
+        lines.append(f"| [ ] | {f['page']} | {f['src']} | `{f['alt']}` | {suggestion} | ☐ |")
+    lines += ["", "## Audio-Versionen", ""]
+    for page, files in audio.items():
+        for fp in files:
+            lines.append(f"- {page}: {fp.name} ({fp.stat().st_size // 1024} kB)")
+    lines.append("")
+    out.write_text("\n".join(lines), encoding="utf-8")
+```
+
+Das Dokument für die Beispiel-Website:
+
+```markdown
+# Review — Barrierefreiheit (BFSG)
+
+Bitte jeden Vorschlag prüfen, bevor er live geht. AI-Alt-Texte können falsch sein.
+
+| | Seite | Datei | Aktueller Alt | Vorschlag | OK? |
+|---|-------|-------|---------------|-----------|-----|
+| [ ] | index.html | img/hund.jpg | `None` | "" (dekorativ) | ☐ |
+| [ ] | index.html | img/kanu.jpg | `` | (dekorativ — leer lassen) | ☐ |
+| [ ] | index.html | img/robbe.jpg | `Bild1` | "" (dekorativ) | ☐ |
+| [ ] | kontakt.html | img/team.jpg | `None` | (nicht generiert — Datei fehlt?) | ☐ |
+
+## Audio-Versionen
+
+- index.html: index_00.opus (30 kB)
+- kontakt.html: kontakt_00.opus (106 kB)
+```
+
+Nach der Freigabe trägst du die akzeptierten Alt-Texte ins HTML ein (oder übergibst das Dokument an die CMS-Pflege der Kunden) und lieferst die Opus-Dateien neben den Seiten aus, zu denen sie gehören. Ein erneutes Audit sollte danach nur noch `ok` und bewusste `empty`-Einträge melden.
+
+## Komplette Pipeline {#komplette-pipeline}
+
+```python
+def main():
+    print("== Stufe 1: Audit ==")
+    findings = audit_site(SITE)
+    for f in findings:
+        print(f"  {f['status']:8s} {f['page']:15s} {f['src']:15s} alt={f['alt']!r}")
+
+    print("\n== Stufe 2: Alt-Texte ==")
+    results = {}
+    for f in findings:
+        if f["status"] not in ("missing", "bad"):
+            continue
+        key = f"{f['page']}::{f['src']}"
+        if not f["path"].exists():
+            print(f"  SKIP {key} (Datei nicht gefunden)")
+            continue
+        r = generate_alt(f["path"], context=f["page"])
+        results[key] = r
+        print(f"  {key}: decorative={r['decorative']} alt={r['alt']!r} ({r['usage']} tokens)")
+
+    print("\n== Stufe 3: Audio-Versionen ==")
+    audio = {}
+    for page in ("index.html", "kontakt.html"):
+        soup = BeautifulSoup((SITE / page).read_text(encoding="utf-8"), "html.parser")
+        text = " ".join(p.get_text() for p in soup.find_all(["h1", "p"]))
+        out_dir = Path("audio") / page.replace(".html", "")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        audio[page] = synthesize_page(page, text, out_dir)
+        for fp in audio[page]:
+            print(f"  {page} -> {fp} ({fp.stat().st_size // 1024} kB)")
+
+    print("\n== Stufe 4: Review-Dokument ==")
+    write_review_sheet(findings, results, audio, Path("REVIEW.md"))
+    print("  REVIEW.md geschrieben")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## Kostenprofil {#kostenprofil}
+
+Gemessen am öffentlichen Gateway mit einem 800×600-JPEG:
+
+| Aufruf | Token / Größe | Anmerkung |
+| ------ | ------------- | --------- |
+| Ein Alt-Text (`Qwen3.5-0.8B`) | ~640 gesamt (~475 multimodal) | ~0,7 s Hin-und-Rückweg |
+| Ein Alt-Text (`Ministral-3-14B-Instruct-2512`) | ~725 gesamt | ~0,6 s Hin-und-Rückweg |
+| Ein Audio-Block (~260 Zeichen, `opus`) | 106-kB-Datei, 24,7 s Audio | ~2 s Generierung |
+
+Eine Kundenwebsite mit 100 Bildern kostet grob 60.000 Token an `Qwen3.5-0.8B`-Verkehr plus einige TTS-Aufrufe für die wichtigen Seiten. `Qwen3.5-0.8B` ist das kosteneffizienteste Modell im Katalog — deshalb ist ein Audit pro Website ein abrechenbarer Posten statt eines manuellen Nachmittags.
+
+## Einschränkungen {#einschraenkungen}
+
+- **Das menschliche Review gehört zum Prozess.** Alt-Texte kleiner Modelle enthalten Fehler (siehe das Walross-Beispiel), die Umlaut-Wiederherstellung ist eine Heuristik, und nur eine Person kann beurteilen, ob ein Bild im Kontext dekorativ ist.
+- **Das Audit deckt `<img>`-Tags ab.** Hintergrundbilder in CSS, SVGs mit eingebettetem Text und Videos ohne Untertitel werden nicht geprüft — erweitere `audit_site` dafür, falls die Kundenwebsite sie nutzt.
+- **Audio-Versionen decken die Seiten ab, die du wählst.** Der BFSG verlangt nicht, dass jede Seite eine Audio-Alternative hat; die textlastigen auszuwählen ist eine sinnvolle Interpretation, keine Garantie.
+- **Das ist keine Rechtsberatung.** Anwendungsbereich, Ausnahmen und Bußgelder gehören in ein Gespräch mit der Rechtsabteilung der Kunden.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/100-bfsg-accessibility.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/100-bfsg-accessibility.mdx
@@ -8,12 +8,12 @@ Seit dem 28. Juni 2025 gelten die Anforderungen des [Barrierefreiheitsstärkungs
 
 Diese Anleitung baut eine Pipeline, die beide Lücken findet, mit mittwald AI Hosting-Modellen Vorschläge erstellt und das Ergebnis an einen menschlichen Prüfer übergibt — ein Workflow, den deine Agentur für jede Kundenwebsite durchlaufen kann:
 
-| Stufe | Modell | Was es macht |
-| ----- | ------ | ------------ |
-| 1 — Audit | keines (reines HTML-Parsing) | Findet `<img>`-Tags mit fehlendem, leerem oder Platzhalter-Alt-Text |
-| 2 — Alt-Texte | [Qwen3.5-0.8B](/docs/v2/platform/aihosting/models/qwen3-5-0-8b) | Schreibt pro Bild einen deutschen Alt-Text und markiert dekorative Bilder |
-| 3 — Audio | [Qwen3-TTS-12Hz-1.7B-CustomVoice](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice) | liest wichtige Seiten als Opus-Dateien vor, die auf der Seite abgespielt werden können |
-| 4 — Review | Mensch | prüft jeden Vorschlag, bevor etwas live geht |
+| Stufe         | Modell                                                                                      | Was es macht                                                                           |
+| ------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 1 — Audit     | keines (reines HTML-Parsing)                                                                | Findet `<img>`-Tags mit fehlendem, leerem oder Platzhalter-Alt-Text                    |
+| 2 — Alt-Texte | [Qwen3.5-0.8B](/docs/v2/platform/aihosting/models/qwen3-5-0-8b)                             | Schreibt pro Bild einen deutschen Alt-Text und markiert dekorative Bilder              |
+| 3 — Audio     | [Qwen3-TTS-12Hz-1.7B-CustomVoice](/docs/v2/platform/aihosting/models/qwen3-tts-customvoice) | liest wichtige Seiten als Opus-Dateien vor, die auf der Seite abgespielt werden können |
+| 4 — Review    | Mensch                                                                                      | prüft jeden Vorschlag, bevor etwas live geht                                           |
 
 :::note[Anwendungsbereich]
 Der BFSG gilt für Unternehmen, die Waren oder Dienste an Verbraucher verkaufen; sehr kleine Unternehmen (weniger als 10 Mitarbeiter und unter 2 Millionen Euro Jahresumsatz) sind ausgenommen. Diese Anleitung ist technische Dokumentation, keine Rechtsberatung — kläre vor einem Compliance-Auftrag, ob der betroffene Kunde überhaupt im Anwendungsbereich liegt.
@@ -34,15 +34,18 @@ Lege eine kleine Beispiel-Website an. Zwei Seiten reichen, um alle Stufen zu üb
 <!-- site/index.html -->
 <!DOCTYPE html>
 <html lang="de">
-<head><meta charset="utf-8"><title>Garten &amp; Wohnen</title></head>
-<body>
-<h1>Ihr Shop fuer Garten und Wohnen</h1>
-<p>Willkommen bei uns! Entdecken Sie ueber 500 Produkte.</p>
-<img src="img/hund.jpg">
-<img src="img/kanu.jpg" alt="">
-<img src="img/robbe.jpg" alt="Bild1">
-<img src="logo.png" alt="Garten und Wohnen Logo">
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Garten &amp; Wohnen</title>
+  </head>
+  <body>
+    <h1>Ihr Shop fuer Garten und Wohnen</h1>
+    <p>Willkommen bei uns! Entdecken Sie ueber 500 Produkte.</p>
+    <img src="img/hund.jpg" />
+    <img src="img/kanu.jpg" alt="" />
+    <img src="img/robbe.jpg" alt="Bild1" />
+    <img src="logo.png" alt="Garten und Wohnen Logo" />
+  </body>
 </html>
 ```
 
@@ -50,15 +53,20 @@ Lege eine kleine Beispiel-Website an. Zwei Seiten reichen, um alle Stufen zu üb
 <!-- site/kontakt.html -->
 <!DOCTYPE html>
 <html lang="de">
-<head><meta charset="utf-8"><title>Kontakt</title></head>
-<body>
-<h1>Kontakt</h1>
-<p>Sie erreichen uns moeglichst werktags zwischen neun und sechzehn Uhr unter der
-Telefonnummer 05772 293-100. Schreiben Sie uns auch gerne eine E-Mail an
-info@example-shop.de. Unser Team antwortet in der Regel innerhalb eines
-Werktages auf Ihre Anfrage.</p>
-<img src="img/team.jpg">
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Kontakt</title>
+  </head>
+  <body>
+    <h1>Kontakt</h1>
+    <p>
+      Sie erreichen uns moeglichst werktags zwischen neun und sechzehn Uhr unter
+      der Telefonnummer 05772 293-100. Schreiben Sie uns auch gerne eine E-Mail
+      an info@example-shop.de. Unser Team antwortet in der Regel innerhalb eines
+      Werktages auf Ihre Anfrage.
+    </p>
+    <img src="img/team.jpg" />
+  </body>
 </html>
 ```
 
@@ -140,7 +148,7 @@ Für eine echte Kundenwebsite holst du die Seiten vorher mit `requests` und legs
 
 Sende jedes markierte Bild an `Qwen3.5-0.8B` mit einem strengen Ausgabeformat. Der Prompt ist bewusst auf Deutsch: Das Modell schreibt deutsche Alt-Texte, und die gemessene Qualität ist besser, wenn die Regeln in der Zielsprache formuliert sind.
 
-```python
+````python
 ALT_MODEL = "Qwen3.5-0.8B"
 
 ALT_PROMPT = (
@@ -178,7 +186,7 @@ def generate_alt(image_path: Path, context: str = "") -> dict:
         "alt": str(result.get("alt", ""))[:125],
         "usage": resp.usage.total_tokens,
     }
-```
+````
 
 :::warning[Mehrere Bilder nicht in einer Anfrage zusammenfassen]
 Wir haben getestet, drei Bilder in einer einzigen Nachricht zu senden und je einen Alt-Text zu verlangen. In jedem Lauf beschrieb das Modell nur das erste Bild und stoppte. Sende ein Bild pro Anfrage und iteriere — genau das macht der Treiber in Stufe 4.
@@ -190,10 +198,10 @@ Bilder müssen als Base64-Data-URL gesendet werden; externe Bild-URLs werden mit
 
 `Qwen3.5-0.8B` ist das günstigste Modell im Katalog und kommt mit üblichen Produkt- und Teambildern gut zurecht, aber es ist ein kleines Modell. Auf denselben Beispiel-Bildern im Vergleich:
 
-| Bild | `Qwen3.5-0.8B` | `Ministral-3-14B-Instruct-2512` |
-| ---- | -------------- | ------------------------------- |
-| Welpe auf Holzdielen | „Ein schwarzer Labrador-Pudel sitzt auf einer Holzplatte und blickt nach oben.“ | „Schwarzer Labradorwelpe mit aufmerksamen Augen sitzt auf Holzuntergrund.“ |
-| Walrosse am Strand | „Walder auf Sand“ | „Zwei Walrosse auf sandigem Untergrund mit typischen Stoßzähnen und faltiger Haut, ruhend am Strand.“ |
+| Bild                 | `Qwen3.5-0.8B`                                                                  | `Ministral-3-14B-Instruct-2512`                                                                       |
+| -------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Welpe auf Holzdielen | „Ein schwarzer Labrador-Pudel sitzt auf einer Holzplatte und blickt nach oben.“ | „Schwarzer Labradorwelpe mit aufmerksamen Augen sitzt auf Holzuntergrund.“                            |
+| Walrosse am Strand   | „Walder auf Sand“                                                               | „Zwei Walrosse auf sandigem Untergrund mit typischen Stoßzähnen und faltiger Haut, ruhend am Strand.“ |
 
 Trägt eine Seite Hero-Bilder, bei denen die Formulierung zählt, wechsle `ALT_MODEL` für diese Bilder auf `Ministral-3-14B-Instruct-2512`. In beiden Fällen geht nichts ohne die Review-Stufe live.
 
@@ -319,12 +327,12 @@ Das Dokument für die Beispiel-Website:
 
 Bitte jeden Vorschlag prüfen, bevor er live geht. AI-Alt-Texte können falsch sein.
 
-| | Seite | Datei | Aktueller Alt | Vorschlag | OK? |
-|---|-------|-------|---------------|-----------|-----|
-| [ ] | index.html | img/hund.jpg | `None` | "" (dekorativ) | ☐ |
-| [ ] | index.html | img/kanu.jpg | `` | (dekorativ — leer lassen) | ☐ |
-| [ ] | index.html | img/robbe.jpg | `Bild1` | "" (dekorativ) | ☐ |
-| [ ] | kontakt.html | img/team.jpg | `None` | (nicht generiert — Datei fehlt?) | ☐ |
+|     | Seite        | Datei         | Aktueller Alt | Vorschlag                        | OK? |
+| --- | ------------ | ------------- | ------------- | -------------------------------- | --- |
+| [ ] | index.html   | img/hund.jpg  | `None`        | "" (dekorativ)                   | ☐   |
+| [ ] | index.html   | img/kanu.jpg  | ``            | (dekorativ — leer lassen)        | ☐   |
+| [ ] | index.html   | img/robbe.jpg | `Bild1`       | "" (dekorativ)                   | ☐   |
+| [ ] | kontakt.html | img/team.jpg  | `None`        | (nicht generiert — Datei fehlt?) | ☐   |
 
 ## Audio-Versionen
 
@@ -380,11 +388,11 @@ if __name__ == "__main__":
 
 Gemessen am öffentlichen Gateway mit einem 800×600-JPEG:
 
-| Aufruf | Token / Größe | Anmerkung |
-| ------ | ------------- | --------- |
-| Ein Alt-Text (`Qwen3.5-0.8B`) | ~640 gesamt (~475 multimodal) | ~0,7 s Hin-und-Rückweg |
-| Ein Alt-Text (`Ministral-3-14B-Instruct-2512`) | ~725 gesamt | ~0,6 s Hin-und-Rückweg |
-| Ein Audio-Block (~260 Zeichen, `opus`) | 106-kB-Datei, 24,7 s Audio | ~2 s Generierung |
+| Aufruf                                         | Token / Größe                 | Anmerkung              |
+| ---------------------------------------------- | ----------------------------- | ---------------------- |
+| Ein Alt-Text (`Qwen3.5-0.8B`)                  | ~640 gesamt (~475 multimodal) | ~0,7 s Hin-und-Rückweg |
+| Ein Alt-Text (`Ministral-3-14B-Instruct-2512`) | ~725 gesamt                   | ~0,6 s Hin-und-Rückweg |
+| Ein Audio-Block (~260 Zeichen, `opus`)         | 106-kB-Datei, 24,7 s Audio    | ~2 s Generierung       |
 
 Eine Kundenwebsite mit 100 Bildern kostet grob 60.000 Token an `Qwen3.5-0.8B`-Verkehr plus einige TTS-Aufrufe für die wichtigen Seiten. `Qwen3.5-0.8B` ist das kosteneffizienteste Modell im Katalog — deshalb ist ein Audit pro Website ein abrechenbarer Posten statt eines manuellen Nachmittags.
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/110-ecommerce-product-pipeline.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/110-ecommerce-product-pipeline.mdx
@@ -1,0 +1,354 @@
+---
+sidebar_label: E-Commerce-Produkt-Pipeline
+description: Produktfotos zu deutschen Namen, Beschreibungen, Tags und Alt-Texten mit Qwen3.8-27B-NVFP4 machen und per Admin API in Shopware übernehmen
+title: E-Commerce-Produkt-Pipeline
+---
+
+Neue Produkte kommen bei Agenturen als Fotos an — meist ohne jegliche Metadaten. Jemand macht oder lädt ein Bild, legt es in einen Ordner, und das Shop-Team muss Name, Beschreibung, Tags und Alt-Text von Hand schreiben. Diese Anleitung baut eine Pipeline, die diesen Schritt automatisch mit [Qwen3.8-27B-NVFP4](/docs/v2/platform/aihosting/models/qwen3-8-27b-nvfp4) erledigt und das Ergebnis in eine laufende Shopware-Instanz schreibt:
+
+| Stufe | Modell | Was sie tut |
+| ----- | ------ | ----------- |
+| 1 — Generieren | [Qwen3.8-27B-NVFP4](/docs/v2/platform/aihosting/models/qwen3-8-27b-nvfp4) | Schreibt pro Foto einen deutschen Produktnamen, eine Beschreibung, Tags und einen Alt-Text (strikter JSON-Vertrag) |
+| 2 — Review | Mensch | Prüft jeden Text, bevor er live geht |
+| 3 — Übernehmen | keine (Shopware Admin API) | Legt Tags an, lädt Medien hoch und erstellt das Produkt inkl. SEO-Felder |
+
+:::note[Umfang]
+Die Pipeline richtet sich an **Shopware 6.6 LTS** (getestet mit 6.6.10). Katalog-Schreibungen laufen über die **Admin API**, nicht über die Store-API — die Store-API bedient den Storefront-Bereich (Lesezugriffe, Warenkorb, Checkout) und kennt keine Produkt-Schreibrouten. Läuft beim Kunden eine ältere 6.x-Version, existieren dieselben Endpunkte unter dem Präfix `/api/v2`; der Rest dieser Anleitung bleibt unverändert.
+:::
+
+## Vorbereitung {#vorbereitung}
+
+```shellsession
+user@local $ pip install openai pillow requests
+```
+
+Zwei Dinge werden benötigt: Zugriff auf das Vision-Modell und eine Shopware-Instanz mit Integrations-Zugangsdaten.
+
+Für das Modell bis zum GA auf dem öffentlichen Gateway das Playground-Gateway verwenden — die Base URL unten braucht keinen API-Key:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="https://qwen3-8-27b-nvfp4.llm-1.m3.services/v1", api_key="x")
+VISION_MODEL = "Qwen3.8-27B-NVFP4"
+```
+
+Für Shopware im Admin UI eine Integration anlegen: **Einstellungen → Integrationen → Integration erstellen** (mit Administratorrechten), dann *Access Key* und *Secret* kopieren. Für lokale Tests ist die schnellste Variante eine einzelne Container-Instanz:
+
+```shellsession
+user@local $ docker run -d --name sw-test -p 80:80 dockware/shopware:6.6-latest
+```
+
+Drei Fixture-Fotos in `products/` anlegen. Die Dateinamen sind bewusst irreführend — `mug-001.jpg` ist tatsächlich ein Teller — um zu beweisen, dass das Modell auf die Pixel schaut und nicht auf den Dateinamen:
+
+| Datei | Inhalt | Bekannter Preis |
+| ----- | ------ | --------------- |
+| `products/mug-001.jpg` | Weißer Speiseteller mit Randornament | 14,90 EUR |
+| `products/backpack-001.jpg` | Bestickter Leder-Rucksack | 89,00 EUR |
+| `products/headphones-001.jpg` | DSLR-Kamera-Set mit Objektiv und Notizbuch | 249,00 EUR |
+
+Das ist schon alles an Eingabedaten: drei JPEGs und je ein Preis. Der Rest kommt aus Stufe 1.
+
+## Stufe 1 — Produktdaten aus Fotos {#stufe-generieren}
+
+Jedes Foto geht mit einem strikten Output-Vertrag an `Qwen3.8-27B-NVFP4`. Der Prompt ist absichtlich auf Deutsch: Das Modell schreibt deutsche Produkttexte, und die gemessene Output-Qualität ist besser, wenn die Regeln in der Zielsprache formuliert sind (gleiches Muster wie in der [BFSG-Barrierefreiheits-Pipeline](/docs/v2/platform/aihosting/examples/bfsg-accessibility#stufe-alt-texte)).
+
+```python
+import base64
+import io
+import json
+import re
+import time
+from pathlib import Path
+
+from PIL import Image
+
+PROMPT = (
+    "Du bist E-Commerce-Experte und schreibst Produkttexte auf Deutsch fuer einen Online-Shop. "
+    "Beschreibe das Produkt auf dem Bild sachlich und kauftraechtig. "
+    "Regeln: name maximal 60 Zeichen, description 2-4 Saetze ohne uebertreibungen, "
+    "tags sind 3-5 kurze Keywords, alt_text maximal 125 Zeichen und beschreibt nur das Bild. "
+    "Keine Erfindungen von Marken oder Eigenschaften, die nicht sichtbar sind. "
+    'Antworte nur mit JSON: {"name": "...", "description": "...", '
+    '"tags": ["...", "..."], "alt_text": "..."}'
+)
+
+
+def encode_image(path: Path, max_px: int = 1024) -> str:
+    """Resize to max_px on the longest edge and return a Base64 data URL."""
+    with Image.open(path) as img:
+        w, h = img.size
+        scale = min(1.0, max_px / max(w, h))
+        if scale < 1.0:
+            img = img.resize((int(w * scale), int(h * scale)), Image.LANCZOS)
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=85)
+    return f"data:image/jpeg;base64,{base64.b64encode(buf.getvalue()).decode()}"
+
+
+def generate_product_data(image_path: Path) -> dict:
+    t0 = time.time()
+    resp = client.chat.completions.create(
+        model=VISION_MODEL,
+        messages=[{"role": "user", "content": [
+            {"type": "image_url", "image_url": {"url": encode_image(image_path)}},
+            {"type": "text", "text": PROMPT},
+        ]}],
+        temperature=0.4,
+        max_tokens=2000,  # reasoning tokens count against this budget
+    )
+    dt = time.time() - t0
+    raw = resp.choices[0].message.content.strip()
+    raw = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw)
+    data = json.loads(raw)
+    return {
+        "name": str(data["name"])[:60],
+        "description": str(data["description"]),
+        "tags": [str(t)[:40] for t in data.get("tags", [])][:5],
+        "alt_text": str(data.get("alt_text", ""))[:125],
+        "seconds": round(dt, 1),
+        "tokens": resp.usage.total_tokens,
+        "reasoning_tokens": resp.usage.completion_tokens_details.reasoning_tokens,
+    }
+```
+
+Bilder müssen als Base64-Data-URLs gesendet werden; siehe [Bilder kodieren und verkleinern](/docs/v2/platform/aihosting/examples/python#vision-encoding) für das allgemeine Muster.
+
+:::warning[Reasoning-Tokens fressen das max_tokens-Budget]
+`Qwen3.8-27B-NVFP4` ist ein Reasoning-Modell: Bevor es antwortet, gibt es Tokens für internes Reasoning aus, das man nicht sieht, das aber gegen `max_tokens` zählt. Gemessen mit den Fixture-Fotos bei `max_tokens=600`: Die Antwort kam mit `finish_reason=length` und entweder abgeschnittenem oder **leerem** Content zurück (das Reasoning allein nutzte 524–600 des 600-Token-Budgets). Mit `max_tokens=2000` lief jede Anfrage durch. Für Produkttexte mindestens 2000 Tokens einplanen und leeren `content` als Retry-Signal behandeln, nicht als Modellfehler.
+:::
+
+Zwei Verhaltensweisen aus dem Fixture-Run, die man wissen sollte:
+
+- **Marken nur, wenn sichtbar.** Das Kamera-Foto trägt ein gut lesbares Canon-Logo, daher schrieb das Modell „Canon Spiegelreflexkamera“ — korrekt, weil sichtbar. Der Prompt verbietet ausdrücklich, Marken oder Eigenschaften zu erfinden, die nicht auf dem Bild sind; kleinere Modelle sind hier weniger diszipliniert, dafür gibt es die Review-Stufe.
+- **Dateinamen werden ignoriert.** `mug-001.jpg` kam als „Weißer Teller …“ zurück, denn so sieht das Foto aus.
+
+## Stufe 2 — Menschliches Review {#stufe-review}
+
+Eine Review-Liste erzeugen, die ein Mensch zeilenweise abnickt — exakt wie die [Review-Stufe der BFSG-Pipeline](/docs/v2/platform/aihosting/examples/bfsg-accessibility#stufe-review). Nichts kommt vor diesem Schritt in den Shop:
+
+```python
+def write_review_sheet(results: dict, out: Path) -> None:
+    lines = [
+        "# Review — Produkttexte (E-Commerce-Pipeline)",
+        "",
+        "Bitte jeden Text pruefen, bevor er im Shop erscheint.",
+        "",
+        "| | SKU | Name | Beschreibung | Tags | Alt-Text | OK? |",
+        "|---|-----|------|--------------|------|----------|-----|",
+    ]
+    for sku, r in results.items():
+        lines.append(
+            f"| [ ] | {sku} | {r['name']} | {r['description'][:80]}… "
+            f"| {', '.join(r['tags'])} | {r['alt_text'][:50]}… | ☐ |"
+        )
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+```
+
+Die Liste für das Fixture:
+
+```markdown
+# Review — Produkttexte (E-Commerce-Pipeline)
+
+Bitte jeden Text pruefen, bevor er im Shop erscheint.
+
+| | SKU | Name | Beschreibung | Tags | Alt-Text | OK? |
+|---|-----|------|--------------|------|----------|-----|
+| [ ] | mug-001 | Weißer Teller mit dezentem Randmuster | Dieser weiße Teller überzeugt durch sein schlichtes, rundes Design. Ein dezent g… | Teller, Weiß, Randmuster, Essgeschirr, Rund | Weißer runder Teller mit dezentem grauem Wellenmus… | ☐ |
+| [ ] | backpack-001 | Ethnisch bestickter Leder-Rucksack mit Schultergurt | Dieser Rucksack aus dunklem Leder wird über einer Schulter getragen und besticht… | Rucksack, Leder, bestickt, ethno, Frauen | Person in lila T-Shirt und Jeans trägt einen dunkl… | ☐ |
+| [ ] | headphones-001 | Canon DSLR Kamera Set mit Objektiv und Notizbuch | Das Set enthält eine schwarze Canon-Spiegelreflexkamera mit aufgesetztem Objekti… | Kamera, Canon, Notizbuch, Fotografie, Zubehör | Schwarze Canon DSLR mit Objektiv, zweites Objektiv… | ☐ |
+```
+
+Nach Freigabe die akzeptierten Texte übernehmen und Stufe 3 ausführen. Beim erneuten Ausführen der Pipeline sollte die Review-Liste leer bleiben.
+
+## Stufe 3 — In Shopware übernehmen {#stufe-shopware}
+
+### Authentifizierung {#authentifizierung}
+
+Die Admin API authentifiziert sich mit einem kurzlebigen JWT, das gegen die Integrations-Zugangsdaten getauscht wird (`client_credentials`-Grant):
+
+```python
+import requests
+
+SHOPWARE_URL = "http://localhost/api"  # Admin API base (no version prefix on 6.6+)
+INTEGRATION_KEY = "SWIA…"          # Admin UI -> Settings -> Integrations
+INTEGRATION_SECRET = "…"
+
+
+def get_jwt() -> str:
+    r = requests.post(
+        f"{SHOPWARE_URL}/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": INTEGRATION_KEY,
+            "client_secret": INTEGRATION_SECRET,
+        },
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()["access_token"]
+```
+
+Das Token läuft nach 10 Minuten ab — bei längeren Katalog-Läufen einfach neu holen.
+
+### Schreibsemantik: 204 plus exakter Filter {#schreibsemantik}
+
+Zwei Eigenheiten der aktuellen Admin-API, beide an 6.6.10 verifiziert:
+
+- **Schreiboperationen liefern `204 No Content`** — kein Body, keine neue ID. Um danach mit der Entität zu arbeiten, erneut mit einem **exakten Filter** (`equalsAll`) abfragen. Fuzzy-Matching über `search-term` ist dafür nicht zuverlässig (es passt gern `-001` quer über verschiedene Dateien).
+- **Multipart-Uploads brechen unter PHP-FPM.** Der klassische `POST /api/_action/media/{id}/upload` mit `multipart/form-data` schlägt mit `CONTENT__MEDIA_INVALID_CONTENT_LENGTH` fehl, weil PHP-FPM `php://input` für Multipart-Bodies leert. Die Datei stattdessen als **rohen Binär-Body** senden (oder bei `Content-Type: application/json` und `{"url": "..."}` auf eine URL zeigen, wenn das Bild bereits auf einem CDN liegt).
+
+```python
+def sw(method: str, path: str, token: str, **kwargs):
+    r = requests.request(method, f"{SHOPWARE_URL}/{path.lstrip('/')}",
+                         headers={"Authorization": f"Bearer {token}"},
+                         timeout=60, **kwargs)
+    if r.status_code >= 400:
+        raise RuntimeError(f"{method} {path} -> {r.status_code}: {r.text[:400]}")
+    return r
+
+
+def find_id(entity: str, field: str, value: str, token: str) -> str:
+    """Writes return 204 without an id — look the entity up by an exact filter."""
+    r = sw("GET", entity, token, params={
+        "filter[0][type]": "equalsAll",
+        "filter[0][field]": field,
+        "filter[0][value]": value,
+        "fields[]": "id",
+    })
+    elements = r.json()["data"]
+    if not elements:
+        raise RuntimeError(f"{entity} with {field}={value!r} not found")
+    return elements[0]["id"]
+
+
+def ensure_tag(name: str, token: str) -> str:
+    r = sw("GET", "tag", token, params={
+        "filter[0][type]": "equalsAll",
+        "filter[0][field]": "name",
+        "filter[0][value]": name,
+        "fields[]": "id",
+    })
+    if r.json()["data"]:
+        return r.json()["data"][0]["id"]
+    sw("POST", "tag", token, json={"name": name})
+    return find_id("tag", "name", name, token)
+
+
+def create_media(file_name: str, alt: str, image_bytes: bytes, token: str) -> str:
+    sw("POST", "media", token, json={"fileName": file_name, "alt": alt})
+    media_id = find_id("media", "fileName", file_name, token)
+    # raw binary body: multipart/form-data breaks under PHP-FPM (php://input is empty)
+    r = requests.post(
+        f"{SHOPWARE_URL}/_action/media/{media_id}/upload",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "image/jpeg"},
+        params={"fileName": file_name, "extension": "jpg"},
+        data=image_bytes,
+        timeout=60,
+    )
+    if r.status_code >= 400:
+        raise RuntimeError(f"media upload -> {r.status_code}: {r.text[:400]}")
+    return media_id
+```
+
+### Das Produkt anlegen {#produkt-anlegen}
+
+Der Produkt-Payload braucht einige Felder, die leicht fehlen (jedes war beim Testen ein harter 400): `taxId`, `stock`, ein `price`-Eintrag mit `currencyId`/`gross`/`net`/`linked` und Medien-Einträge, die nach `mediaId` — nicht `id` — adressiert sind. Die deutschen Texte kommen in `translations`; die SEO-Felder heißen dort `metaTitle`/`metaDescription`.
+
+```python
+TAX_RATE = 19.0  # German standard VAT
+
+
+def create_product(sku: str, data: dict, price_gross: float,
+                   tax_id: str, currency_id: str, de_lang: str,
+                   media_id: str, tag_ids: list[str], token: str) -> None:
+    net = round(price_gross / (1 + TAX_RATE / 100), 2)
+    payload = {
+        "productNumber": sku,
+        "name": data["name"],
+        "description": data["description"],
+        "taxId": tax_id,
+        "stock": 10,
+        "price": [{"currencyId": currency_id, "gross": price_gross,
+                   "net": net, "linked": True}],
+        "media": [{"mediaId": media_id}],
+        "tags": [{"id": tid} for tid in tag_ids],
+        "translations": [{
+            "languageId": de_lang,
+            "name": data["name"],
+            "description": data["description"],
+            "metaTitle": f"{data['name']} – kaufen online",
+            "metaDescription": data["description"].split(". ")[0][:158],
+        }],
+    }
+    sw("POST", "product", token, json=payload)
+```
+
+Der Driver löst die festen IDs einmal auf (Steuersatz, Währung EUR, Sprache Deutsch) und läuft über die freigegebenen Produkte:
+
+```python
+CATALOG = {
+    "mug-001": {"price_gross": 14.90},
+    "backpack-001": {"price_gross": 89.00},
+    "headphones-001": {"price_gross": 249.00},
+}
+
+
+def main():
+    # stages 1 and 2 first — see above; `results` holds the reviewed data
+    token = get_jwt()
+
+    taxes = sw("GET", "tax", token, params={"limit": 50,
+                                            "fields[]": "id", "fields[]": "taxRate"})
+    tax_id = next(d["id"] for d in taxes.json()["data"]
+                  if d["attributes"].get("taxRate") == TAX_RATE)
+    currencies = sw("GET", "currency", token, params={"limit": 50,
+                                                      "fields[]": "id", "fields[]": "name"})
+    currency_id = next(d["id"] for d in currencies.json()["data"]
+                       if "Euro" in str(d["attributes"].get("name")))
+    languages = sw("GET", "language", token, params={"limit": 50,
+                                                     "fields[]": "id", "fields[]": "name"})
+    de_lang = next(d["id"] for d in languages.json()["data"]
+                   if d["attributes"].get("name") == "Deutsch")
+
+    for sku, data in results.items():
+        image_bytes = (PRODUCTS_DIR / f"{sku}.jpg").read_bytes()
+        media_id = create_media(f"{sku}.jpg", data["alt_text"], image_bytes, token)
+        tag_ids = [ensure_tag(t, token) for t in data["tags"]]
+        create_product(sku, data, CATALOG[sku]["price_gross"], tax_id,
+                       currency_id, de_lang, media_id, tag_ids, token)
+        print(f"  {sku}: product + media + {len(tag_ids)} tags created")
+```
+
+Verifiziertes Ergebnis des Fixture-Runs — alle drei Produkte existieren im Shop mit generierten deutschen Texten:
+
+```text
+mug-001       "Weißer Teller mit dezentem Randmuster"
+              metaTitle: "Weißer Teller mit dezentem Randmuster – kaufen online"
+              price: 14,90 brutto / 12,52 netto EUR, Bestand 10, 5 Tags, Cover-Medium mit Alt-Text
+backpack-001  "Ethnisch bestickter Leder-Rucksack mit Schultergurt"
+              price: 89,00 brutto / 74,79 netto EUR, Bestand 10, 5 Tags
+headphones-001 "Canon DSLR Kamera Set mit Objektiv und Notizbuch"
+               price: 249,00 brutto / 209,24 netto EUR, Bestand 10, 5 Tags
+```
+
+Produkte ohne Kategorie erscheinen nicht in Storefront-Listen — Kategorien im Admin UI zuordnen (oder die Pipeline um eine Kategorie-Mapping-Ebene erweitern) und dabei als Teil der Review-Freigabe behandeln.
+
+## Kostenprofil {#kostenprofil}
+
+Gemessen im Playground mit ~600-px-JPEGs:
+
+| Aufruf | Tokens | Dauer | Anmerkungen |
+| ------ | ------ | ----- | ----------- |
+| Ein Produkt (inkl. Reasoning) | 957–1.178 gesamt | 6,4–9,0 s | davon 369–504 Reasoning-Tokens |
+| Dreier-Fixture | ~3.200 gesamt | ~24 s | plus vernachlässigbarer Admin-API-Verkehr |
+
+Ein Katalog mit 50 Fotos kostet grob 50.000–60.000 Tokens an `Qwen3.8-27B-NVFP4`-Traffic — wenige Cent auf den 5-Millionen-Token-Plänen. Damit wird ein kompletter Katalog-Import eine abrechenbare Automatisierung statt einer Woche Texterstellung. Günstigere Entwürfe liefert `Ministral-3-14B-Instruct-2512` auf dem öffentlichen Gateway; der JSON-Vertrag und der Rest der Pipeline bleiben identisch.
+
+## Einschränkungen {#einschraenkungen}
+
+- **Menschliches Review ist Teil des Prozesses.** Vision-Modelle beschreiben Bilder falsch, die Markenregel ist nur promptseitig erzwungen, und nur ein Mensch kann beurteilen, ob ein generierter Claim publikationsfähig ist.
+- **Preis, Bestand und Kategorie sind Eingaben, keine Ausgaben.** Das Modell sieht das Produkt, nicht die Marge. Die Werte gehören in die `CATALOG`-Tabelle (oder kommen aus einer Tabelle).
+- **Die Shopware-Teile wurden auf 6.6 LTS getestet.** Shopware 6.7 hat die Store-API nach `/store-api` verlegt und einige Admin-API-Antworten umgeformt; der hier dokumentierte Ablauf (JWT, exakte Filter, roher Binär-Upload) ist das, was 6.6 LTS heute liefert.
+- **Eine Sprache pro Lauf.** Das Beispiel schreibt nur Deutsch; pro Sprache einen weiteren `translations`-Eintrag ergänzen und das Modell selbst übersetzen lassen, falls mehrsprachige Shops nötig sind.
+- **Kein Ersatz für die redaktionellen Standards des Kunden.** Shops mit regulierten Produktclaims (Lebensmittel, Kosmetik, Medizin) brauchen einen zusätzlichen Compliance-Check in der Review-Liste.

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/110-ecommerce-product-pipeline.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/110-ecommerce-product-pipeline.mdx
@@ -6,11 +6,11 @@ title: E-Commerce-Produkt-Pipeline
 
 Neue Produkte kommen bei Agenturen als Fotos an — meist ohne jegliche Metadaten. Jemand macht oder lädt ein Bild, legt es in einen Ordner, und das Shop-Team muss Name, Beschreibung, Tags und Alt-Text von Hand schreiben. Diese Anleitung baut eine Pipeline, die diesen Schritt automatisch mit [Qwen3.8-27B-NVFP4](/docs/v2/platform/aihosting/models/qwen3-8-27b-nvfp4) erledigt und das Ergebnis in eine laufende Shopware-Instanz schreibt:
 
-| Stufe | Modell | Was sie tut |
-| ----- | ------ | ----------- |
+| Stufe          | Modell                                                                    | Was sie tut                                                                                                        |
+| -------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | 1 — Generieren | [Qwen3.8-27B-NVFP4](/docs/v2/platform/aihosting/models/qwen3-8-27b-nvfp4) | Schreibt pro Foto einen deutschen Produktnamen, eine Beschreibung, Tags und einen Alt-Text (strikter JSON-Vertrag) |
-| 2 — Review | Mensch | Prüft jeden Text, bevor er live geht |
-| 3 — Übernehmen | keine (Shopware Admin API) | Legt Tags an, lädt Medien hoch und erstellt das Produkt inkl. SEO-Felder |
+| 2 — Review     | Mensch                                                                    | Prüft jeden Text, bevor er live geht                                                                               |
+| 3 — Übernehmen | keine (Shopware Admin API)                                                | Legt Tags an, lädt Medien hoch und erstellt das Produkt inkl. SEO-Felder                                           |
 
 :::note[Umfang]
 Die Pipeline richtet sich an **Shopware 6.6 LTS** (getestet mit 6.6.10). Katalog-Schreibungen laufen über die **Admin API**, nicht über die Store-API — die Store-API bedient den Storefront-Bereich (Lesezugriffe, Warenkorb, Checkout) und kennt keine Produkt-Schreibrouten. Läuft beim Kunden eine ältere 6.x-Version, existieren dieselben Endpunkte unter dem Präfix `/api/v2`; der Rest dieser Anleitung bleibt unverändert.
@@ -33,7 +33,7 @@ client = OpenAI(base_url="https://qwen3-8-27b-nvfp4.llm-1.m3.services/v1", api_k
 VISION_MODEL = "Qwen3.8-27B-NVFP4"
 ```
 
-Für Shopware im Admin UI eine Integration anlegen: **Einstellungen → Integrationen → Integration erstellen** (mit Administratorrechten), dann *Access Key* und *Secret* kopieren. Für lokale Tests ist die schnellste Variante eine einzelne Container-Instanz:
+Für Shopware im Admin UI eine Integration anlegen: **Einstellungen → Integrationen → Integration erstellen** (mit Administratorrechten), dann _Access Key_ und _Secret_ kopieren. Für lokale Tests ist die schnellste Variante eine einzelne Container-Instanz:
 
 ```shellsession
 user@local $ docker run -d --name sw-test -p 80:80 dockware/shopware:6.6-latest
@@ -41,11 +41,11 @@ user@local $ docker run -d --name sw-test -p 80:80 dockware/shopware:6.6-latest
 
 Drei Fixture-Fotos in `products/` anlegen. Die Dateinamen sind bewusst irreführend — `mug-001.jpg` ist tatsächlich ein Teller — um zu beweisen, dass das Modell auf die Pixel schaut und nicht auf den Dateinamen:
 
-| Datei | Inhalt | Bekannter Preis |
-| ----- | ------ | --------------- |
-| `products/mug-001.jpg` | Weißer Speiseteller mit Randornament | 14,90 EUR |
-| `products/backpack-001.jpg` | Bestickter Leder-Rucksack | 89,00 EUR |
-| `products/headphones-001.jpg` | DSLR-Kamera-Set mit Objektiv und Notizbuch | 249,00 EUR |
+| Datei                         | Inhalt                                     | Bekannter Preis |
+| ----------------------------- | ------------------------------------------ | --------------- |
+| `products/mug-001.jpg`        | Weißer Speiseteller mit Randornament       | 14,90 EUR       |
+| `products/backpack-001.jpg`   | Bestickter Leder-Rucksack                  | 89,00 EUR       |
+| `products/headphones-001.jpg` | DSLR-Kamera-Set mit Objektiv und Notizbuch | 249,00 EUR      |
 
 Das ist schon alles an Eingabedaten: Drei JPEGs und je ein Preis. Der Rest kommt aus Stufe 1.
 
@@ -53,7 +53,7 @@ Das ist schon alles an Eingabedaten: Drei JPEGs und je ein Preis. Der Rest kommt
 
 Jedes Foto geht mit einem strikten Output-Vertrag an `Qwen3.8-27B-NVFP4`. Der Prompt ist absichtlich auf Deutsch: Das Modell schreibt deutsche Produkttexte, und die gemessene Output-Qualität ist besser, wenn die Regeln in der Zielsprache formuliert sind (gleiches Muster wie in der [BFSG-Barrierefreiheits-Pipeline](/docs/v2/platform/aihosting/examples/bfsg-accessibility#stufe-alt-texte)).
 
-```python
+````python
 import base64
 import io
 import json
@@ -110,7 +110,7 @@ def generate_product_data(image_path: Path) -> dict:
         "tokens": resp.usage.total_tokens,
         "reasoning_tokens": resp.usage.completion_tokens_details.reasoning_tokens,
     }
-```
+````
 
 Bilder müssen als Base64-Data-URLs gesendet werden; siehe [Bilder kodieren und verkleinern](/docs/v2/platform/aihosting/examples/python#vision-encoding) für das allgemeine Muster.
 
@@ -152,11 +152,11 @@ Die Liste für das Fixture:
 
 Bitte jeden Text pruefen, bevor er im Shop erscheint.
 
-| | SKU | Name | Beschreibung | Tags | Alt-Text | OK? |
-|---|-----|------|--------------|------|----------|-----|
-| [ ] | mug-001 | Weißer Teller mit dezentem Randmuster | Dieser weiße Teller überzeugt durch sein schlichtes, rundes Design. Ein dezent g… | Teller, Weiß, Randmuster, Essgeschirr, Rund | Weißer runder Teller mit dezentem grauem Wellenmus… | ☐ |
-| [ ] | backpack-001 | Ethnisch bestickter Leder-Rucksack mit Schultergurt | Dieser Rucksack aus dunklem Leder wird über einer Schulter getragen und besticht… | Rucksack, Leder, bestickt, ethno, Frauen | Person in lila T-Shirt und Jeans trägt einen dunkl… | ☐ |
-| [ ] | headphones-001 | Canon DSLR Kamera Set mit Objektiv und Notizbuch | Das Set enthält eine schwarze Canon-Spiegelreflexkamera mit aufgesetztem Objekti… | Kamera, Canon, Notizbuch, Fotografie, Zubehör | Schwarze Canon DSLR mit Objektiv, zweites Objektiv… | ☐ |
+|     | SKU            | Name                                                | Beschreibung                                                                      | Tags                                          | Alt-Text                                            | OK? |
+| --- | -------------- | --------------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------- | --------------------------------------------------- | --- |
+| [ ] | mug-001        | Weißer Teller mit dezentem Randmuster               | Dieser weiße Teller überzeugt durch sein schlichtes, rundes Design. Ein dezent g… | Teller, Weiß, Randmuster, Essgeschirr, Rund   | Weißer runder Teller mit dezentem grauem Wellenmus… | ☐   |
+| [ ] | backpack-001   | Ethnisch bestickter Leder-Rucksack mit Schultergurt | Dieser Rucksack aus dunklem Leder wird über einer Schulter getragen und besticht… | Rucksack, Leder, bestickt, ethno, Frauen      | Person in lila T-Shirt und Jeans trägt einen dunkl… | ☐   |
+| [ ] | headphones-001 | Canon DSLR Kamera Set mit Objektiv und Notizbuch    | Das Set enthält eine schwarze Canon-Spiegelreflexkamera mit aufgesetztem Objekti… | Kamera, Canon, Notizbuch, Fotografie, Zubehör | Schwarze Canon DSLR mit Objektiv, zweites Objektiv… | ☐   |
 ```
 
 Nach Freigabe die akzeptierten Texte übernehmen und Stufe 3 ausführen. Beim erneuten Ausführen der Pipeline sollte die Review-Liste leer bleiben.
@@ -338,10 +338,10 @@ Produkte ohne Kategorie erscheinen nicht in Storefront-Listen — Kategorien im 
 
 Gemessen im Playground mit ~600-px-JPEGs:
 
-| Aufruf | Tokens | Dauer | Anmerkungen |
-| ------ | ------ | ----- | ----------- |
-| Ein Produkt (inkl. Reasoning) | 957–1.178 gesamt | 6,4–9,0 s | davon 369–504 Reasoning-Tokens |
-| Dreier-Fixture | ~3.200 gesamt | ~24 s | plus vernachlässigbarer Admin-API-Verkehr |
+| Aufruf                        | Tokens           | Dauer     | Anmerkungen                               |
+| ----------------------------- | ---------------- | --------- | ----------------------------------------- |
+| Ein Produkt (inkl. Reasoning) | 957–1.178 gesamt | 6,4–9,0 s | davon 369–504 Reasoning-Tokens            |
+| Dreier-Fixture                | ~3.200 gesamt    | ~24 s     | plus vernachlässigbarer Admin-API-Verkehr |
 
 Ein Katalog mit 50 Fotos kostet grob 50.000–60.000 Tokens an `Qwen3.8-27B-NVFP4`-Traffic — wenige Cent auf den 5-Millionen-Token-Plänen. Damit wird ein kompletter Katalog-Import eine abrechenbare Automatisierung statt einer Woche Texterstellung. Günstigere Entwürfe liefert `Ministral-3-14B-Instruct-2512` auf dem öffentlichen Gateway; der JSON-Vertrag und der Rest der Pipeline bleiben identisch.
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/110-ecommerce-product-pipeline.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/platform/aihosting/50-examples/110-ecommerce-product-pipeline.mdx
@@ -47,7 +47,7 @@ Drei Fixture-Fotos in `products/` anlegen. Die Dateinamen sind bewusst irreführ
 | `products/backpack-001.jpg` | Bestickter Leder-Rucksack | 89,00 EUR |
 | `products/headphones-001.jpg` | DSLR-Kamera-Set mit Objektiv und Notizbuch | 249,00 EUR |
 
-Das ist schon alles an Eingabedaten: drei JPEGs und je ein Preis. Der Rest kommt aus Stufe 1.
+Das ist schon alles an Eingabedaten: Drei JPEGs und je ein Preis. Der Rest kommt aus Stufe 1.
 
 ## Stufe 1 — Produktdaten aus Fotos {#stufe-generieren}
 


### PR DESCRIPTION
Two agency-facing tutorials plus the vision correction on the Qwen3.5-0.8B model page (EN + DE).

Stacked on top of #1277 — the BFSG tutorial links to the Qwen3-TTS model page and the text-to-speech guide, which land in that PR. Base can be retargeted to `master` once #1277 is merged.

## What's here

| File | |
|---|---|
| `50-examples/100-bfsg-accessibility.mdx` | New BFSG accessibility pipeline tutorial (EN + DE) |
| `50-examples/110-ecommerce-product-pipeline.mdx` | New e-commerce product pipeline tutorial (EN + DE) |
| `30-models/90-qwen3-5-0-8b.mdx` | Vision support corrected (EN + DE) |
| `30-models/index.mdx` | Table row + model-picking entry updated for vision (EN + DE) |

## BFSG accessibility pipeline

Four stages an agency can run per client site:

1. **Audit** — plain HTML parsing, finds `<img>` tags with missing, empty, or placeholder alt texts
2. **Alt text** — `Qwen3.5-0.8B` writes a German alt text per image, one image per request
3. **Audio** — `Qwen3-TTS-12Hz-1.7B-CustomVoice` renders key pages as Opus for on-page playback
4. **Review** — a human review sheet; nothing ships unreviewed

Two things worth calling out, both measured on a live deployment:

- **Batching images fails silently.** Three images in one message produced one alt text for the first image and nothing for the rest, in every run. Documented as a warning; the driver loops per image.
- **Remote image URLs are rejected** with HTTP 400. Images have to be Base64 data URLs.

The tutorial also compares `Qwen3.5-0.8B` against `Ministral-3-14B-Instruct-2512` on the same fixture images, so readers can decide when the cheap model is good enough.

## E-commerce product pipeline

Photo in, German product name, description, tags and alt text out, pushed into a running Shopware instance via the Admin API. Uses `Qwen3.8-27B-NVFP4` with a strict JSON contract, with a human review stage before anything goes live.

## Model page correction

`Qwen3.5-0.8B` **does** support images via Base64 data URLs — verified live, multimodal tokens billed. The model page and the index table previously claimed no vision support.

## Checks

- [x] Code examples verified against the live gateways
- [x] EN and DE say the same thing, section for section
- [x] German pages have no `slug:`, anchors named in German
- [x] `npx prettier --write` over all new and changed files
- [x] `npm run build` clean for both locales; the only remaining broken anchors are the pre-existing `containers/` and `openwebui/` ones on master
